### PR TITLE
PS-69 - Seeding exercise and equipment catalog from free-exercise-db

### DIFF
--- a/database/migrations/2026_06_27_000001_create_equipment_types_table.php
+++ b/database/migrations/2026_06_27_000001_create_equipment_types_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('equipment_types', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            // null user_id marks a system-seeded type shared by all users (ADR-004).
+            $table->foreignId('user_id')->nullable()->constrained()->cascadeOnDelete();
+            $table->boolean('is_system')->default(false);
+            $table->timestamps();
+            $table->unique(['name', 'user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('equipment_types');
+    }
+};

--- a/database/migrations/2026_06_27_000002_create_exercises_table.php
+++ b/database/migrations/2026_06_27_000002_create_exercises_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('exercises', function (Blueprint $table) {
+            $table->id();
+            // null user_id marks a system-seeded exercise shared by all users (ADR-010).
+            $table->foreignId('user_id')->nullable()->constrained()->cascadeOnDelete();
+            // Block-if-used on equipment deletion is enforced at the application layer (ADR-002);
+            // restrictOnDelete reinforces it at the database level.
+            $table->foreignId('equipment_type_id')->nullable()->constrained()->restrictOnDelete();
+            $table->string('name');
+            $table->string('type')->index();
+            $table->text('notes')->nullable();
+            $table->timestamps();
+            $table->unique(['user_id', 'name']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('exercises');
+    }
+};

--- a/database/migrations/2026_06_27_000003_create_exercise_resistance_table.php
+++ b/database/migrations/2026_06_27_000003_create_exercise_resistance_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('exercise_resistance', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('exercise_id')->unique()->constrained()->cascadeOnDelete();
+            $table->boolean('bodyweight_base')->default(false);
+            $table->boolean('allows_added_weight')->default(false);
+            $table->boolean('bilateral')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('exercise_resistance');
+    }
+};

--- a/database/migrations/2026_06_27_000004_create_exercise_timed_hold_table.php
+++ b/database/migrations/2026_06_27_000004_create_exercise_timed_hold_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('exercise_timed_hold', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('exercise_id')->unique()->constrained()->cascadeOnDelete();
+            $table->integer('target_duration_seconds')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('exercise_timed_hold');
+    }
+};

--- a/database/migrations/2026_06_27_000005_create_exercise_distance_table.php
+++ b/database/migrations/2026_06_27_000005_create_exercise_distance_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('exercise_distance', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('exercise_id')->unique()->constrained()->cascadeOnDelete();
+            $table->enum('distance_unit', ['meters', 'kilometers', 'miles', 'yards']);
+            $table->boolean('tracks_elevation')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('exercise_distance');
+    }
+};

--- a/database/migrations/2026_06_27_000006_create_exercise_interval_table.php
+++ b/database/migrations/2026_06_27_000006_create_exercise_interval_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('exercise_interval', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('exercise_id')->unique()->constrained()->cascadeOnDelete();
+            $table->integer('default_work_seconds')->nullable();
+            $table->integer('default_rest_seconds')->nullable();
+            $table->integer('default_rounds')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('exercise_interval');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -21,5 +21,11 @@ class DatabaseSeeder extends Seeder
             'name' => 'Test User',
             'email' => 'test@example.com',
         ]);
+
+        // Equipment must seed before exercises: exercises resolve equipment by FK.
+        $this->call([
+            EquipmentTypeSeeder::class,
+            ExerciseLibrarySeeder::class,
+        ]);
     }
 }

--- a/database/seeders/EquipmentTypeSeeder.php
+++ b/database/seeders/EquipmentTypeSeeder.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Seeds the system equipment-type catalog (ADR-004).
+ *
+ * System types carry a null user_id and is_system = true. Upsert keeps ids
+ * stable so exercise foreign keys survive a re-seed.
+ */
+class EquipmentTypeSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $now = now();
+
+        foreach ($this->catalog() as $name) {
+            DB::table('equipment_types')->updateOrInsert(
+                ['name' => $name, 'user_id' => null],
+                ['is_system' => true, 'created_at' => $now, 'updated_at' => $now],
+            );
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function catalog(): array
+    {
+        $path = database_path('seeders/data/equipment_types.json');
+        $names = json_decode((string) file_get_contents($path), true);
+
+        if (! is_array($names)) {
+            return [];
+        }
+
+        return array_values(array_map('strval', $names));
+    }
+}

--- a/database/seeders/ExerciseLibrarySeeder.php
+++ b/database/seeders/ExerciseLibrarySeeder.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Seeds the system exercise catalog from free-exercise-db (ADR-003, ADR-010).
+ *
+ * Each exercise is a system row (null user_id) plus one Class Table Inheritance
+ * child row keyed by type. Equipment is resolved from the system catalog by name.
+ * Must run after EquipmentTypeSeeder. Upsert on (user_id, name) makes re-seeding
+ * safe and preserves ids.
+ */
+class ExerciseLibrarySeeder extends Seeder
+{
+    /** @var array<string, string> */
+    private const CHILD_TABLES = [
+        'resistance' => 'exercise_resistance',
+        'timed_hold' => 'exercise_timed_hold',
+        'distance' => 'exercise_distance',
+        'interval' => 'exercise_interval',
+    ];
+
+    public function run(): void
+    {
+        $exercises = $this->load();
+        if ($exercises === []) {
+            return;
+        }
+
+        /** @var array<string, int> $equipmentIds */
+        $equipmentIds = DB::table('equipment_types')
+            ->whereNull('user_id')
+            ->pluck('id', 'name')
+            ->all();
+
+        $now = now();
+
+        DB::transaction(function () use ($exercises, $equipmentIds, $now): void {
+            foreach ($exercises as $exercise) {
+                $equipmentName = $exercise['equipment'];
+                $equipmentTypeId = $equipmentName !== null ? ($equipmentIds[$equipmentName] ?? null) : null;
+
+                DB::table('exercises')->updateOrInsert(
+                    ['user_id' => null, 'name' => $exercise['name']],
+                    [
+                        'type' => $exercise['type'],
+                        'equipment_type_id' => $equipmentTypeId,
+                        'created_at' => $now,
+                        'updated_at' => $now,
+                    ],
+                );
+
+                $exerciseId = DB::table('exercises')
+                    ->whereNull('user_id')
+                    ->where('name', $exercise['name'])
+                    ->value('id');
+
+                DB::table(self::CHILD_TABLES[$exercise['type']])->updateOrInsert(
+                    ['exercise_id' => $exerciseId],
+                    $exercise['attributes'] + ['created_at' => $now, 'updated_at' => $now],
+                );
+            }
+        });
+    }
+
+    /**
+     * @return list<array{name: string, type: string, equipment: string|null, attributes: array<string, mixed>}>
+     */
+    private function load(): array
+    {
+        $path = database_path('seeders/data/exercises.json');
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        if (! is_array($decoded)) {
+            return [];
+        }
+
+        /** @var list<array{name: string, type: string, equipment: string|null, attributes: array<string, mixed>}> $decoded */
+        return $decoded;
+    }
+}

--- a/database/seeders/data/equipment_types.json
+++ b/database/seeders/data/equipment_types.json
@@ -1,0 +1,19 @@
+[
+  "barbell",
+  "dumbbell",
+  "cable machine",
+  "lever machine",
+  "smith machine",
+  "treadmill",
+  "stationary bike",
+  "rowing machine",
+  "kettlebell",
+  "resistance band",
+  "pull-up bar",
+  "bench",
+  "medicine ball",
+  "exercise ball",
+  "foam roller",
+  "elliptical",
+  "stair climber"
+]

