### PR TITLE
PS-71 - Consolidating weight and distance unit preferences into a single measurement system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,10 @@ Thumbs.db
 /.superpowers
 /docs/superpowers
 /docs/project
-/CLAUDE.md
+/.claude/
 /temp
+.codex/
+AGENTS.md
 
 # Linked git worktrees
 .worktrees/

--- a/app/Enums/MeasurementDimension.php
+++ b/app/Enums/MeasurementDimension.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum MeasurementDimension: string
+{
+    case Weight = 'weight';
+    case Distance = 'distance';
+    case Speed = 'speed';
+}

--- a/app/Enums/MeasurementSystem.php
+++ b/app/Enums/MeasurementSystem.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum MeasurementSystem: string
+{
+    case Imperial = 'imperial';
+    case Metric = 'metric';
+}

--- a/app/Services/MeasurementLabelService.php
+++ b/app/Services/MeasurementLabelService.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Enums\MeasurementDimension;
+use App\Enums\MeasurementSystem;
+use PhpUnitConversion\Unit\Length\KiloMeter;
+use PhpUnitConversion\Unit\Length\Mile;
+use PhpUnitConversion\Unit\Mass\KiloGram;
+use PhpUnitConversion\Unit\Mass\Pound;
+use PhpUnitConversion\Unit\Velocity\KiloMeterPerHour;
+use PhpUnitConversion\Unit\Velocity\MilesPerHour;
+
+class MeasurementLabelService
+{
+    public function symbol(MeasurementSystem $system, MeasurementDimension $dimension): string
+    {
+        $unitClass = match ([$system, $dimension]) {
+            [MeasurementSystem::Imperial, MeasurementDimension::Weight] => Pound::class,
+            [MeasurementSystem::Metric, MeasurementDimension::Weight] => KiloGram::class,
+            [MeasurementSystem::Imperial, MeasurementDimension::Distance] => Mile::class,
+            [MeasurementSystem::Metric, MeasurementDimension::Distance] => KiloMeter::class,
+            [MeasurementSystem::Imperial, MeasurementDimension::Speed] => MilesPerHour::class,
+            [MeasurementSystem::Metric, MeasurementDimension::Speed] => KiloMeterPerHour::class,
+        };
+
+        return (new $unitClass())->getSymbol();
+    }
+}

--- a/bin/commit
+++ b/bin/commit
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-exec docker compose run --rm --no-deps \
-  app git -c core.hooksPath=.githooks commit "$@"

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         "laravel/framework": "^13.8",
         "laravel/passport": "^13.0",
         "laravel/tinker": "^3.0",
+        "php-unit-conversion/php-unit-conversion": "^1.30",
         "predis/predis": "^3.5"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "740c8db4356e55bf8a3e5c56f03b40cc",
+    "content-hash": "96fb22816136a8a4044f8f7a78e0e116",
     "packages": [
         {
             "name": "brick/math",
@@ -2570,6 +2570,69 @@
             "time": "2026-01-02T08:56:05+00:00"
         },
         {
+            "name": "myclabs/php-enum",
+            "version": "1.8.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/php-enum.git",
+                "reference": "e7be26966b7398204a234f8673fdad5ac6277802"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/php-enum/zipball/e7be26966b7398204a234f8673fdad5ac6277802",
+                "reference": "e7be26966b7398204a234f8673fdad5ac6277802",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^7.3 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5",
+                "squizlabs/php_codesniffer": "1.*",
+                "vimeo/psalm": "^4.6.2 || ^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "MyCLabs\\Enum\\": "src/"
+                },
+                "classmap": [
+                    "stubs/Stringable.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP Enum contributors",
+                    "homepage": "https://github.com/myclabs/php-enum/graphs/contributors"
+                }
+            ],
+            "description": "PHP Enum implementation",
+            "homepage": "https://github.com/myclabs/php-enum",
+            "keywords": [
+                "enum"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/php-enum/issues",
+                "source": "https://github.com/myclabs/php-enum/tree/1.8.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/mnapoli",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/php-enum",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-01-14T11:49:03+00:00"
+        },
+        {
             "name": "nesbot/carbon",
             "version": "3.13.0",
             "source": {
@@ -3174,6 +3237,61 @@
                 "source": "https://github.com/php-http/discovery/tree/1.20.0"
             },
             "time": "2024-10-02T11:20:13+00:00"
+        },
+        {
+            "name": "php-unit-conversion/php-unit-conversion",
+            "version": "1.30",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pimlie/php-unit-conversion.git",
+                "reference": "fff05653b8d8aaaa0ab73e83c7cb0e41a415a64c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pimlie/php-unit-conversion/zipball/fff05653b8d8aaaa0ab73e83c7cb0e41a415a64c",
+                "reference": "fff05653b8d8aaaa0ab73e83c7cb0e41a415a64c",
+                "shasum": ""
+            },
+            "require": {
+                "myclabs/php-enum": "^1.5",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5.0|^6.0",
+                "squizlabs/php_codesniffer": "^3.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpUnitConversion\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "pimlie",
+                    "email": "pimlie@hotmail.com",
+                    "homepage": "https://github.com/pimlie/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A fully PSR-4 compatible PHP library for converting between standard units of measure.",
+            "homepage": "https://github.com/pimlie/php-unit-conversion",
+            "keywords": [
+                "conversion",
+                "measurement",
+                "unit"
+            ],
+            "support": {
+                "email": "pimlie@hotmail.com",
+                "issues": "https://github.com/pimlie/php-unit-conversion/issues",
+                "source": "https://github.com/pimlie/php-unit-conversion"
+            },
+            "time": "2020-04-05T08:12:55+00:00"
         },
         {
             "name": "phpoption/phpoption",

--- a/docs/decisions/adr-005-weight-unit-preference.md
+++ b/docs/decisions/adr-005-weight-unit-preference.md
@@ -1,7 +1,7 @@
 # ADR-005: Weight Unit Preference
 
 ## Status
-Accepted
+Superseded by [ADR-013](adr-013-measurement-system-preference.md)
 
 ## Date
 2026-06-27

--- a/docs/decisions/adr-008-api-format-and-versioning.md
+++ b/docs/decisions/adr-008-api-format-and-versioning.md
@@ -66,8 +66,8 @@ versioned prefix alongside resource routes. No separate auth namespace.
 ## Related Decisions
 
 - **ADR-001** (auth): Passport + JWT, auth endpoints under /v1/
-- **ADR-005** (weight unit): API responses include weight_unit field
-  alongside weight values
+- **ADR-013** (measurement system): API responses include measurement_system on
+  user resource
 - **ADR-006** (composable metrics): query patterns assume standard REST
   responses
 

--- a/docs/decisions/adr-012-distance-unit-preference.md
+++ b/docs/decisions/adr-012-distance-unit-preference.md
@@ -1,7 +1,7 @@
 # ADR-012: Distance Unit Preference
 
 ## Status
-Accepted
+Superseded by [ADR-013](adr-013-measurement-system-preference.md)
 
 ## Date
 2026-06-28

--- a/docs/decisions/adr-013-measurement-system-preference.md
+++ b/docs/decisions/adr-013-measurement-system-preference.md
@@ -1,0 +1,129 @@
+# ADR-013: Measurement System Preference
+
+## Status
+Accepted
+
+## Supersedes
+- [ADR-005](adr-005-weight-unit-preference.md) (weight unit preference)
+- [ADR-012](adr-012-distance-unit-preference.md) (distance unit preference)
+
+## Date
+2026-06-28
+
+## Deciders
+- Justin Christenson (Decision maker and application owner)
+
+---
+
+## Context
+
+The app originally planned separate per-dimension unit preferences
+(`weight_unit` for kg/lb, `distance_unit` for miles/km). This creates UX
+friction: two selectors at registration instead of one. It adds complexity
+for each new measurement dimension (e.g. adding elevation requires another
+user preference column). This diverges from standard fitness app practice
+where users select a single measurement system that applies globally.
+
+---
+
+## Decision
+
+Replace per-dimension unit preferences with a single `measurement_system`
+enum (`imperial` | `metric`) on the user record. This preference is
+required at registration and editable in profile settings.
+
+A `MeasurementLabelService` resolves `(measurement_system, dimension)`
+to a unit label using the `php-unit-conversion/php-unit-conversion`
+library. The service is the single point of truth for all unit label
+resolution.
+
+### Measurement dimension table
+
+Derived from a codebase audit of exercise types (ADR-003), composable
+metrics (ADR-006), and cardio settings:
+
+| Dimension | Imperial | Metric | Used by |
+|-----------|----------|--------|---------|
+| Weight | lb | kg | `log_load_metrics` (target/actual weight) |
+| Distance | mi | km | `log_distance_metrics` (target/actual distance) |
+| Speed | mph | km/h | `log_cardio_settings` (speed) |
+
+Dimensions with fixed units (no system preference needed): duration
+(seconds), reps (count), rounds (count), cadence (RPM), heart rate (BPM),
+incline (percentage), resistance level (unitless).
+
+### Storage
+
+Values are stored as raw numbers. No canonical unit, no server-side
+conversion. The number means whatever the user's configured measurement
+system says it means.
+
+### API responses
+
+API resources include the user's measurement_system as context. Individual
+metric values do not carry inline unit fields at the user-preference level.
+
+### Unit switching
+
+Not supported in the MVP. Changing the measurement system changes future
+labels but does not convert historical data. The `php-unit-conversion`
+library supports conversion via its `->to()` method for future
+implementation.
+
+### Per-exercise distance_unit
+
+The `exercise_distance.distance_unit` column (ADR-003) is a per-exercise
+definition attribute (meters/kilometers/miles/yards), not a user preference.
+It remains unchanged. Similarly, `log_distance_metrics.distance_unit` is a
+per-entry attribute that records what unit a specific value was logged in.
+
+---
+
+## Migration Structure
+
+```sql
+-- Add to users table:
+measurement_system (enum: 'imperial', 'metric', NOT NULL, DEFAULT 'imperial')
+```
+
+No `weight_unit` or `distance_unit` columns on the users table.
+
+---
+
+## Consequences
+
+### Positive
+- Single selector at registration instead of two
+- Adding a new measurement dimension (e.g. elevation) requires one case
+  in the service, not a new user preference column
+- Standard pattern used by every major fitness app
+- `php-unit-conversion` library handles symbol resolution and future
+  conversion
+- Consistent labels across all display surfaces
+
+### Negative
+- Users cannot mix systems (e.g. weight in kg but distance in miles).
+  This is an intentional trade for simplicity and matches fitness app
+  conventions.
+
+---
+
+## Related Decisions
+
+- **ADR-003** (exercise definitions) `exercise_distance.distance_unit`
+  unchanged
+- **ADR-006** (composable metrics) `log_distance_metrics.distance_unit`
+  unchanged
+- **ADR-008** (API format) API responses include measurement_system on
+  user resource
+
+---
+
+## Participants
+
+- Justin Christenson (decision maker)
+
+## Review Date
+
+Review if users report needing mixed measurement systems or unit
+conversion for historical data.

--- a/resources/js/api/fixtures.ts
+++ b/resources/js/api/fixtures.ts
@@ -5,8 +5,7 @@ export const fixtureUser: User = {
   firstName: 'Justin',
   lastName: 'Carter',
   email: 'justin@physistrong.app',
-  weightUnit: 'lb',
-  distanceUnit: 'miles',
+  measurementSystem: 'imperial',
   theme: 'light',
 }
 

--- a/resources/js/api/types.ts
+++ b/resources/js/api/types.ts
@@ -1,10 +1,11 @@
+import type { MeasurementSystem } from '@/lib/units'
+
 export interface User {
   id: string
   firstName: string
   lastName: string
   email: string
-  weightUnit: 'kg' | 'lb'
-  distanceUnit: 'miles' | 'kilometers'
+  measurementSystem: MeasurementSystem
   theme: 'light' | 'dark' | 'system'
 }
 

--- a/resources/js/components/app/metric-inputs.tsx
+++ b/resources/js/components/app/metric-inputs.tsx
@@ -2,6 +2,7 @@ import { Trophy, Plus, ChevronDown } from 'lucide-react'
 import type { WorkoutEntry, Exercise } from '@/api/types'
 import { useApp } from '@/lib/use-app'
 import { cn } from '@/lib/utils'
+import { unitLabel } from '@/lib/units'
 import { Badge } from '@/components/ui/badge'
 import { formatDuration } from '@/lib/formatters'
 
@@ -77,7 +78,7 @@ interface EntryMetricsProps {
 
 export function EntryMetrics({ entry, exercise, allTimeBest, onChange }: EntryMetricsProps) {
   const { user } = useApp()
-  const unit = user.weightUnit === 'kg' ? 'kg' : 'lb'
+  const unit = unitLabel(user.measurementSystem, 'weight')
 
   if (exercise.type === 'resistance') {
     const lm = entry.loadMetric || { targetWeight: null, actualWeight: null, bodyweightOnly: false }
@@ -185,13 +186,12 @@ export function EntryMetrics({ entry, exercise, allTimeBest, onChange }: EntryMe
     const dist = entry.distanceMetric || {
       targetDistance: null,
       actualDistance: null,
-      distanceUnit: user.distanceUnit,
+      distanceUnit: user.measurementSystem === 'imperial' ? 'miles' : 'kilometers',
       lapCount: null,
       strokeCount: null,
     }
     const dur = entry.durationMetric || { targetDurationSeconds: null, actualDurationSeconds: null }
-    const du =
-      dist.distanceUnit === 'kilometers' ? 'km' : dist.distanceUnit === 'miles' ? 'mi' : 'unit'
+    const du = unitLabel(user.measurementSystem, 'distance')
     const isPR =
       allTimeBest != null &&
       dist.actualDistance != null &&

--- a/resources/js/hooks/use-exercise-progress.ts
+++ b/resources/js/hooks/use-exercise-progress.ts
@@ -1,5 +1,6 @@
 import { useApp } from '@/lib/use-app'
 import { formatDuration } from '@/lib/formatters'
+import { unitLabel } from '@/lib/units'
 import type { ExerciseProgressData, TimeRange } from '@/api/types'
 
 interface UseExerciseProgressResult {
@@ -118,7 +119,7 @@ export function useExerciseProgress(
       records.push({
         label: 'Heaviest',
         value: `${maxW}`,
-        unit: user.weightUnit,
+        unit: unitLabel(user.measurementSystem, 'weight'),
         sub: maxWReps ? `× ${maxWReps} reps` : null,
       })
     if (maxReps > -Infinity)
@@ -127,7 +128,7 @@ export function useExerciseProgress(
       records.push({
         label: 'Top set volume',
         value: `${maxVol.toLocaleString()}`,
-        unit: user.weightUnit,
+        unit: unitLabel(user.measurementSystem, 'weight'),
         sub: null,
       })
   } else if (ex.type === 'timed_hold') {
@@ -139,7 +140,7 @@ export function useExerciseProgress(
       records.push({
         label: 'Farthest',
         value: `${m}`,
-        unit: user.distanceUnit === 'miles' ? 'mi' : 'km',
+        unit: unitLabel(user.measurementSystem, 'distance'),
         sub: null,
       })
   } else if (ex.type === 'interval') {

--- a/resources/js/lib/store.tsx
+++ b/resources/js/lib/store.tsx
@@ -164,7 +164,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
             distanceMetric: {
               targetDistance: null,
               actualDistance: null,
-              distanceUnit: user.distanceUnit,
+              distanceUnit: user.measurementSystem === 'imperial' ? 'miles' : 'kilometers',
               lapCount: null,
               strokeCount: null,
             },
@@ -222,7 +222,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
       setWorkouts(ws => [w, ...ws])
       return w
     },
-    [templates, exercises, user.distanceUnit]
+    [templates, exercises, user.measurementSystem]
   )
 
   const updateTemplate = useCallback((id: string, patch: Partial<WorkoutTemplate>) => {

--- a/resources/js/lib/units.ts
+++ b/resources/js/lib/units.ts
@@ -1,0 +1,11 @@
+export type MeasurementSystem = 'imperial' | 'metric'
+export type MeasurementDimension = 'weight' | 'distance' | 'speed'
+
+const UNIT_LABELS: Record<MeasurementSystem, Record<MeasurementDimension, string>> = {
+  imperial: { weight: 'lb', distance: 'mi', speed: 'mph' },
+  metric: { weight: 'kg', distance: 'km', speed: 'km/h' },
+}
+
+export function unitLabel(system: MeasurementSystem, dimension: MeasurementDimension): string {
+  return UNIT_LABELS[system][dimension]
+}

--- a/resources/js/pages/auth.tsx
+++ b/resources/js/pages/auth.tsx
@@ -132,8 +132,7 @@ export function RegisterPage() {
     password: '',
     passwordConfirm: '',
   })
-  const [weightUnit, setWeightUnit] = useState<'kg' | 'lb' | null>(null)
-  const [distanceUnit, setDistanceUnit] = useState<'miles' | 'kilometers'>('miles')
+  const [measurementSystem, setMeasurementSystem] = useState<'imperial' | 'metric' | null>(null)
 
   const updateField = (key: keyof RegisterFormState) => (value: string) => {
     setForm(prev => ({ ...prev, [key]: value }))
@@ -144,7 +143,7 @@ export function RegisterPage() {
     form.email &&
     form.password &&
     form.password === form.passwordConfirm &&
-    weightUnit
+    measurementSystem
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
@@ -153,8 +152,7 @@ export function RegisterPage() {
       firstName: form.first,
       lastName: form.last,
       email: form.email,
-      weightUnit,
-      distanceUnit,
+      measurementSystem,
     })
     login()
     navigate('/workouts')
@@ -216,31 +214,19 @@ export function RegisterPage() {
 
         <div className="ps-metric p-3">
           <span className="label-caps text-text-secondary block mb-2">
-            Weight unit <span className="text-destructive">*</span>
+            Measurement system <span className="text-destructive">*</span>
           </span>
           <SegmentedControl
-            value={weightUnit || ''}
-            onChange={v => setWeightUnit(v as 'kg' | 'lb')}
+            value={measurementSystem || ''}
+            onChange={v => setMeasurementSystem(v as 'imperial' | 'metric')}
             options={[
-              { value: 'kg', label: 'Kilograms (kg)' },
-              { value: 'lb', label: 'Pounds (lb)' },
+              { value: 'imperial', label: 'Imperial (lb, mi)' },
+              { value: 'metric', label: 'Metric (kg, km)' },
             ]}
           />
           <p className="text-[12px] text-text-muted mt-2">
-            Used everywhere you log a lift. You can change it later.
+            Controls unit labels across the app. You can change it later.
           </p>
-        </div>
-
-        <div>
-          <span className="label-caps text-text-secondary block mb-2">Distance unit</span>
-          <SegmentedControl
-            value={distanceUnit}
-            onChange={v => setDistanceUnit(v as 'miles' | 'kilometers')}
-            options={[
-              { value: 'miles', label: 'Miles' },
-              { value: 'kilometers', label: 'Kilometers' },
-            ]}
-          />
         </div>
 
         <Button type="submit" full size="lg" disabled={!isValid}>

--- a/resources/js/pages/exercise-detail.tsx
+++ b/resources/js/pages/exercise-detail.tsx
@@ -55,7 +55,7 @@ export function ExerciseDetailPage() {
     attrs.push(['Allows added weight', ex.allowsAddedWeight ? 'Yes' : 'No'])
     attrs.push(['Bilateral', ex.bilateral ? 'Yes' : 'No (single-arm/leg)'])
   } else if (ex.type === 'distance') {
-    attrs.push(['Distance unit', user.distanceUnit === 'kilometers' ? 'Kilometers' : 'Miles'])
+    attrs.push(['Distance unit', user.measurementSystem === 'metric' ? 'Kilometers' : 'Miles'])
     attrs.push(['Tracks elevation', ex.tracksElevation ? 'Yes' : 'No'])
   } else if (ex.type === 'interval') {
     attrs.push(['Default work', formatDuration(ex.defaultWorkSeconds)])

--- a/resources/js/pages/profile.tsx
+++ b/resources/js/pages/profile.tsx
@@ -93,30 +93,16 @@ export function ProfilePage() {
       <h2 className="label-caps text-text-secondary mb-2">Preferences</h2>
       <Card className="p-4 mb-6 flex flex-col gap-4">
         <div>
-          <div className="text-sm font-medium mb-2">Weight unit</div>
+          <div className="text-sm font-medium mb-2">Measurement system</div>
           <SegmentedControl
-            value={user.weightUnit}
+            value={user.measurementSystem}
             onChange={v => {
-              updateUser({ weightUnit: v as 'kg' | 'lb' })
-              toast('Unit updated.')
+              updateUser({ measurementSystem: v as 'imperial' | 'metric' })
+              toast('Measurement system updated.')
             }}
             options={[
-              { value: 'kg', label: 'Kilograms (kg)' },
-              { value: 'lb', label: 'Pounds (lb)' },
-            ]}
-          />
-        </div>
-        <div>
-          <div className="text-sm font-medium mb-2">Distance unit</div>
-          <SegmentedControl
-            value={user.distanceUnit || 'miles'}
-            onChange={v => {
-              updateUser({ distanceUnit: v as 'miles' | 'kilometers' })
-              toast('Unit updated.')
-            }}
-            options={[
-              { value: 'miles', label: 'Miles' },
-              { value: 'kilometers', label: 'Kilometers' },
+              { value: 'imperial', label: 'Imperial (lb, mi)' },
+              { value: 'metric', label: 'Metric (kg, km)' },
             ]}
           />
         </div>

--- a/resources/js/pages/workout-detail.tsx
+++ b/resources/js/pages/workout-detail.tsx
@@ -308,8 +308,9 @@ export function WorkoutDetailPage() {
     if (!ex) return
     const ref = block.entries[0]
     if (!ref) return
+    const distanceUnit = user.measurementSystem === 'imperial' ? 'miles' : 'kilometers'
     const ne: WorkoutEntry = {
-      ...freshEntry(ex, workoutId, uid, user.distanceUnit),
+      ...freshEntry(ex, workoutId, uid, distanceUnit),
       loadMetric: ref.loadMetric ? { ...ref.loadMetric, actualWeight: null } : undefined,
       repMetric: ref.repMetric
         ? { ...ref.repMetric, actualReps: null, toFailure: false, failureRep: null }
@@ -328,7 +329,8 @@ export function WorkoutDetailPage() {
   }
 
   const addExercise = (ex: Exercise) => {
-    const ne = freshEntry(ex, workoutId, uid, user.distanceUnit)
+    const distanceUnit = user.measurementSystem === 'imperial' ? 'miles' : 'kilometers'
+    const ne = freshEntry(ex, workoutId, uid, distanceUnit)
     persist([
       { kind: 'exercise', id: `b-new-${ne.id}`, exerciseId: ex.id, entries: [ne] },
       ...blocks,
@@ -365,11 +367,12 @@ export function WorkoutDetailPage() {
     const chosen = blocks.filter(b => selected.includes(b.id) && b.kind === 'exercise')
     const groupEntries: WorkoutEntry[] = []
 
+    const distanceUnit = user.measurementSystem === 'imperial' ? 'miles' : 'kilometers'
     for (let r = 1; r <= cfg.plannedRounds; r++) {
       chosen.forEach(b => {
         const ex = exerciseById(exercises, b.exerciseId ?? '')
         if (ex) {
-          const e = freshEntry(ex, workoutId, uid, user.distanceUnit)
+          const e = freshEntry(ex, workoutId, uid, distanceUnit)
           groupEntries.push({
             ...e,
             entryGroupId: gid,

--- a/tests/Unit/Services/MeasurementLabelServiceTest.php
+++ b/tests/Unit/Services/MeasurementLabelServiceTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services;
+
+use App\Enums\MeasurementDimension;
+use App\Enums\MeasurementSystem;
+use App\Services\MeasurementLabelService;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class MeasurementLabelServiceTest extends TestCase
+{
+    private MeasurementLabelService $service;
+
+    protected function setUp(): void
+    {
+        $this->service = new MeasurementLabelService();
+    }
+
+    #[DataProvider('symbolProvider')]
+    public function test_returns_correct_symbol(
+        MeasurementSystem $system,
+        MeasurementDimension $dimension,
+        string $expected,
+    ): void {
+        $symbol = $this->service->symbol($system, $dimension);
+        $this->assertSame($expected, $symbol);
+    }
+
+    /**
+     * @return array<string, array{MeasurementSystem, MeasurementDimension, string}>
+     */
+    public static function symbolProvider(): array
+    {
+        return [
+            'imperial weight' => [MeasurementSystem::Imperial, MeasurementDimension::Weight, 'lb'],
+            'metric weight' => [MeasurementSystem::Metric, MeasurementDimension::Weight, 'kg'],
+            'imperial distance' => [MeasurementSystem::Imperial, MeasurementDimension::Distance, 'mi'],
+            'metric distance' => [MeasurementSystem::Metric, MeasurementDimension::Distance, 'km'],
+            'imperial speed' => [MeasurementSystem::Imperial, MeasurementDimension::Speed, 'mph'],
+            'metric speed' => [MeasurementSystem::Metric, MeasurementDimension::Speed, 'km/h'],
+        ];
+    }
+}


### PR DESCRIPTION
## Problem

The app had two separate user preference fields for units: `weight_unit` (kg/lb) and `distance_unit` (miles/km). This meant two selectors at registration, and every new measurement dimension would require another column on the users table and another UI control.

## Solution

Replaced both fields with a single `measurement_system` preference (imperial or metric).

- Installed `php-unit-conversion/php-unit-conversion` and built a `MeasurementLabelService` (`app/Services/MeasurementLabelService.php`) that resolves a measurement system and dimension to the correct unit symbol (lb/kg, mi/km, mph/km/h) using the library
- Added `MeasurementSystem` and `MeasurementDimension` enums in `app/Enums/`
- Created a frontend `unitLabel()` helper in `resources/js/lib/units.ts` that mirrors the backend mapping
- Updated the `User` TypeScript interface to carry `measurementSystem` instead of `weightUnit` and `distanceUnit`
- Collapsed the two unit selectors on the registration page (`auth.tsx`) and profile page (`profile.tsx`) into a single Imperial/Metric toggle
- Updated all metric display components (`metric-inputs.tsx`, `use-exercise-progress.ts`, `store.tsx`, `workout-detail.tsx`, `exercise-detail.tsx`) to derive unit labels from the measurement system
- Written ADR-013 documenting the consolidated approach; marked ADR-005 and ADR-012 as superseded