--- a/database/seeders/data/exercises.json
+++ b/database/seeders/data/exercises.json
@@ -1,0 +1,8522 @@
+[
+  {
+    "name": "3/4 Sit-Up",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "90/90 Hamstring",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Ab Crunch Machine",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Ab Roller",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Adductor",
+    "type": "timed_hold",
+    "equipment": "foam roller",
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Adductor/Groin",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Advanced Kettlebell Windmill",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Air Bike",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "All Fours Quad Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Alternate Hammer Curl",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Alternate Heel Touchers",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Alternate Incline Dumbbell Curl",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Alternate Leg Diagonal Bound",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Alternating Cable Shoulder Press",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Alternating Deltoid Raise",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Alternating Floor Press",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Alternating Hang Clean",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Alternating Kettlebell Press",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Alternating Kettlebell Row",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Alternating Renegade Row",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Ankle Circles",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Ankle On The Knee",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Anterior Tibialis-SMR",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Anti-Gravity Press",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Arm Circles",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Arnold Dumbbell Press",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Around The Worlds",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Atlas Stone Trainer",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Atlas Stones",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Axle Deadlift",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Back Flyes - With Bands",
+    "type": "resistance",
+    "equipment": "resistance band",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Backward Drag",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Backward Medicine Ball Throw",
+    "type": "resistance",
+    "equipment": "medicine ball",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Balance Board",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Ball Leg Curl",
+    "type": "resistance",
+    "equipment": "exercise ball",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Band Assisted Pull-Up",
+    "type": "resistance",
+    "equipment": "pull-up bar",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": true,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Band Good Morning",
+    "type": "resistance",
+    "equipment": "resistance band",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Band Good Morning (Pull Through)",
+    "type": "resistance",
+    "equipment": "resistance band",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Band Hip Adductions",
+    "type": "resistance",
+    "equipment": "resistance band",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Band Pull Apart",
+    "type": "resistance",
+    "equipment": "resistance band",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Band Skull Crusher",
+    "type": "resistance",
+    "equipment": "resistance band",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Barbell Ab Rollout",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Barbell Ab Rollout - On Knees",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Barbell Bench Press - Medium Grip",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Barbell Curl",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Barbell Curls Lying Against An Incline",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Barbell Deadlift",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Barbell Full Squat",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Barbell Glute Bridge",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Barbell Guillotine Bench Press",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Barbell Hack Squat",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Barbell Hip Thrust",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Barbell Incline Bench Press - Medium Grip",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Barbell Incline Shoulder Raise",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Barbell Lunge",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Barbell Rear Delt Row",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Barbell Rollout from Bench",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Barbell Seated Calf Raise",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Barbell Shoulder Press",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Barbell Shrug",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Barbell Shrug Behind The Back",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Barbell Side Bend",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Barbell Side Split Squat",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Barbell Squat",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Barbell Squat To A Bench",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Barbell Step Ups",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Barbell Walking Lunge",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Battling Ropes",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Bear Crawl Sled Drags",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Behind Head Chest Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Bench Dips",
+    "type": "resistance",
+    "equipment": "bench",
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": true,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Bench Jump",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Bench Press - Powerlifting",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Bench Press - With Bands",
+    "type": "resistance",
+    "equipment": "resistance band",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Bench Press with Chains",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Bench Sprint",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Bent-Arm Barbell Pullover",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Bent-Arm Dumbbell Pullover",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Bent-Knee Hip Raise",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Bent Over Barbell Row",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Bent Over Dumbbell Rear Delt Raise With Head On Bench",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Bent Over Low-Pulley Side Lateral",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Bent Over One-Arm Long Bar Row",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "Bent Over Two-Arm Long Bar Row",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Bent Over Two-Dumbbell Row",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Bent Over Two-Dumbbell Row With Palms In",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Bent Press",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Bicycling",
+    "type": "distance",
+    "equipment": null,
+    "attributes": {
+      "distance_unit": "miles",
+      "tracks_elevation": false
+    }
+  },
+  {
+    "name": "Bicycling, Stationary",
+    "type": "distance",
+    "equipment": "stationary bike",
+    "attributes": {
+      "distance_unit": "miles",
+      "tracks_elevation": false
+    }
+  },
+  {
+    "name": "Board Press",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Body-Up",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Body Tricep Press",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Bodyweight Flyes",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Bodyweight Mid Row",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Bodyweight Squat",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Bodyweight Walking Lunge",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Bosu Ball Cable Crunch With Side Bends",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Bottoms-Up Clean From The Hang Position",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Bottoms Up",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Box Jump (Multiple Response)",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Box Skip",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Box Squat",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Box Squat with Bands",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Box Squat with Chains",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Brachialis-SMR",
+    "type": "timed_hold",
+    "equipment": "foam roller",
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Bradford/Rocky Presses",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Butt-Ups",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Butt Lift (Bridge)",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Butterfly",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Cable Chest Press",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Cable Crossover",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Cable Crunch",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Cable Deadlifts",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Cable Hammer Curls - Rope Attachment",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Cable Hip Adduction",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Cable Incline Pushdown",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Cable Incline Triceps Extension",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Cable Internal Rotation",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Cable Iron Cross",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Cable Judo Flip",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Cable Lying Triceps Extension",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Cable One Arm Tricep Extension",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "Cable Preacher Curl",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Cable Rear Delt Fly",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Cable Reverse Crunch",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Cable Rope Overhead Triceps Extension",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Cable Rope Rear-Delt Rows",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Cable Russian Twists",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Cable Seated Crunch",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Cable Seated Lateral Raise",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Cable Shoulder Press",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Cable Shrugs",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Cable Wrist Curl",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Calf-Machine Shoulder Shrug",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Calf Press",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Calf Press On The Leg Press Machine",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Calf Raise On A Dumbbell",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Calf Raises - With Bands",
+    "type": "resistance",
+    "equipment": "resistance band",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Calf Stretch Elbows Against Wall",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Calf Stretch Hands Against Wall",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Calves-SMR",
+    "type": "timed_hold",
+    "equipment": "foam roller",
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Car Deadlift",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Car Drivers",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Carioca Quick Step",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Cat Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Catch and Overhead Throw",
+    "type": "resistance",
+    "equipment": "medicine ball",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Chain Handle Extension",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Chain Press",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Chair Leg Extended Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Chair Lower Back Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Chair Squat",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Chair Upper Body Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Chest And Front Of Shoulder Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Chest Push from 3 point stance",
+    "type": "resistance",
+    "equipment": "medicine ball",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Chest Push (multiple response)",
+    "type": "resistance",
+    "equipment": "medicine ball",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Chest Push (single response)",
+    "type": "resistance",
+    "equipment": "medicine ball",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Chest Push with Run Release",
+    "type": "resistance",
+    "equipment": "medicine ball",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Chest Stretch on Stability Ball",
+    "type": "timed_hold",
+    "equipment": "exercise ball",
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Child's Pose",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Chin-Up",
+    "type": "resistance",
+    "equipment": "pull-up bar",
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": true,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Chin To Chest Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Circus Bell",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Clean",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Clean Deadlift",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Clean Pull",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Clean Shrug",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Clean and Jerk",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Clean and Press",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Clean from Blocks",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Clock Push-Up",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Close-Grip Barbell Bench Press",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Close-Grip Dumbbell Press",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Close-Grip EZ-Bar Curl with Band",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Close-Grip EZ-Bar Press",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Close-Grip EZ Bar Curl",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Close-Grip Front Lat Pulldown",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Close-Grip Push-Up off of a Dumbbell",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Close-Grip Standing Barbell Curl",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Cocoons",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Conan's Wheel",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Concentration Curls",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Cross-Body Crunch",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Cross Body Hammer Curl",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Cross Over - With Bands",
+    "type": "resistance",
+    "equipment": "resistance band",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Crossover Reverse Lunge",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Crucifix",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Crunch - Hands Overhead",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Crunch - Legs On Exercise Ball",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Crunches",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Cuban Press",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Dancer's Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Dead Bug",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Deadlift with Bands",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Deadlift with Chains",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Decline Barbell Bench Press",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Decline Close-Grip Bench To Skull Crusher",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Decline Crunch",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Decline Dumbbell Bench Press",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Decline Dumbbell Flyes",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Decline Dumbbell Triceps Extension",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Decline EZ Bar Triceps Extension",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Decline Oblique Crunch",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Decline Push-Up",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Decline Reverse Crunch",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Decline Smith Press",
+    "type": "resistance",
+    "equipment": "smith machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Deficit Deadlift",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Depth Jump Leap",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Dip Machine",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": true,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Dips - Chest Version",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": true,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Dips - Triceps Version",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": true,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Donkey Calf Raises",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Double Kettlebell Alternating Hang Clean",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Double Kettlebell Jerk",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Double Kettlebell Push Press",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Double Kettlebell Snatch",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Double Kettlebell Windmill",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Double Leg Butt Kick",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Downward Facing Balance",
+    "type": "resistance",
+    "equipment": "exercise ball",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Drag Curl",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Drop Push",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Dumbbell Alternate Bicep Curl",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Dumbbell Bench Press",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Dumbbell Bench Press with Neutral Grip",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Dumbbell Bicep Curl",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Dumbbell Clean",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Dumbbell Floor Press",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Dumbbell Flyes",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Dumbbell Incline Row",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Dumbbell Incline Shoulder Raise",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Dumbbell Lunges",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Dumbbell Lying One-Arm Rear Lateral Raise",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "Dumbbell Lying Pronation",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Dumbbell Lying Rear Lateral Raise",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Dumbbell Lying Supination",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Dumbbell One-Arm Shoulder Press",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "Dumbbell One-Arm Triceps Extension",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "Dumbbell One-Arm Upright Row",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "Dumbbell Prone Incline Curl",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Dumbbell Raise",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Dumbbell Rear Lunge",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Dumbbell Scaption",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Dumbbell Seated Box Jump",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Dumbbell Seated One-Leg Calf Raise",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "Dumbbell Shoulder Press",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Dumbbell Shrug",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Dumbbell Side Bend",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Dumbbell Squat",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Dumbbell Squat To A Bench",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Dumbbell Step Ups",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Dumbbell Tricep Extension -Pronated Grip",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Dynamic Back Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Dynamic Chest Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "EZ-Bar Curl",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "EZ-Bar Skullcrusher",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Elbow Circles",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Elbow to Knee",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Elbows Back",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Elevated Back Lunge",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Elevated Cable Rows",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Elliptical Trainer",
+    "type": "distance",
+    "equipment": "elliptical",
+    "attributes": {
+      "distance_unit": "miles",
+      "tracks_elevation": false
+    }
+  },
+  {
+    "name": "Exercise Ball Crunch",
+    "type": "resistance",
+    "equipment": "exercise ball",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Exercise Ball Pull-In",
+    "type": "resistance",
+    "equipment": "exercise ball",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Extended Range One-Arm Kettlebell Floor Press",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "External Rotation",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "External Rotation with Band",
+    "type": "resistance",
+    "equipment": "resistance band",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "External Rotation with Cable",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Face Pull",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Farmer's Walk",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Fast Skipping",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Finger Curls",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Flat Bench Cable Flyes",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Flat Bench Leg Pull-In",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Flat Bench Lying Leg Raise",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Flexor Incline Dumbbell Curls",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Floor Glute-Ham Raise",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Floor Press",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Floor Press with Chains",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Flutter Kicks",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Foot-SMR",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Forward Drag with Press",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Frankenstein Squat",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Freehand Jump Squat",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Frog Hops",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Frog Sit-Ups",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Front Barbell Squat",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Front Barbell Squat To A Bench",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Front Box Jump",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Front Cable Raise",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Front Cone Hops (or hurdle hops)",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Front Dumbbell Raise",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Front Incline Dumbbell Raise",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Front Leg Raises",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Front Plate Raise",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Front Raise And Pullover",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Front Squat (Clean Grip)",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Front Squats With Two Kettlebells",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Front Two-Dumbbell Raise",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Full Range-Of-Motion Lat Pulldown",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Gironda Sternum Chins",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Glute Ham Raise",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Glute Kickback",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Goblet Squat",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Good Morning",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Good Morning off Pins",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Gorilla Chin/Crunch",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Groin and Back Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Groiners",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Hack Squat",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Hammer Curls",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Hammer Grip Incline DB Bench Press",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Hamstring-SMR",
+    "type": "timed_hold",
+    "equipment": "foam roller",
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Hamstring Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Handstand Push-Ups",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Hang Clean",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Hang Clean - Below the Knees",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Hang Snatch",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Hang Snatch - Below Knees",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Hanging Bar Good Morning",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Hanging Leg Raise",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Hanging Pike",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Heaving Snatch Balance",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Heavy Bag Thrust",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "High Cable Curls",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Hip Circles (prone)",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Hip Extension with Bands",
+    "type": "resistance",
+    "equipment": "resistance band",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Hip Flexion with Band",
+    "type": "resistance",
+    "equipment": "resistance band",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Hip Lift with Band",
+    "type": "resistance",
+    "equipment": "resistance band",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Hug A Ball",
+    "type": "timed_hold",
+    "equipment": "exercise ball",
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Hug Knees To Chest",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Hurdle Hops",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Hyperextensions (Back Extensions)",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Hyperextensions With No Hyperextension Bench",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "IT Band and Glute Stretch",
+    "type": "timed_hold",
+    "equipment": "resistance band",
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Iliotibial Tract-SMR",
+    "type": "timed_hold",
+    "equipment": "foam roller",
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Inchworm",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Incline Barbell Triceps Extension",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Incline Bench Pull",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Incline Cable Chest Press",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Incline Cable Flye",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Incline Dumbbell Bench With Palms Facing In",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Incline Dumbbell Curl",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Incline Dumbbell Flyes",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Incline Dumbbell Flyes - With A Twist",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Incline Dumbbell Press",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Incline Hammer Curls",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Incline Inner Biceps Curl",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Incline Push-Up",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Incline Push-Up Close-Grip",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Incline Push-Up Depth Jump",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Incline Push-Up Medium",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Incline Push-Up Reverse Grip",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Incline Push-Up Wide",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Intermediate Groin Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Intermediate Hip Flexor and Quad Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Internal Rotation with Band",
+    "type": "resistance",
+    "equipment": "resistance band",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Inverted Row",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Inverted Row with Straps",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Iron Cross",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Iron Crosses (stretch)",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Isometric Chest Squeezes",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Isometric Neck Exercise - Front And Back",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Isometric Neck Exercise - Sides",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Isometric Wipers",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "JM Press",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Jackknife Sit-Up",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Janda Sit-Up",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Jefferson Squats",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Jerk Balance",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Jerk Dip Squat",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": true,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Jogging, Treadmill",
+    "type": "distance",
+    "equipment": "treadmill",
+    "attributes": {
+      "distance_unit": "miles",
+      "tracks_elevation": false
+    }
+  },
+  {
+    "name": "Keg Load",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Kettlebell Arnold Press",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Kettlebell Dead Clean",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Kettlebell Figure 8",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Kettlebell Hang Clean",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Kettlebell One-Legged Deadlift",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "Kettlebell Pass Between The Legs",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Kettlebell Pirate Ships",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Kettlebell Pistol Squat",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Kettlebell Seated Press",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Kettlebell Seesaw Press",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Kettlebell Sumo High Pull",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Kettlebell Thruster",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Kettlebell Turkish Get-Up (Lunge style)",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Kettlebell Turkish Get-Up (Squat style)",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Kettlebell Windmill",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Kipping Muscle Up",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Knee Across The Body",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Knee Circles",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Knee/Hip Raise On Parallel Bars",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Knee Tuck Jump",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Kneeling Arm Drill",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Kneeling Cable Crunch With Alternating Oblique Twists",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Kneeling Cable Triceps Extension",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Kneeling Forearm Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Kneeling High Pulley Row",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Kneeling Hip Flexor",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Kneeling Jump Squat",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Kneeling Single-Arm High Pulley Row",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "Kneeling Squat",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Landmine 180's",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Landmine Linear Jammer",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Lateral Bound",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Lateral Box Jump",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Lateral Cone Hops",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Lateral Raise - With Bands",
+    "type": "resistance",
+    "equipment": "resistance band",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Latissimus Dorsi-SMR",
+    "type": "timed_hold",
+    "equipment": "foam roller",
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Leg-Over Floor Press",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Leg-Up Hamstring Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Leg Extensions",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Leg Lift",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Leg Press",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Leg Pull-In",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Leverage Chest Press",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Leverage Deadlift",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Leverage Decline Chest Press",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Leverage High Row",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Leverage Incline Chest Press",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Leverage Iso Row",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Leverage Shoulder Press",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Leverage Shrug",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Linear 3-Part Start Technique",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Linear Acceleration Wall Drill",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Linear Depth Jump",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Log Lift",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "London Bridges",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Looking At Ceiling",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Low Cable Crossover",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Low Cable Triceps Extension",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Low Pulley Row To Neck",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Lower Back-SMR",
+    "type": "timed_hold",
+    "equipment": "foam roller",
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Lower Back Curl",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Lunge Pass Through",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Lunge Sprint",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Lying Bent Leg Groin",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Lying Cable Curl",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Lying Cambered Barbell Row",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Lying Close-Grip Bar Curl On High Pulley",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Lying Close-Grip Barbell Triceps Extension Behind The Head",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Lying Close-Grip Barbell Triceps Press To Chin",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Lying Crossover",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Lying Dumbbell Tricep Extension",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Lying Face Down Plate Neck Resistance",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Lying Face Up Plate Neck Resistance",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Lying Glute",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Lying Hamstring",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Lying High Bench Barbell Curl",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Lying Leg Curls",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Lying Machine Squat",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Lying One-Arm Lateral Raise",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "Lying Prone Quadriceps",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Lying Rear Delt Raise",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Lying Supine Dumbbell Curl",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Lying T-Bar Row",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Lying Triceps Press",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Machine Bench Press",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Machine Bicep Curl",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Machine Preacher Curls",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Machine Shoulder (Military) Press",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Machine Triceps Extension",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Medicine Ball Chest Pass",
+    "type": "resistance",
+    "equipment": "medicine ball",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Medicine Ball Full Twist",
+    "type": "resistance",
+    "equipment": "medicine ball",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Medicine Ball Scoop Throw",
+    "type": "resistance",
+    "equipment": "medicine ball",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Middle Back Shrug",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Middle Back Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Mixed Grip Chin",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Monster Walk",
+    "type": "resistance",
+    "equipment": "resistance band",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Mountain Climbers",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Moving Claw Series",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Muscle Snatch",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Muscle Up",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Narrow Stance Hack Squats",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Narrow Stance Leg Press",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Narrow Stance Squats",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Natural Glute Ham Raise",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Neck-SMR",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Neck Press",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Oblique Crunches",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Oblique Crunches - On The Floor",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Olympic Squat",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "On-Your-Back Quad Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "On Your Side Quad Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "One-Arm Dumbbell Row",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "One-Arm Flat Bench Dumbbell Flye",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "One-Arm High-Pulley Cable Side Bends",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "One-Arm Incline Lateral Raise",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "One-Arm Kettlebell Clean",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "One-Arm Kettlebell Clean and Jerk",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "One-Arm Kettlebell Floor Press",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "One-Arm Kettlebell Jerk",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "One-Arm Kettlebell Military Press To The Side",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "One-Arm Kettlebell Para Press",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "One-Arm Kettlebell Push Press",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "One-Arm Kettlebell Row",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "One-Arm Kettlebell Snatch",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "One-Arm Kettlebell Split Jerk",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "One-Arm Kettlebell Split Snatch",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "One-Arm Kettlebell Swings",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "One-Arm Long Bar Row",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "One-Arm Medicine Ball Slam",
+    "type": "resistance",
+    "equipment": "medicine ball",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "One-Arm Open Palm Kettlebell Clean",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "One-Arm Overhead Kettlebell Squats",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "One-Arm Side Deadlift",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "One-Arm Side Laterals",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "One-Legged Cable Kickback",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "One Arm Against Wall",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "One Arm Chin-Up",
+    "type": "resistance",
+    "equipment": "pull-up bar",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": true,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "One Arm Dumbbell Bench Press",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "One Arm Dumbbell Preacher Curl",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "One Arm Floor Press",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "One Arm Lat Pulldown",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "One Arm Pronated Dumbbell Triceps Extension",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "One Arm Supinated Dumbbell Triceps Extension",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "One Half Locust",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "One Handed Hang",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "One Knee To Chest",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "One Leg Barbell Squat",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "Open Palm Kettlebell Clean",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Otis-Up",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Overhead Cable Curl",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Overhead Lat",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Overhead Slam",
+    "type": "resistance",
+    "equipment": "medicine ball",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Overhead Squat",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Overhead Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Overhead Triceps",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Pallof Press",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Pallof Press With Rotation",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Palms-Down Dumbbell Wrist Curl Over A Bench",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Palms-Down Wrist Curl Over A Bench",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Palms-Up Barbell Wrist Curl Over A Bench",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Palms-Up Dumbbell Wrist Curl Over A Bench",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Parallel Bar Dip",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": true,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Pelvic Tilt Into Bridge",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Peroneals-SMR",
+    "type": "timed_hold",
+    "equipment": "foam roller",
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Peroneals Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Physioball Hip Bridge",
+    "type": "resistance",
+    "equipment": "exercise ball",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Pin Presses",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Piriformis-SMR",
+    "type": "timed_hold",
+    "equipment": "foam roller",
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Plank",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Plate Pinch",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Plate Twist",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Platform Hamstring Slides",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Plie Dumbbell Squat",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Plyo Kettlebell Pushups",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Plyo Push-up",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Posterior Tibialis Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Power Clean",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Power Clean from Blocks",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Power Jerk",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Power Partials",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Power Snatch",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Power Snatch from Blocks",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Power Stairs",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Preacher Curl",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Preacher Hammer Dumbbell Curl",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Press Sit-Up",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Prone Manual Hamstring",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Prowler Sprint",
+    "type": "distance",
+    "equipment": null,
+    "attributes": {
+      "distance_unit": "miles",
+      "tracks_elevation": false
+    }
+  },
+  {
+    "name": "Pull Through",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Pullups",
+    "type": "resistance",
+    "equipment": "pull-up bar",
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": true,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Push-Up Wide",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Push-Ups - Close Triceps Position",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Push-Ups With Feet Elevated",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Push-Ups With Feet On An Exercise Ball",
+    "type": "resistance",
+    "equipment": "exercise ball",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Push Press",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Push Press - Behind the Neck",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Push Up to Side Plank",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Pushups",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Pushups (Close and Wide Hand Positions)",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Pyramid",
+    "type": "timed_hold",
+    "equipment": "exercise ball",
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Quad Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Quadriceps-SMR",
+    "type": "timed_hold",
+    "equipment": "foam roller",
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Quick Leap",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Rack Delivery",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Rack Pull with Bands",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Rack Pulls",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Rear Leg Raises",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Recumbent Bike",
+    "type": "distance",
+    "equipment": "stationary bike",
+    "attributes": {
+      "distance_unit": "miles",
+      "tracks_elevation": false
+    }
+  },
+  {
+    "name": "Return Push from Stance",
+    "type": "resistance",
+    "equipment": "medicine ball",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Reverse Band Bench Press",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Reverse Band Box Squat",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Reverse Band Deadlift",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Reverse Band Power Squat",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Reverse Band Sumo Deadlift",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Reverse Barbell Curl",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Reverse Barbell Preacher Curls",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Reverse Cable Curl",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Reverse Crunch",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Reverse Flyes",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Reverse Flyes With External Rotation",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Reverse Grip Bent-Over Rows",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Reverse Grip Triceps Pushdown",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Reverse Hyperextension",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Reverse Machine Flyes",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Reverse Plate Curls",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Reverse Triceps Bench Press",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Rhomboids-SMR",
+    "type": "timed_hold",
+    "equipment": "foam roller",
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Rickshaw Carry",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Rickshaw Deadlift",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Ring Dips",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": true,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Rocket Jump",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Rocking Standing Calf Raise",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Rocky Pull-Ups/Pulldowns",
+    "type": "resistance",
+    "equipment": "pull-up bar",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": true,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Romanian Deadlift",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Romanian Deadlift from Deficit",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Rope Climb",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Rope Crunch",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Rope Jumping",
+    "type": "distance",
+    "equipment": null,
+    "attributes": {
+      "distance_unit": "miles",
+      "tracks_elevation": false
+    }
+  },
+  {
+    "name": "Rope Straight-Arm Pulldown",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Round The World Shoulder Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Rowing, Stationary",
+    "type": "distance",
+    "equipment": "rowing machine",
+    "attributes": {
+      "distance_unit": "miles",
+      "tracks_elevation": false
+    }
+  },
+  {
+    "name": "Runner's Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Running, Treadmill",
+    "type": "distance",
+    "equipment": "treadmill",
+    "attributes": {
+      "distance_unit": "miles",
+      "tracks_elevation": false
+    }
+  },
+  {
+    "name": "Russian Twist",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Sandbag Load",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Scapular Pull-Up",
+    "type": "resistance",
+    "equipment": "pull-up bar",
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": true,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Scissor Kick",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Scissors Jump",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Seated Band Hamstring Curl",
+    "type": "resistance",
+    "equipment": "resistance band",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Seated Barbell Military Press",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Seated Barbell Twist",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Seated Bent-Over One-Arm Dumbbell Triceps Extension",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "Seated Bent-Over Rear Delt Raise",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Seated Bent-Over Two-Arm Dumbbell Triceps Extension",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Seated Biceps",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Seated Cable Rows",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Seated Cable Shoulder Press",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Seated Calf Raise",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Seated Calf Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Seated Close-Grip Concentration Barbell Curl",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Seated Dumbbell Curl",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Seated Dumbbell Inner Biceps Curl",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Seated Dumbbell Palms-Down Wrist Curl",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Seated Dumbbell Palms-Up Wrist Curl",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Seated Dumbbell Press",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Seated Flat Bench Leg Pull-In",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Seated Floor Hamstring Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Seated Front Deltoid",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Seated Glute",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Seated Good Mornings",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Seated Hamstring",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Seated Hamstring and Calf Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Seated Head Harness Neck Resistance",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Seated Leg Curl",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Seated Leg Tucks",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Seated One-Arm Dumbbell Palms-Down Wrist Curl",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "Seated One-Arm Dumbbell Palms-Up Wrist Curl",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "Seated One-arm Cable Pulley Rows",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "Seated Overhead Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Seated Palm-Up Barbell Wrist Curl",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Seated Palms-Down Barbell Wrist Curl",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Seated Side Lateral Raise",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Seated Triceps Press",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Seated Two-Arm Palms-Up Low-Pulley Wrist Curl",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "See-Saw Press (Alternating Side Press)",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Shotgun Row",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Shoulder Circles",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Shoulder Press - With Bands",
+    "type": "resistance",
+    "equipment": "resistance band",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Shoulder Raise",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Shoulder Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Side-Lying Floor Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Side Bridge",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Side Hop-Sprint",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Side Jackknife",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Side Lateral Raise",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Side Laterals to Front Raise",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Side Leg Raises",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Side Lying Groin Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Side Neck Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Side Standing Long Jump",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Side To Side Chins",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Side Wrist Pull",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Side to Side Box Shuffle",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Single-Arm Cable Crossover",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "Single-Arm Linear Jammer",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "Single-Arm Push-Up",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "Single-Cone Sprint Drill",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Single-Leg High Box Squat",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "Single-Leg Hop Progression",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "Single-Leg Lateral Hop",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "Single-Leg Leg Extension",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "Single-Leg Stride Jump",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "Single Dumbbell Raise",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Single Leg Butt Kick",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "Single Leg Glute Bridge",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "Single Leg Push-off",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "Sit-Up",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Sit Squats",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Skating",
+    "type": "distance",
+    "equipment": null,
+    "attributes": {
+      "distance_unit": "miles",
+      "tracks_elevation": false
+    }
+  },
+  {
+    "name": "Sled Drag - Harness",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Sled Overhead Backward Walk",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Sled Overhead Triceps Extension",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Sled Push",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Sled Reverse Flye",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Sled Row",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Sledgehammer Swings",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Smith Incline Shoulder Raise",
+    "type": "resistance",
+    "equipment": "smith machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Smith Machine Behind the Back Shrug",
+    "type": "resistance",
+    "equipment": "smith machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Smith Machine Bench Press",
+    "type": "resistance",
+    "equipment": "smith machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Smith Machine Bent Over Row",
+    "type": "resistance",
+    "equipment": "smith machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Smith Machine Calf Raise",
+    "type": "resistance",
+    "equipment": "smith machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Smith Machine Close-Grip Bench Press",
+    "type": "resistance",
+    "equipment": "smith machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Smith Machine Decline Press",
+    "type": "resistance",
+    "equipment": "smith machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Smith Machine Hang Power Clean",
+    "type": "resistance",
+    "equipment": "smith machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Smith Machine Hip Raise",
+    "type": "resistance",
+    "equipment": "smith machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Smith Machine Incline Bench Press",
+    "type": "resistance",
+    "equipment": "smith machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Smith Machine Leg Press",
+    "type": "resistance",
+    "equipment": "smith machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Smith Machine One-Arm Upright Row",
+    "type": "resistance",
+    "equipment": "smith machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "Smith Machine Overhead Shoulder Press",
+    "type": "resistance",
+    "equipment": "smith machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Smith Machine Pistol Squat",
+    "type": "resistance",
+    "equipment": "smith machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Smith Machine Reverse Calf Raises",
+    "type": "resistance",
+    "equipment": "smith machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Smith Machine Squat",
+    "type": "resistance",
+    "equipment": "smith machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Smith Machine Stiff-Legged Deadlift",
+    "type": "resistance",
+    "equipment": "smith machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Smith Machine Upright Row",
+    "type": "resistance",
+    "equipment": "smith machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Smith Single-Leg Split Squat",
+    "type": "resistance",
+    "equipment": "smith machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "Snatch",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Snatch Balance",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Snatch Deadlift",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Snatch Pull",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Snatch Shrug",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Snatch from Blocks",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Speed Band Overhead Triceps",
+    "type": "resistance",
+    "equipment": "resistance band",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Speed Box Squat",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Speed Squats",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Spell Caster",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Spider Crawl",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Spider Curl",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Spinal Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Split Clean",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Split Jerk",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Split Jump",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Split Snatch",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Split Squat with Dumbbells",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Split Squats",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Squat Jerk",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Squat with Bands",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Squat with Chains",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Squat with Plate Movers",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Squats - With Bands",
+    "type": "resistance",
+    "equipment": "resistance band",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Stairmaster",
+    "type": "distance",
+    "equipment": "stair climber",
+    "attributes": {
+      "distance_unit": "miles",
+      "tracks_elevation": false
+    }
+  },
+  {
+    "name": "Standing Alternating Dumbbell Press",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Standing Barbell Calf Raise",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Standing Barbell Press Behind Neck",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Standing Bent-Over One-Arm Dumbbell Triceps Extension",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "Standing Bent-Over Two-Arm Dumbbell Triceps Extension",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Standing Biceps Cable Curl",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Standing Biceps Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Standing Bradford Press",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Standing Cable Chest Press",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Standing Cable Lift",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Standing Cable Wood Chop",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Standing Calf Raises",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Standing Concentration Curl",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Standing Dumbbell Calf Raise",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Standing Dumbbell Press",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Standing Dumbbell Reverse Curl",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Standing Dumbbell Straight-Arm Front Delt Raise Above Head",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Standing Dumbbell Triceps Extension",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Standing Dumbbell Upright Row",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Standing Elevated Quad Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Standing Front Barbell Raise Over Head",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Standing Gastrocnemius Calf Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Standing Hamstring and Calf Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Standing Hip Circles",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Standing Hip Flexors",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Standing Inner-Biceps Curl",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Standing Lateral Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Standing Leg Curl",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Standing Long Jump",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Standing Low-Pulley Deltoid Raise",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Standing Low-Pulley One-Arm Triceps Extension",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "Standing Military Press",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Standing Olympic Plate Hand Squeeze",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Standing One-Arm Cable Curl",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "Standing One-Arm Dumbbell Curl Over Incline Bench",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "Standing One-Arm Dumbbell Triceps Extension",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "Standing Overhead Barbell Triceps Extension",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Standing Palm-In One-Arm Dumbbell Press",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "Standing Palms-In Dumbbell Press",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Standing Palms-Up Barbell Behind The Back Wrist Curl",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Standing Pelvic Tilt",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Standing Rope Crunch",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Standing Soleus And Achilles Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Standing Toe Touches",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Standing Towel Triceps Extension",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Standing Two-Arm Overhead Throw",
+    "type": "resistance",
+    "equipment": "medicine ball",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Star Jump",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Step-up with Knee Raise",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Step Mill",
+    "type": "distance",
+    "equipment": "stair climber",
+    "attributes": {
+      "distance_unit": "miles",
+      "tracks_elevation": false
+    }
+  },
+  {
+    "name": "Stiff-Legged Barbell Deadlift",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Stiff-Legged Dumbbell Deadlift",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Stiff Leg Barbell Good Morning",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Stomach Vacuum",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Straight-Arm Dumbbell Pullover",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Straight-Arm Pulldown",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Straight Bar Bench Mid Rows",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Straight Raises on Incline Bench",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Stride Jump Crossover",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Sumo Deadlift",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Sumo Deadlift with Bands",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Sumo Deadlift with Chains",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Superman",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Supine Chest Throw",
+    "type": "resistance",
+    "equipment": "medicine ball",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Supine One-Arm Overhead Throw",
+    "type": "resistance",
+    "equipment": "medicine ball",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": false
+    }
+  },
+  {
+    "name": "Supine Two-Arm Overhead Throw",
+    "type": "resistance",
+    "equipment": "medicine ball",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Suspended Fallout",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Suspended Push-Up",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Suspended Reverse Crunch",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Suspended Row",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Suspended Split Squat",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Svend Press",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "T-Bar Row with Handle",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Tate Press",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "The Straddle",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Thigh Abductor",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Thigh Adductor",
+    "type": "resistance",
+    "equipment": "lever machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Tire Flip",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Toe Touchers",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Torso Rotation",
+    "type": "timed_hold",
+    "equipment": "exercise ball",
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Trail Running/Walking",
+    "type": "distance",
+    "equipment": null,
+    "attributes": {
+      "distance_unit": "miles",
+      "tracks_elevation": false
+    }
+  },
+  {
+    "name": "Trap Bar Deadlift",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Tricep Dumbbell Kickback",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Tricep Side Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Triceps Overhead Extension with Rope",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Triceps Pushdown",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Triceps Pushdown - Rope Attachment",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Triceps Pushdown - V-Bar Attachment",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Triceps Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Tuck Crunch",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Two-Arm Dumbbell Preacher Curl",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Two-Arm Kettlebell Clean",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Two-Arm Kettlebell Jerk",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Two-Arm Kettlebell Military Press",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Two-Arm Kettlebell Row",
+    "type": "resistance",
+    "equipment": "kettlebell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Underhand Cable Pulldowns",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Upper Back-Leg Grab",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Upper Back Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Upright Barbell Row",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Upright Cable Row",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Upright Row - With Bands",
+    "type": "resistance",
+    "equipment": "resistance band",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Upward Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "V-Bar Pulldown",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "V-Bar Pullup",
+    "type": "resistance",
+    "equipment": "pull-up bar",
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": true,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Vertical Swing",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Walking, Treadmill",
+    "type": "distance",
+    "equipment": "treadmill",
+    "attributes": {
+      "distance_unit": "miles",
+      "tracks_elevation": false
+    }
+  },
+  {
+    "name": "Weighted Ball Hyperextension",
+    "type": "resistance",
+    "equipment": "exercise ball",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Weighted Ball Side Bend",
+    "type": "resistance",
+    "equipment": "exercise ball",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Weighted Bench Dip",
+    "type": "resistance",
+    "equipment": "bench",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": true,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Weighted Crunches",
+    "type": "resistance",
+    "equipment": "medicine ball",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Weighted Jump Squat",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Weighted Pull Ups",
+    "type": "resistance",
+    "equipment": "pull-up bar",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": true,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Weighted Sissy Squat",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Weighted Sit-Ups - With Bands",
+    "type": "resistance",
+    "equipment": "resistance band",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Weighted Squat",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Wide-Grip Barbell Bench Press",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Wide-Grip Decline Barbell Bench Press",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Wide-Grip Decline Barbell Pullover",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Wide-Grip Lat Pulldown",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Wide-Grip Pulldown Behind The Neck",
+    "type": "resistance",
+    "equipment": "cable machine",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Wide-Grip Rear Pull-Up",
+    "type": "resistance",
+    "equipment": "pull-up bar",
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": true,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Wide-Grip Standing Barbell Curl",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Wide Stance Barbell Squat",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Wide Stance Stiff Legs",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Wind Sprints",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": true,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Windmills",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "World's Greatest Stretch",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Wrist Circles",
+    "type": "timed_hold",
+    "equipment": null,
+    "attributes": {
+      "target_duration_seconds": null
+    }
+  },
+  {
+    "name": "Wrist Roller",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Wrist Rotations with Straight Bar",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Yoke Walk",
+    "type": "resistance",
+    "equipment": null,
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Zercher Squats",
+    "type": "resistance",
+    "equipment": "barbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Zottman Curl",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Zottman Preacher Curl",
+    "type": "resistance",
+    "equipment": "dumbbell",
+    "attributes": {
+      "bodyweight_base": false,
+      "allows_added_weight": false,
+      "bilateral": true
+    }
+  },
+  {
+    "name": "Tabata Intervals",
+    "type": "interval",
+    "equipment": null,
+    "attributes": {
+      "default_work_seconds": 20,
+      "default_rest_seconds": 10,
+      "default_rounds": 8
+    }
+  },
+  {
+    "name": "EMOM (Every Minute on the Minute)",
+    "type": "interval",
+    "equipment": null,
+    "attributes": {
+      "default_work_seconds": 60,
+      "default_rest_seconds": 0,
+      "default_rounds": 10
+    }
+  },
+  {
+    "name": "AMRAP (As Many Rounds As Possible)",
+    "type": "interval",
+    "equipment": null,
+    "attributes": {
+      "default_work_seconds": 1200,
+      "default_rest_seconds": 0,
+      "default_rounds": 1
+    }
+  },
+  {
+    "name": "HIIT Sprint Intervals",
+    "type": "interval",
+    "equipment": "treadmill",
+    "attributes": {
+      "default_work_seconds": 30,
+      "default_rest_seconds": 90,
+      "default_rounds": 8
+    }
+  },
+  {
+    "name": "Circuit Training",
+    "type": "interval",
+    "equipment": null,
+    "attributes": {
+      "default_work_seconds": 45,
+      "default_rest_seconds": 15,
+      "default_rounds": 3
+    }
+  }
+]

--- a/docs/decisions/adr-003-exercise-type-set-data-model.md
+++ b/docs/decisions/adr-003-exercise-type-set-data-model.md
@@ -73,7 +73,7 @@ Exercise types have been restructured from 9 to 4 based on shared attribute patt
 ```sql
 exercises
 ├── id (PK, auto-increment)
-├── user_id (FK → users.id, indexed)
+├── user_id (FK → users.id, nullable, indexed)  -- null = system-owned (ADR-010)
 ├── equipment_type_id (FK → equipment_types.id, nullable, indexed)
 ├── name (string)
 ├── type (string, indexed, discriminator)
@@ -157,6 +157,7 @@ Each child table's `exercise_id` FK is UNIQUE (one-to-one) and cascades on delet
 - **ADR-004** (gym equipment): equipment is a type catalog referenced by exercise definitions
 - **ADR-005** (weight unit): raw numbers in user's configured unit
 - **ADR-006** (composable metrics): performance logging schema that composes with these definitions
+- **ADR-010** (system-owned exercises): amends this schema to make user_id nullable, where null marks a system-owned catalog row
 
 ---
 

--- a/docs/decisions/adr-004-gym-equipment-domain-model.md
+++ b/docs/decisions/adr-004-gym-equipment-domain-model.md
@@ -71,7 +71,7 @@ definitions cannot be silently removed.
 equipment_types
 +----- id (PK, auto-increment)
 +----- name (string)
-+----- user_id (FK -> users.id, nullable) -- null = system-seeded
++----- user_id (FK -> users.id, nullable, ON DELETE CASCADE) -- null = system-seeded; custom types removed with their owner
 +----- is_system (boolean, default false)
 +----- created_at, updated_at
 +----- UNIQUE(name, user_id) -- prevent per-user duplicates

--- a/docs/decisions/adr-010-system-owned-exercises.md
+++ b/docs/decisions/adr-010-system-owned-exercises.md
@@ -1,0 +1,128 @@
+# ADR-010: System-Owned Exercises via Nullable user_id
+
+## Status
+Accepted
+
+## Date
+2026-06-27
+
+## Deciders
+- Justin Christenson (Decision maker and application owner)
+
+---
+
+## Context
+
+Physistrong requires a shared, read-only exercise catalog to reduce user setup friction. The application is seeding approximately 873 exercises from the free-exercise-db open dataset as a starter library available to every user.
+
+During initial planning (ADR-003), exercises were modeled as strictly per-user: the `exercises` table carried a non-null `user_id` with a `UNIQUE(user_id, name)` constraint. This design enforced per-user ownership and per-user name uniqueness, but it provided no mechanism for system-seeded, shared exercise definitions.
+
+The equipment-type model (ADR-004) already solved an analogous problem: `equipment_types.user_id` is nullable, with null indicating a system-seeded record. This established a pattern that exercises can follow.
+
+Without system-owned exercises, every user must create their own definitions for common exercises (bench press, squat, deadlift, etc.), duplicating effort and setup burden. With a seeded catalog, users can immediately see and use 873 standard exercises and optionally create custom ones.
+
+---
+
+## Decision
+
+**Exercises carry a nullable `user_id` field.** A null `user_id` indicates a system-owned exercise (read-only catalog). A non-null `user_id` indicates a user-owned custom exercise. This pattern mirrors ADR-004 exactly.
+
+### Amend ADR-003
+
+The `exercises` table schema changes:
+- `user_id` becomes nullable (was non-null with NOT NULL constraint)
+- `UNIQUE(user_id, name)` constraint remains and continues to enforce per-user name uniqueness
+
+### MySQL UNIQUE Index Behavior with NULL
+
+MySQL treats NULL values as distinct in unique indexes: two rows with NULL user_id do NOT violate a `UNIQUE(user_id, name)` constraint. This means name uniqueness is NOT enforced across system exercises. This is acceptable because:
+- Seed data is pre-deduplicated; all 873 exercise names are unique
+- System exercises are read-only; users cannot create duplicates
+- Per-user uniqueness for custom exercises is still enforced (both rows with the same user_id and name would violate the constraint)
+
+### Authorization (ExercisePolicy)
+
+- **Read:** Users can read their own exercises plus all system exercises (null user_id)
+- **Create:** Sets `user_id` to the authenticated user
+- **Update / Delete:** Users can only update/delete their own exercises (non-null user_id matching the authenticated user)
+- **System exercises are read-only:** Users cannot modify system exercises via the API
+
+### Deletion (ADR-002 interaction)
+
+- User-owned exercises follow ADR-002: block-if-used (return 409 if referenced by a workout entry)
+- System exercises are not user-deletable and have no block-if-used logic (the API does not expose a delete endpoint for system exercises)
+
+---
+
+## Migration Structure
+
+Amend the `exercises` migration from ADR-003:
+
+```sql
+exercises
+├── id (PK, auto-increment)
+├── user_id (FK → users.id, nullable, indexed)  -- null = system-owned
+├── equipment_type_id (FK → equipment_types.id, nullable, indexed)
+├── name (string)
+├── type (string, indexed, discriminator)
+├── notes (text, nullable)
+├── created_at, updated_at
+└── UNIQUE(user_id, name)
+```
+
+The `user_id` constraint changes from NOT NULL to nullable. The unique index `UNIQUE(user_id, name)` is unchanged; it continues to prevent duplicate names per user while permitting multiple system exercises to share a name with null user_id.
+
+---
+
+## Consequences
+
+### Positive
+- Seeded exercise catalog available to every user at no setup cost
+- Pattern consistency: mirrors ADR-004 (equipment_types.user_id nullable)
+- Users can still create custom exercises (non-null user_id)
+- Per-user name uniqueness is preserved; custom exercises cannot duplicate user-owned names
+- Simple authorization: null user_id is the sole authoritative marker for system ownership
+
+### Negative
+- System exercise catalog is not user-editable or customizable per user
+- If seed data contains an exercise users consider incorrectly named or typed, the application must publish a correction (no user override)
+- Seeding must ensure all 873 exercise names are globally unique across types (no duplicates)
+
+### New Decisions Required
+- Seeder script: insert 873 exercises with `user_id = NULL`
+- ADR-003 migration specification must be updated (see Migration Structure above)
+- Project CLAUDE.md must be updated: change "No shared data except system-seeded equipment types" to "No shared data except system-seeded equipment types and exercises"
+
+---
+
+## Alternatives Considered
+
+**is_system boolean flag.** The `equipment_types` table (ADR-004) carries both a nullable `user_id` AND an `is_system` boolean. We chose to use null `user_id` as the sole marker (not carry `is_system`) to keep the system-ownership signal unambiguous and to mirror the simplest variant of the equipment-type pattern. A single source of truth (null user_id) reduces the risk of contradiction (is_system=true but user_id is non-null).
+
+---
+
+## Related Decisions
+
+- **ADR-002** (deletion): block-if-used applies to user-owned exercises; system exercises are read-only
+- **ADR-003** (exercise definitions): this decision amends the schema from ADR-003; the migration spec must be updated
+- **ADR-004** (gym equipment): the pattern (nullable user_id for system ownership) mirrors this decision exactly
+- **Phase 2 seeding work:** requires a seeder script that inserts 873 exercises with `user_id = NULL`
+
+---
+
+## Influences
+
+- The equipment-type model (ADR-004) successfully demonstrated nullable `user_id` for system ownership
+- User feedback on setup friction: every user recreating the same 100 common exercises
+- Free-exercise-db provides a pre-curated, deduplicated catalog of 873 exercises
+- MySQL unique index behavior: null is distinct in unique constraints, suitable for this use case
+
+---
+
+## Participants
+
+- Justin Christenson (decision maker)
+
+## Review Date
+
+Review after Phase 2 seeding is complete and users have exercised the system-owned catalog. Revisit if users request per-user customization of system exercises or if catalog errors are discovered.

--- a/docs/decisions/adr-011-bodyweight-exercise-modeling.md
+++ b/docs/decisions/adr-011-bodyweight-exercise-modeling.md
@@ -1,0 +1,155 @@
+# ADR-011: Bodyweight Exercise Modeling
+
+## Status
+Proposed
+
+## Date
+2026-06-27
+
+## Deciders
+- Justin Christenson (Decision maker and application owner)
+
+---
+
+## Context
+
+Physistrong currently models bodyweight exercises thinly across two layers. At the exercise definition level (ADR-003), the `exercise_resistance` table carries two booleans: `bodyweight_base` (the movement is fundamentally bodyweight, e.g., pull-up, push-up) and `allows_added_weight` (extra load can be hung off it, e.g., weighted pull-up). At the performance logging level (ADR-006), `log_load_metrics` carries a `bodyweight_only` flag and target/actual weight columns.
+
+This works for basic cases: a pull-up is marked `bodyweight_base=true` and `allows_added_weight=true`, and the log stores only the added weight. But several real-world cases fall short:
+
+- **Assisted bodyweight** (band-assisted or machine-assisted pull-ups/dips): the assistance is effectively negative load. A flag cannot express "bodyweight minus 40 lb of band assistance", and the log has no way to record or analyze the actual working load.
+
+- **Added-weight bodyweight volume and PRs**: a weighted pull-up's true working load is bodyweight plus added weight. The log stores only the added weight. Volume and PR math that ignores bodyweight understates the real load and makes progress analytics incomplete.
+
+- **Bodyweight as a load variable for analytics**: progress queries (ADR-006 patterns) and future Phase 9 progress tracking may want the user's bodyweight at the time of the set to compute true load = bodyweight +/- added/assist. Bodyweight changes over time, implying the need to capture it per workout or per set, not only as a static user profile value.
+
+- **Percentage-of-bodyweight or relative-strength views**: some users track lifts relative to bodyweight (e.g., "can I lift 1.5x my weight?"). The current schema does not support this kind of relative analysis.
+
+- **Legacy antipattern avoidance**: the old code used weight <= 0 to mean "Body" (ADR-003 context). ADR-003 deliberately eliminated this. Any new approach must not reintroduce magic-value conventions.
+
+This design gap does not block current work (Phase 2 seed data sets `bodyweight_base` heuristically, which is sufficient for now), but it will constrain Phase 9 (progress tracking) analytics and will require a decision before deep work begins there.
+
+---
+
+## Decision
+
+No decision has been made yet. This ADR lays out the problem and options for a future call. The options below are open and require discussion and consensus before implementation.
+
+---
+
+## Alternatives Considered
+
+### Option 1: Keep the Boolean Flags As-Is (Status Quo)
+
+Accept that assisted and added-weight nuance, bodyweight-as-load analytics, and relative-strength views are beyond the current scope. The existing `bodyweight_base` and `allows_added_weight` flags on the definition, plus the `bodyweight_only` flag on the log, cover the happy path (basic bodyweight + simple added weight). Advanced cases are deferred or approximated.
+
+**Pros:**
+- No schema changes required.
+- No new database tables or columns.
+- Minimum complexity and maintenance burden.
+
+**Cons:**
+- Cannot record or analyze assisted bodyweight work (band-assisted pull-ups, machine-assisted dips).
+- Volume and PR calculations for weighted bodyweight exercises are incomplete (ignore the user's bodyweight as a load component).
+- Progress tracking queries cannot normalize across users or time (bodyweight is not captured at set time).
+- Relative-strength analytics (lifts as a percentage of bodyweight) require manual computation outside the app.
+- The heuristic in Phase 2 seeding (`bodyweight_base` inferred from equipment type) may be inaccurate; no easy correction path without a broader bodyweight model.
+
+### Option 2: Signed Load on the Existing Load Metric
+
+Extend `log_load_metrics` to allow added weight to be positive and assistance (band/machine) to be negative on a single column. A weighted pull-up would store `+25` (lbs added); a band-assisted pull-up would store `-40` (lbs assistance). This collapses added weight and assistance into a single signed-load dimension.
+
+**Pros:**
+- Expressible in the existing schema with no new tables.
+- Adds nuance for assisted work without expanding the metric tables.
+- Queries can sum absolute load across entries (though negative values need care in interpretation).
+
+**Cons:**
+- Semantics of a negative "weight" are counterintuitive. Code and queries must explicitly handle the sign; this is error-prone without strong documentation.
+- Does not capture the user's bodyweight at set time, so true load = bodyweight + signed_load still cannot be computed for volume/PR analytics.
+- Mixing negative and positive on the same column violates the "no magic values" principle (though less egregiously than 0/"Body"). Reviewers and future maintainers may misinterpret a negative value as a data entry error.
+- Progress queries would need conditional logic to interpret negative loads correctly.
+
+### Option 3: Capture Bodyweight as a First-Class Log Input
+
+Record the user's bodyweight at workout (or set) time so that true load can be computed as bodyweight +/- added/assist. This implies a new column on `workout_entries` or a new metric table `log_bodyweight_snapshots`, plus a decision about granularity (per-workout vs. per-set) and source (profile snapshot at workout time vs. manual entry per set).
+
+**Pros:**
+- Enables true-load computation for volume and PR analytics (bodyweight + added - assistance).
+- Supports relative-strength views (lifts as % of bodyweight at set time).
+- Bodyweight-as-time-series becomes queryable for progress tracking.
+- Avoids magic values; bodyweight is a first-class numeric field.
+
+**Cons:**
+- Requires a migration and new column(s) on `workout_entries` or a new metric table.
+- Decision needed: capture at workout level (simpler, assumes consistent bodyweight across a workout) or per-set (more accurate, more granular).
+- Decision needed: automatic (snapshot user's profile weight at workout time) or manual (user enters bodyweight per workout/set). Manual entry adds friction; automatic creates stale data if the user's weight changes mid-phase.
+- If granularity is per-set, adds a column to every workout entry even for exercises that don't need it (pure luck if this is a performance win).
+- Phase 9 progress queries become more complex; they now need to handle bodyweight as a load variable in calculations.
+
+### Option 4: A Dedicated Bodyweight-Load Metric / Sub-Model
+
+Model bodyweight loading as its own composable metric dimension (separate from `log_load_metrics`), with columns for added load, assistance load, and bodyweight-at-time. For example, a `log_bodyweight_metrics` table carries `target_bodyweight`, `actual_bodyweight`, `target_added_load`, `actual_added_load`, `target_assistance`, `actual_assistance`. This is the most expressive option.
+
+**Pros:**
+- Fully expressive: added weight, assistance, and bodyweight are first-class, named columns.
+- Aligns with composable-metrics philosophy (ADR-006): bodyweight loading is one orthogonal metric dimension.
+- Separate metric table keeps bodyweight logic isolated and testable.
+- Phase 9 progress queries can directly access true load components without computation.
+
+**Cons:**
+- Requires a new table and a migration.
+- Adds schema surface area: 6+ columns on a new table, applied only to resistance exercises with bodyweight.
+- Overkill for exercises that don't use bodyweight; the metric attaches to an entry even when unused.
+- Most schema cost of all options.
+- Requires a clear decision about which exercises attach this metric (only `bodyweight_base=true`? or all resistance exercises?).
+
+---
+
+## Consequences
+
+### Positive
+- This ADR names the problem space explicitly, preventing ad-hoc solutions during Phase 9 work.
+- Options are laid out so the choice can be made with full context rather than discovered during implementation.
+
+### Negative
+- Phase 2 seeding (bodyweight_base heuristics) will not be perfect; it relies on the current thin model.
+- Phase 9 (progress tracking) work will be blocked until this decision is made; the choice directly affects how PRs and volume are calculated.
+
+### New Decisions Required
+- Which option to pursue: status quo, signed load, bodyweight capture, or dedicated metric.
+- If Option 3 or 4: granularity (per-workout vs. per-set) and source (automatic vs. manual).
+- If Option 3: whether to snapshot bodyweight on `workout_entries` or create a separate `log_bodyweight_snapshots` table.
+- If Option 4: which exercises attach the metric and how to validate it in the application layer.
+- Either way: how Phase 9 progress queries adapt to the chosen model.
+
+---
+
+## Influences
+
+- ADR-003 (exercise definitions, CTI) established `bodyweight_base` and `allows_added_weight` as boolean flags, insufficient for advanced cases.
+- ADR-006 (composable metrics) introduced the multi-table metric pattern; a new metric table is a natural fit if option 4 is chosen.
+- ADR-005 (weight unit, raw numbers no conversion) constrains the data type (decimal, not canonical unit), but the choice of how to store bodyweight-related values depends on this ADR's outcome.
+- Phase 2 seeding work (free-exercise-db integration) creates heuristic values for `bodyweight_base` based on equipment type. These will be preserved regardless of which option is chosen, but a robust model will enable future corrections.
+- User feedback and design intent: Justin flagged that bodyweight handling "feels almost like its own thing" and should be explored separately rather than decided inline during seed-data work.
+
+---
+
+## Related Decisions
+
+- **ADR-003** (exercise definitions): defines `bodyweight_base` and `allows_added_weight` flags; this decision may extend or replace them.
+- **ADR-005** (weight unit preference): constrains the data type of any weight-related columns; raw numbers in user's configured unit.
+- **ADR-006** (composable metrics): if option 4 is chosen, a new metric table fits the composable pattern.
+- **ADR-002** (deletion): no change expected, but deletion impact should be verified if schema is extended.
+- **Phase 9 (Progress Tracking)**: future ADRs for PR detection, volume calculation, and relative-strength analytics will depend on this decision.
+- **Phase 2 Seeding**: currently uses heuristics for `bodyweight_base` from free-exercise-db equipment type; the choice here does not change Phase 2 but informs any future corrections to seeded data.
+
+---
+
+## Participants
+
+- Justin Christenson (decision maker)
+
+## Review Date
+
+Before Phase 9 (Progress Tracking) implementation begins. This decision is load-bearing for PR and volume analytics and should be finalized before that work is scoped.

--- a/tests/Feature/ExerciseLibrarySeederTest.php
+++ b/tests/Feature/ExerciseLibrarySeederTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Tests\Feature;
+
+use Database\Seeders\EquipmentTypeSeeder;
+use Database\Seeders\ExerciseLibrarySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class ExerciseLibrarySeederTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const CHILD_TABLES = [
+        'resistance' => 'exercise_resistance',
+        'timed_hold' => 'exercise_timed_hold',
+        'distance' => 'exercise_distance',
+        'interval' => 'exercise_interval',
+    ];
+
+    public function test_seeds_full_catalog_across_all_cti_types(): void
+    {
+        $this->seedLibrary();
+
+        $fixture = $this->fixtureExercises();
+        $this->assertSame(count($fixture), DB::table('exercises')->count());
+
+        // Seeded exercises are system-owned (ADR-010).
+        $this->assertSame(0, DB::table('exercises')->whereNotNull('user_id')->count());
+
+        $expectedByType = $this->countByType($fixture);
+        $this->assertCount(4, $expectedByType, 'all four CTI types must be represented');
+
+        foreach ($expectedByType as $type => $count) {
+            $this->assertSame(
+                $count,
+                DB::table('exercises')->where('type', $type)->count(),
+                "base row count for {$type}",
+            );
+            // Class Table Inheritance: one child row per base exercise of that type.
+            $this->assertSame(
+                $count,
+                DB::table(self::CHILD_TABLES[$type])->count(),
+                "child row count for {$type}",
+            );
+        }
+    }
+
+    public function test_equipment_catalog_is_system_owned_and_resolved_by_name(): void
+    {
+        $this->seedLibrary();
+
+        $catalog = $this->fixtureEquipment();
+        $this->assertSame(count($catalog), DB::table('equipment_types')->count());
+        $this->assertSame(
+            count($catalog),
+            DB::table('equipment_types')->whereNull('user_id')->where('is_system', true)->count(),
+        );
+
+        // An exercise tagged with equipment resolves to that type's FK.
+        $withEquipment = collect($this->fixtureExercises())->firstWhere('equipment', '!==', null);
+        $this->assertNotNull($withEquipment);
+        $expectedId = DB::table('equipment_types')
+            ->whereNull('user_id')
+            ->where('name', $withEquipment['equipment'])
+            ->value('id');
+        $this->assertSame(
+            $expectedId,
+            DB::table('exercises')->where('name', $withEquipment['name'])->value('equipment_type_id'),
+        );
+
+        // A bodyweight exercise carries no equipment.
+        $bodyweight = collect($this->fixtureExercises())->first(fn ($e) => $e['equipment'] === null);
+        $this->assertNotNull($bodyweight);
+        $this->assertNull(
+            DB::table('exercises')->where('name', $bodyweight['name'])->value('equipment_type_id'),
+        );
+    }
+
+    public function test_reseeding_is_idempotent(): void
+    {
+        $this->seedLibrary();
+        $before = $this->tableCounts();
+
+        $this->seedLibrary();
+
+        $this->assertSame($before, $this->tableCounts());
+    }
+
+    private function seedLibrary(): void
+    {
+        $this->seed(EquipmentTypeSeeder::class);
+        $this->seed(ExerciseLibrarySeeder::class);
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function tableCounts(): array
+    {
+        return [
+            'equipment_types' => DB::table('equipment_types')->count(),
+            'exercises' => DB::table('exercises')->count(),
+            'exercise_resistance' => DB::table('exercise_resistance')->count(),
+            'exercise_timed_hold' => DB::table('exercise_timed_hold')->count(),
+            'exercise_distance' => DB::table('exercise_distance')->count(),
+            'exercise_interval' => DB::table('exercise_interval')->count(),
+        ];
+    }
+
+    /**
+     * @return list<array{name: string, type: string, equipment: string|null, attributes: array<string, mixed>}>
+     */
+    private function fixtureExercises(): array
+    {
+        $decoded = json_decode((string) file_get_contents(database_path('seeders/data/exercises.json')), true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function fixtureEquipment(): array
+    {
+        $decoded = json_decode((string) file_get_contents(database_path('seeders/data/equipment_types.json')), true);
+
+        return is_array($decoded) ? array_values(array_map('strval', $decoded)) : [];
+    }
+
+    /**
+     * @param  list<array{name: string, type: string, equipment: string|null, attributes: array<string, mixed>}>  $exercises
+     * @return array<string, int>
+     */
+    private function countByType(array $exercises): array
+    {
+        $counts = [];
+        foreach ($exercises as $exercise) {
+            $counts[$exercise['type']] = ($counts[$exercise['type']] ?? 0) + 1;
+        }
+
+        return $counts;
+    }
+}


### PR DESCRIPTION
## Problem

Physistrong had no schema or data for exercises or the equipment they use, so a user would have to create every exercise by hand before logging a workout. The original data model also assumed every exercise belongs to a single user, with no way to ship a shared catalog that all users can draw from.

## Solution

Add the exercise and equipment schema and seed it with a starter catalog imported from the open free-exercise-db dataset.

Schema (six migrations):
- `equipment_types` holds the equipment catalog.
- `exercises` is the base table, with a `type` discriminator and a nullable `equipment_type_id`.
- Four child tables hold the type-specific columns: `exercise_resistance`, `exercise_timed_hold`, `exercise_distance`, and `exercise_interval`. Each is one-to-one with `exercises` and cascades on delete.

Both `exercises` and `equipment_types` allow a null `user_id`, which marks a row as system-owned: shared across all users and read-only. Users still create their own exercises and equipment on top, which carry their `user_id`, so per-user data stays isolated.

Seed data:
- 873 exercises imported from free-exercise-db, each mapped to one of the four exercise types and resolved to one of 17 equipment types (or none, for bodyweight movements). Five interval exercises are added by hand because the source set has none, for 878 total.
- The mapped data is committed as JSON under `database/seeders/data/`. `EquipmentTypeSeeder` and `ExerciseLibrarySeeder` load it with `DB::table` upserts so they are safe to re-run, and are wired into `DatabaseSeeder` with equipment first, since exercises reference it.
- A feature test exercises both seeders against the database, covering population of all four types, the matching child rows, system ownership, equipment resolution by name, and re-run safety.

Two decision records are included: one for the system-owned model, and one open proposal weighing options for richer bodyweight handling. Two existing records were updated so their schema notes match the migrations.
