### PR TITLE
PS-57 - Adding auth, user profile, and equipment type API with Passport personal access tokens

### DIFF
--- a/app/Enums/ThemePreference.php
+++ b/app/Enums/ThemePreference.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum ThemePreference: string
+{
+    case Light = 'light';
+    case Dark = 'dark';
+    case System = 'system';
+}

--- a/app/Http/Controllers/Api/V1/Auth/ForgotPasswordController.php
+++ b/app/Http/Controllers/Api/V1/Auth/ForgotPasswordController.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Password;
+use Illuminate\Support\Facades\RateLimiter;
+
+class ForgotPasswordController extends Controller
+{
+    public function __invoke(Request $request): JsonResponse
+    {
+        $request->validate(['email' => ['required', 'email']]);
+
+        $key = 'password-forgot:'.$request->ip();
+
+        if (RateLimiter::tooManyAttempts($key, 3)) {
+            return response()->json([
+                'message' => 'Too many requests. Try again later.',
+            ], 429);
+        }
+
+        RateLimiter::hit($key, 3600);
+
+        Password::sendResetLink($request->only('email'));
+
+        return response()->json([
+            'message' => 'If that email is registered, a reset link has been sent.',
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/V1/Auth/LoginController.php
+++ b/app/Http/Controllers/Api/V1/Auth/LoginController.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\LoginRequest;
+use App\Http\Resources\Api\V1\UserResource;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\RateLimiter;
+
+class LoginController extends Controller
+{
+    public function __invoke(LoginRequest $request): JsonResponse
+    {
+        $key = 'login:'.$request->ip();
+
+        if (RateLimiter::tooManyAttempts($key, 5)) {
+            return response()->json([
+                'message' => 'Too many login attempts. Try again later.',
+            ], 429);
+        }
+
+        $user = User::where('email', $request->email)->first();
+
+        if (! $user || ! Hash::check($request->password, $user->password)) {
+            RateLimiter::hit($key, 60);
+
+            return response()->json(['message' => 'Invalid credentials.'], 401);
+        }
+
+        RateLimiter::clear($key);
+
+        $token = $user->createToken('auth');
+
+        return response()->json([
+            'user' => new UserResource($user),
+            'token' => $token->accessToken,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/V1/Auth/LogoutController.php
+++ b/app/Http/Controllers/Api/V1/Auth/LogoutController.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Laravel\Passport\Token;
+
+class LogoutController extends Controller
+{
+    public function __invoke(Request $request): Response
+    {
+        $token = $request->user()->currentAccessToken();
+
+        if ($token instanceof Token) {
+            $token->revoke();
+        }
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/Api/V1/Auth/RegisterController.php
+++ b/app/Http/Controllers/Api/V1/Auth/RegisterController.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\RegisterRequest;
+use App\Http\Resources\Api\V1\UserResource;
+use App\Models\User;
+use Illuminate\Auth\Events\Registered;
+use Illuminate\Http\JsonResponse;
+
+class RegisterController extends Controller
+{
+    public function __invoke(RegisterRequest $request): JsonResponse
+    {
+        $user = User::create($request->validated());
+
+        event(new Registered($user));
+
+        $token = $user->createToken('auth');
+
+        return response()->json([
+            'user' => new UserResource($user),
+            'token' => $token->accessToken,
+        ], 201);
+    }
+}

--- a/app/Http/Controllers/Api/V1/Auth/ResetPasswordController.php
+++ b/app/Http/Controllers/Api/V1/Auth/ResetPasswordController.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\ResetPasswordRequest;
+use Illuminate\Auth\Events\PasswordReset;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Password;
+use Illuminate\Validation\ValidationException;
+
+class ResetPasswordController extends Controller
+{
+    public function __invoke(ResetPasswordRequest $request): JsonResponse
+    {
+        $status = Password::reset(
+            $request->only('email', 'password', 'password_confirmation', 'token'),
+            function ($user, string $password): void {
+                $user->forceFill(['password' => Hash::make($password)])->save();
+                event(new PasswordReset($user));
+            },
+        );
+
+        if ($status !== Password::PASSWORD_RESET) {
+            throw ValidationException::withMessages([
+                'email' => [__($status)],
+            ]);
+        }
+
+        return response()->json(['message' => 'Password has been reset.']);
+    }
+}

--- a/app/Http/Controllers/Api/V1/EquipmentTypeController.php
+++ b/app/Http/Controllers/Api/V1/EquipmentTypeController.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\StoreEquipmentTypeRequest;
+use App\Http\Requests\Api\V1\UpdateEquipmentTypeRequest;
+use App\Http\Resources\Api\V1\EquipmentTypeResource;
+use App\Models\EquipmentType;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\DB;
+
+class EquipmentTypeController extends Controller
+{
+    use AuthorizesRequests;
+
+    public function index(Request $request): AnonymousResourceCollection
+    {
+        $types = EquipmentType::where('is_system', true)
+            ->orWhere('user_id', $request->user()->id)
+            ->orderBy('name')
+            ->get();
+
+        return EquipmentTypeResource::collection($types);
+    }
+
+    public function store(StoreEquipmentTypeRequest $request): JsonResponse
+    {
+        $type = EquipmentType::create([
+            'name' => $request->validated('name'),
+            'user_id' => $request->user()->id,
+            'is_system' => false,
+        ]);
+
+        return (new EquipmentTypeResource($type))
+            ->response()
+            ->setStatusCode(201);
+    }
+
+    public function show(EquipmentType $equipmentType): EquipmentTypeResource
+    {
+        $this->authorize('view', $equipmentType);
+
+        return new EquipmentTypeResource($equipmentType);
+    }
+
+    public function update(UpdateEquipmentTypeRequest $request, EquipmentType $equipmentType): EquipmentTypeResource
+    {
+        $this->authorize('update', $equipmentType);
+
+        $equipmentType->update($request->validated());
+
+        return new EquipmentTypeResource($equipmentType);
+    }
+
+    public function destroy(EquipmentType $equipmentType): Response|JsonResponse
+    {
+        $this->authorize('delete', $equipmentType);
+
+        $inUse = DB::table('exercises')
+            ->where('equipment_type_id', $equipmentType->id)
+            ->exists();
+
+        if ($inUse) {
+            return response()->json([
+                'message' => 'Equipment type is in use by exercises.',
+            ], 409);
+        }
+
+        $equipmentType->delete();
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/Api/V1/UserController.php
+++ b/app/Http/Controllers/Api/V1/UserController.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\UpdateUserRequest;
+use App\Http\Resources\Api\V1\UserResource;
+use Illuminate\Http\Request;
+
+class UserController extends Controller
+{
+    public function show(Request $request): UserResource
+    {
+        return new UserResource($request->user());
+    }
+
+    public function update(UpdateUserRequest $request): UserResource
+    {
+        $user = $request->user();
+        $user->update($request->validated());
+
+        return new UserResource($user->fresh());
+    }
+}

--- a/app/Http/Requests/Api/V1/LoginRequest.php
+++ b/app/Http/Requests/Api/V1/LoginRequest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class LoginRequest extends FormRequest
+{
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'email'],
+            'password' => ['required', 'string'],
+        ];
+    }
+}

--- a/app/Http/Requests/Api/V1/RegisterRequest.php
+++ b/app/Http/Requests/Api/V1/RegisterRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use App\Enums\MeasurementSystem;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Enum;
+
+class RegisterRequest extends FormRequest
+{
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'email', 'unique:users,email'],
+            'password' => ['required', 'string', 'min:6', 'confirmed'],
+            'measurement_system' => ['required', new Enum(MeasurementSystem::class)],
+            'first_name' => ['nullable', 'string', 'max:255'],
+            'last_name' => ['nullable', 'string', 'max:255'],
+        ];
+    }
+}

--- a/app/Http/Requests/Api/V1/ResetPasswordRequest.php
+++ b/app/Http/Requests/Api/V1/ResetPasswordRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ResetPasswordRequest extends FormRequest
+{
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'email'],
+            'token' => ['required', 'string'],
+            'password' => ['required', 'string', 'min:6', 'confirmed'],
+        ];
+    }
+}

--- a/app/Http/Requests/Api/V1/StoreEquipmentTypeRequest.php
+++ b/app/Http/Requests/Api/V1/StoreEquipmentTypeRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreEquipmentTypeRequest extends FormRequest
+{
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        return [
+            'name' => [
+                'required',
+                'string',
+                'max:255',
+                Rule::unique('equipment_types')->where('user_id', $this->user()->id),
+            ],
+        ];
+    }
+}

--- a/app/Http/Requests/Api/V1/UpdateEquipmentTypeRequest.php
+++ b/app/Http/Requests/Api/V1/UpdateEquipmentTypeRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateEquipmentTypeRequest extends FormRequest
+{
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        return [
+            'name' => [
+                'required',
+                'string',
+                'max:255',
+                Rule::unique('equipment_types')
+                    ->where('user_id', $this->user()->id)
+                    ->ignore($this->route('equipment_type')),
+            ],
+        ];
+    }
+}

--- a/app/Http/Requests/Api/V1/UpdateUserRequest.php
+++ b/app/Http/Requests/Api/V1/UpdateUserRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use App\Enums\MeasurementSystem;
+use App\Enums\ThemePreference;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Enum;
+
+class UpdateUserRequest extends FormRequest
+{
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        return [
+            'first_name' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'last_name' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'email' => ['sometimes', 'email', 'unique:users,email,'.$this->user()->id],
+            'measurement_system' => ['sometimes', new Enum(MeasurementSystem::class)],
+            'theme' => ['sometimes', new Enum(ThemePreference::class)],
+            'current_password' => ['required_with:password', 'current_password:api'],
+            'password' => ['sometimes', 'string', 'min:6', 'confirmed'],
+        ];
+    }
+}

--- a/app/Http/Resources/Api/V1/EquipmentTypeResource.php
+++ b/app/Http/Resources/Api/V1/EquipmentTypeResource.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use App\Models\EquipmentType;
+
+/** @mixin EquipmentType */
+class EquipmentTypeResource extends JsonResource
+{
+    /** @return array<string, mixed> */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'is_system' => $this->is_system,
+            'user_id' => $this->user_id,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/app/Http/Resources/Api/V1/UserResource.php
+++ b/app/Http/Resources/Api/V1/UserResource.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use App\Models\User;
+
+/** @mixin User */
+class UserResource extends JsonResource
+{
+    /** @return array<string, mixed> */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'email' => $this->email,
+            'first_name' => $this->first_name,
+            'last_name' => $this->last_name,
+            'measurement_system' => $this->measurement_system,
+            'theme' => $this->theme,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/app/Models/EquipmentType.php
+++ b/app/Models/EquipmentType.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class EquipmentType extends Model
+{
+    /** @var list<string> */
+    protected $fillable = ['name', 'user_id', 'is_system'];
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'is_system' => 'boolean',
+        ];
+    }
+
+    /** @return BelongsTo<User, $this> */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,18 +2,23 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Enums\MeasurementSystem;
+use App\Enums\ThemePreference;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Laravel\Passport\Contracts\OAuthenticatable;
+use Laravel\Passport\HasApiTokens;
 
-#[Fillable(['name', 'email', 'password'])]
+#[Fillable(['first_name', 'last_name', 'email', 'password', 'measurement_system', 'theme'])]
 #[Hidden(['password', 'remember_token'])]
-class User extends Authenticatable
+class User extends Authenticatable implements OAuthenticatable
 {
+    use HasApiTokens;
+
     /** @use HasFactory<UserFactory> */
     use HasFactory;
 
@@ -25,6 +30,8 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'measurement_system' => MeasurementSystem::class,
+            'theme' => ThemePreference::class,
         ];
     }
 }

--- a/app/Notifications/WelcomeNotification.php
+++ b/app/Notifications/WelcomeNotification.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class WelcomeNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $name = $notifiable->first_name ?? 'there';
+
+        return (new MailMessage())
+            ->subject('Welcome to Physistrong')
+            ->greeting("Hey {$name},")
+            ->line('Your Physistrong account is ready. Start tracking your workouts today.')
+            ->action('Open Physistrong', config('app.url'));
+    }
+}

--- a/app/Policies/EquipmentTypePolicy.php
+++ b/app/Policies/EquipmentTypePolicy.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\EquipmentType;
+use App\Models\User;
+use Illuminate\Auth\Access\Response;
+
+class EquipmentTypePolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    public function view(User $user, EquipmentType $equipmentType): bool
+    {
+        return $equipmentType->is_system || $equipmentType->user_id === $user->id;
+    }
+
+    public function create(User $user): bool
+    {
+        return true;
+    }
+
+    public function update(User $user, EquipmentType $equipmentType): Response
+    {
+        if ($equipmentType->is_system) {
+            return Response::deny('System equipment types cannot be modified.');
+        }
+
+        return $equipmentType->user_id === $user->id
+            ? Response::allow()
+            : Response::deny();
+    }
+
+    public function delete(User $user, EquipmentType $equipmentType): Response
+    {
+        if ($equipmentType->is_system) {
+            return Response::deny('System equipment types cannot be deleted.');
+        }
+
+        return $equipmentType->user_id === $user->id
+            ? Response::allow()
+            : Response::deny();
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,23 +2,27 @@
 
 namespace App\Providers;
 
+use App\Notifications\WelcomeNotification;
+use DateInterval;
+use Illuminate\Auth\Events\Registered;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Passport\Passport;
 
 class AppServiceProvider extends ServiceProvider
 {
-    /**
-     * Register any application services.
-     */
     public function register(): void
     {
         //
     }
 
-    /**
-     * Bootstrap any application services.
-     */
     public function boot(): void
     {
-        //
+        Passport::tokensExpireIn(new DateInterval('P30D'));
+        Passport::personalAccessTokensExpireIn(new DateInterval('P30D'));
+
+        Event::listen(Registered::class, function (Registered $event): void {
+            $event->user->notify(new WelcomeNotification());
+        });
     }
 }

--- a/config/auth.php
+++ b/config/auth.php
@@ -42,6 +42,11 @@ return [
             'driver' => 'session',
             'provider' => 'users',
         ],
+
+        'api' => [
+            'driver' => 'passport',
+            'provider' => 'users',
+        ],
     ],
 
     /*

--- a/config/passport.php
+++ b/config/passport.php
@@ -1,0 +1,48 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Passport Guard
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify which authentication guard Passport will use when
+    | authenticating users. This value should correspond with one of your
+    | guards that is already present in your "auth" configuration file.
+    |
+    */
+
+    'guard' => 'web',
+
+    'middleware' => [],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Encryption Keys
+    |--------------------------------------------------------------------------
+    |
+    | Passport uses encryption keys while generating secure access tokens for
+    | your application. By default, the keys are stored as local files but
+    | can be set via environment variables when that is more convenient.
+    |
+    */
+
+    'private_key' => env('PASSPORT_PRIVATE_KEY'),
+
+    'public_key' => env('PASSPORT_PUBLIC_KEY'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Passport Database Connection
+    |--------------------------------------------------------------------------
+    |
+    | By default, Passport's models will utilize your application's default
+    | database connection. If you wish to use a different connection you
+    | may specify the configured name of the database connection here.
+    |
+    */
+
+    'connection' => env('PASSPORT_CONNECTION'),
+
+];

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,44 +2,44 @@
 
 namespace Database\Factories;
 
+use App\Enums\MeasurementSystem;
+use App\Enums\ThemePreference;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 
-/**
- * @extends Factory<User>
- */
+/** @extends Factory<User> */
 class UserFactory extends Factory
 {
-    /**
-     * The current password being used by the factory.
-     */
     protected static ?string $password;
 
-    /**
-     * Define the model's default state.
-     *
-     * @return array<string, mixed>
-     */
+    /** @return array<string, mixed> */
     public function definition(): array
     {
         return [
-            'name' => fake()->name(),
+            'first_name' => fake()->firstName(),
+            'last_name' => fake()->lastName(),
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
+            'measurement_system' => MeasurementSystem::Imperial,
+            'theme' => ThemePreference::System,
             'remember_token' => Str::random(10),
         ];
     }
 
-    /**
-     * Indicate that the model's email address should be unverified.
-     */
     public function unverified(): static
     {
         return $this->state(fn (array $attributes) => [
             'email_verified_at' => null,
+        ]);
+    }
+
+    public function metric(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'measurement_system' => MeasurementSystem::Metric,
         ]);
     }
 }

--- a/database/migrations/2026_06_28_000001_modify_users_table_for_auth.php
+++ b/database/migrations/2026_06_28_000001_modify_users_table_for_auth.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('name');
+            $table->string('first_name')->nullable()->after('id');
+            $table->string('last_name')->nullable()->after('first_name');
+            $table->string('measurement_system')->after('password');
+            $table->string('theme')->default('system')->after('measurement_system');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['first_name', 'last_name', 'measurement_system', 'theme']);
+            $table->string('name')->after('id');
+        });
+    }
+};

--- a/database/migrations/2026_06_28_184700_create_oauth_auth_codes_table.php
+++ b/database/migrations/2026_06_28_184700_create_oauth_auth_codes_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('oauth_auth_codes', function (Blueprint $table) {
+            $table->char('id', 80)->primary();
+            $table->foreignId('user_id')->index();
+            $table->foreignUuid('client_id');
+            $table->text('scopes')->nullable();
+            $table->boolean('revoked');
+            $table->dateTime('expires_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('oauth_auth_codes');
+    }
+
+    /**
+     * Get the migration connection name.
+     */
+    public function getConnection(): ?string
+    {
+        return $this->connection ?? config('passport.connection');
+    }
+};

--- a/database/migrations/2026_06_28_184701_create_oauth_access_tokens_table.php
+++ b/database/migrations/2026_06_28_184701_create_oauth_access_tokens_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('oauth_access_tokens', function (Blueprint $table) {
+            $table->char('id', 80)->primary();
+            $table->foreignId('user_id')->nullable()->index();
+            $table->foreignUuid('client_id');
+            $table->string('name')->nullable();
+            $table->text('scopes')->nullable();
+            $table->boolean('revoked');
+            $table->timestamps();
+            $table->dateTime('expires_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('oauth_access_tokens');
+    }
+
+    /**
+     * Get the migration connection name.
+     */
+    public function getConnection(): ?string
+    {
+        return $this->connection ?? config('passport.connection');
+    }
+};

--- a/database/migrations/2026_06_28_184702_create_oauth_refresh_tokens_table.php
+++ b/database/migrations/2026_06_28_184702_create_oauth_refresh_tokens_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('oauth_refresh_tokens', function (Blueprint $table) {
+            $table->char('id', 80)->primary();
+            $table->char('access_token_id', 80)->index();
+            $table->boolean('revoked');
+            $table->dateTime('expires_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('oauth_refresh_tokens');
+    }
+
+    /**
+     * Get the migration connection name.
+     */
+    public function getConnection(): ?string
+    {
+        return $this->connection ?? config('passport.connection');
+    }
+};

--- a/database/migrations/2026_06_28_184703_create_oauth_clients_table.php
+++ b/database/migrations/2026_06_28_184703_create_oauth_clients_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('oauth_clients', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->nullableMorphs('owner');
+            $table->string('name');
+            $table->string('secret')->nullable();
+            $table->string('provider')->nullable();
+            $table->text('redirect_uris');
+            $table->text('grant_types');
+            $table->boolean('revoked');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('oauth_clients');
+    }
+
+    /**
+     * Get the migration connection name.
+     */
+    public function getConnection(): ?string
+    {
+        return $this->connection ?? config('passport.connection');
+    }
+};

--- a/database/migrations/2026_06_28_184704_create_oauth_device_codes_table.php
+++ b/database/migrations/2026_06_28_184704_create_oauth_device_codes_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('oauth_device_codes', function (Blueprint $table) {
+            $table->char('id', 80)->primary();
+            $table->foreignId('user_id')->nullable()->index();
+            $table->foreignUuid('client_id')->index();
+            $table->char('user_code', 8)->unique();
+            $table->text('scopes');
+            $table->boolean('revoked');
+            $table->dateTime('user_approved_at')->nullable();
+            $table->dateTime('last_polled_at')->nullable();
+            $table->dateTime('expires_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('oauth_device_codes');
+    }
+
+    /**
+     * Get the migration connection name.
+     */
+    public function getConnection(): ?string
+    {
+        return $this->connection ?? config('passport.connection');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -10,19 +10,14 @@ class DatabaseSeeder extends Seeder
 {
     use WithoutModelEvents;
 
-    /**
-     * Seed the application's database.
-     */
     public function run(): void
     {
-        // User::factory(10)->create();
-
         User::factory()->create([
-            'name' => 'Test User',
+            'first_name' => 'Test',
+            'last_name' => 'User',
             'email' => 'test@example.com',
         ]);
 
-        // Equipment must seed before exercises: exercises resolve equipment by FK.
         $this->call([
             EquipmentTypeSeeder::class,
             ExerciseLibrarySeeder::class,

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,24 @@
 <?php
 
+use App\Http\Controllers\Api\V1\Auth\ForgotPasswordController;
+use App\Http\Controllers\Api\V1\Auth\LoginController;
+use App\Http\Controllers\Api\V1\Auth\LogoutController;
+use App\Http\Controllers\Api\V1\Auth\RegisterController;
+use App\Http\Controllers\Api\V1\Auth\ResetPasswordController;
+use App\Http\Controllers\Api\V1\EquipmentTypeController;
+use App\Http\Controllers\Api\V1\UserController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/health', fn () => response()->json(['status' => 'ok']));
+
+Route::post('/register', RegisterController::class);
+Route::post('/login', LoginController::class);
+Route::post('/password/forgot', ForgotPasswordController::class);
+Route::post('/password/reset', ResetPasswordController::class);
+
+Route::middleware('auth:api')->group(function () {
+    Route::post('/logout', LogoutController::class);
+    Route::get('/user', [UserController::class, 'show']);
+    Route::put('/user', [UserController::class, 'update']);
+    Route::apiResource('equipment-types', EquipmentTypeController::class);
+});

--- a/tests/CreatesPassportToken.php
+++ b/tests/CreatesPassportToken.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use Laravel\Passport\ClientRepository;
+
+trait CreatesPassportToken
+{
+    protected function setUpPassport(): void
+    {
+        app(ClientRepository::class)->createPersonalAccessGrantClient('Test Personal Access Client');
+    }
+}

--- a/tests/Feature/Api/V1/Auth/LoginTest.php
+++ b/tests/Feature/Api/V1/Auth/LoginTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1\Auth;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\ClientRepository;
+use Tests\TestCase;
+
+class LoginTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        app(ClientRepository::class)->createPersonalAccessGrantClient('Test Personal Access Client');
+    }
+
+    public function test_logs_in_with_valid_credentials(): void
+    {
+        User::factory()->create([
+            'email' => 'user@example.com',
+            'password' => 'secret123',
+        ]);
+
+        $response = $this->postJson('/api/v1/login', [
+            'email' => 'user@example.com',
+            'password' => 'secret123',
+        ]);
+
+        $response->assertOk()
+            ->assertJsonStructure(['user', 'token']);
+    }
+
+    public function test_rejects_wrong_password(): void
+    {
+        User::factory()->create([
+            'email' => 'user@example.com',
+            'password' => 'secret123',
+        ]);
+
+        $this->postJson('/api/v1/login', [
+            'email' => 'user@example.com',
+            'password' => 'wrong',
+        ])->assertStatus(401);
+    }
+
+    public function test_rejects_nonexistent_email(): void
+    {
+        $this->postJson('/api/v1/login', [
+            'email' => 'nobody@example.com',
+            'password' => 'secret123',
+        ])->assertStatus(401);
+    }
+
+    public function test_validates_required_fields(): void
+    {
+        $this->postJson('/api/v1/login', [])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['email', 'password']);
+    }
+
+    public function test_is_rate_limited(): void
+    {
+        User::factory()->create(['email' => 'user@example.com']);
+
+        for ($i = 0; $i < 5; $i++) {
+            $this->postJson('/api/v1/login', [
+                'email' => 'user@example.com',
+                'password' => 'wrong',
+            ]);
+        }
+
+        $this->postJson('/api/v1/login', [
+            'email' => 'user@example.com',
+            'password' => 'wrong',
+        ])->assertStatus(429);
+    }
+}

--- a/tests/Feature/Api/V1/Auth/LoginTest.php
+++ b/tests/Feature/Api/V1/Auth/LoginTest.php
@@ -6,17 +6,18 @@ namespace Tests\Feature\Api\V1\Auth;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Laravel\Passport\ClientRepository;
+use Tests\CreatesPassportToken;
 use Tests\TestCase;
 
 class LoginTest extends TestCase
 {
+    use CreatesPassportToken;
     use RefreshDatabase;
 
     protected function setUp(): void
     {
         parent::setUp();
-        app(ClientRepository::class)->createPersonalAccessGrantClient('Test Personal Access Client');
+        $this->setUpPassport();
     }
 
     public function test_logs_in_with_valid_credentials(): void

--- a/tests/Feature/Api/V1/Auth/LogoutTest.php
+++ b/tests/Feature/Api/V1/Auth/LogoutTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1\Auth;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
+use Tests\TestCase;
+
+class LogoutTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_revokes_current_token(): void
+    {
+        $user = User::factory()->create();
+        Passport::actingAs($user);
+
+        $this->postJson('/api/v1/logout')->assertNoContent();
+    }
+
+    public function test_rejects_unauthenticated_request(): void
+    {
+        $this->postJson('/api/v1/logout')->assertStatus(401);
+    }
+}

--- a/tests/Feature/Api/V1/Auth/PasswordResetTest.php
+++ b/tests/Feature/Api/V1/Auth/PasswordResetTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1\Auth;
+
+use App\Models\User;
+use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Password;
+use Tests\TestCase;
+
+class PasswordResetTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_sends_reset_link(): void
+    {
+        Notification::fake();
+        $user = User::factory()->create(['email' => 'user@example.com']);
+
+        $this->postJson('/api/v1/password/forgot', ['email' => 'user@example.com'])
+            ->assertOk()
+            ->assertJsonStructure(['message']);
+
+        Notification::assertSentTo($user, ResetPassword::class);
+    }
+
+    public function test_forgot_returns_ok_for_unknown_email(): void
+    {
+        $this->postJson('/api/v1/password/forgot', ['email' => 'nobody@example.com'])
+            ->assertOk();
+    }
+
+    public function test_forgot_validates_email(): void
+    {
+        $this->postJson('/api/v1/password/forgot', ['email' => 'not-an-email'])
+            ->assertStatus(422);
+    }
+
+    public function test_resets_password_with_valid_token(): void
+    {
+        $user = User::factory()->create(['email' => 'user@example.com']);
+        $token = Password::createToken($user);
+
+        $this->postJson('/api/v1/password/reset', [
+            'email' => 'user@example.com',
+            'token' => $token,
+            'password' => 'newpassword',
+            'password_confirmation' => 'newpassword',
+        ])->assertOk();
+    }
+
+    public function test_rejects_invalid_reset_token(): void
+    {
+        User::factory()->create(['email' => 'user@example.com']);
+
+        $this->postJson('/api/v1/password/reset', [
+            'email' => 'user@example.com',
+            'token' => 'bad-token',
+            'password' => 'newpassword',
+            'password_confirmation' => 'newpassword',
+        ])->assertStatus(422);
+    }
+
+    public function test_reset_validates_password_confirmation(): void
+    {
+        $user = User::factory()->create(['email' => 'user@example.com']);
+        $token = Password::createToken($user);
+
+        $this->postJson('/api/v1/password/reset', [
+            'email' => 'user@example.com',
+            'token' => $token,
+            'password' => 'newpassword',
+            'password_confirmation' => 'mismatch',
+        ])->assertStatus(422)
+            ->assertJsonValidationErrors('password');
+    }
+
+    public function test_forgot_is_rate_limited(): void
+    {
+        User::factory()->create(['email' => 'user@example.com']);
+        Notification::fake();
+
+        for ($i = 0; $i < 3; $i++) {
+            $this->postJson('/api/v1/password/forgot', ['email' => 'user@example.com']);
+        }
+
+        $this->postJson('/api/v1/password/forgot', ['email' => 'user@example.com'])
+            ->assertStatus(429);
+    }
+}

--- a/tests/Feature/Api/V1/Auth/RegisterTest.php
+++ b/tests/Feature/Api/V1/Auth/RegisterTest.php
@@ -7,22 +7,23 @@ namespace Tests\Feature\Api\V1\Auth;
 use App\Enums\MeasurementSystem;
 use App\Enums\ThemePreference;
 use App\Models\User;
+use App\Notifications\WelcomeNotification;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Notification;
-use Laravel\Passport\ClientRepository;
+use Tests\CreatesPassportToken;
 use Tests\TestCase;
-use App\Notifications\WelcomeNotification;
 
 class RegisterTest extends TestCase
 {
+    use CreatesPassportToken;
     use RefreshDatabase;
 
     protected function setUp(): void
     {
         parent::setUp();
-        app(ClientRepository::class)->createPersonalAccessGrantClient('Test Personal Access Client');
+        $this->setUpPassport();
     }
 
     /** @return array<string, mixed> */

--- a/tests/Feature/Api/V1/Auth/RegisterTest.php
+++ b/tests/Feature/Api/V1/Auth/RegisterTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1\Auth;
+
+use App\Enums\MeasurementSystem;
+use App\Enums\ThemePreference;
+use App\Models\User;
+use Illuminate\Auth\Events\Registered;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Notification;
+use Laravel\Passport\ClientRepository;
+use Tests\TestCase;
+use App\Notifications\WelcomeNotification;
+
+class RegisterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        app(ClientRepository::class)->createPersonalAccessGrantClient('Test Personal Access Client');
+    }
+
+    /** @return array<string, mixed> */
+    private function validPayload(array $overrides = []): array
+    {
+        return array_merge([
+            'email' => 'new@example.com',
+            'password' => 'secret123',
+            'password_confirmation' => 'secret123',
+            'measurement_system' => 'imperial',
+            'first_name' => 'Jane',
+            'last_name' => 'Doe',
+        ], $overrides);
+    }
+
+    public function test_registers_user_and_returns_token(): void
+    {
+        $response = $this->postJson('/api/v1/register', $this->validPayload());
+
+        $response->assertStatus(201)
+            ->assertJsonStructure([
+                'user' => ['id', 'email', 'first_name', 'last_name', 'measurement_system', 'theme'],
+                'token',
+            ]);
+
+        $this->assertDatabaseHas('users', [
+            'email' => 'new@example.com',
+            'first_name' => 'Jane',
+            'last_name' => 'Doe',
+        ]);
+
+        $user = User::where('email', 'new@example.com')->first();
+        $this->assertSame(MeasurementSystem::Imperial, $user->measurement_system);
+        $this->assertSame(ThemePreference::System, $user->theme);
+    }
+
+    public function test_fires_registered_event(): void
+    {
+        Event::fake([Registered::class]);
+
+        $this->postJson('/api/v1/register', $this->validPayload());
+
+        Event::assertDispatched(Registered::class);
+    }
+
+    public function test_measurement_system_is_required(): void
+    {
+        $this->postJson('/api/v1/register', $this->validPayload([
+            'measurement_system' => null,
+        ]))->assertStatus(422)
+            ->assertJsonValidationErrors('measurement_system');
+    }
+
+    public function test_rejects_invalid_measurement_system(): void
+    {
+        $this->postJson('/api/v1/register', $this->validPayload([
+            'measurement_system' => 'cubits',
+        ]))->assertStatus(422)
+            ->assertJsonValidationErrors('measurement_system');
+    }
+
+    public function test_password_must_be_confirmed(): void
+    {
+        $this->postJson('/api/v1/register', $this->validPayload([
+            'password_confirmation' => 'wrong',
+        ]))->assertStatus(422)
+            ->assertJsonValidationErrors('password');
+    }
+
+    public function test_password_minimum_length(): void
+    {
+        $this->postJson('/api/v1/register', $this->validPayload([
+            'password' => 'short',
+            'password_confirmation' => 'short',
+        ]))->assertStatus(422)
+            ->assertJsonValidationErrors('password');
+    }
+
+    public function test_email_must_be_unique(): void
+    {
+        User::factory()->create(['email' => 'taken@example.com']);
+
+        $this->postJson('/api/v1/register', $this->validPayload([
+            'email' => 'taken@example.com',
+        ]))->assertStatus(422)
+            ->assertJsonValidationErrors('email');
+    }
+
+    public function test_first_and_last_name_are_optional(): void
+    {
+        $response = $this->postJson('/api/v1/register', $this->validPayload([
+            'first_name' => null,
+            'last_name' => null,
+        ]));
+
+        $response->assertStatus(201);
+        $this->assertDatabaseHas('users', ['email' => 'new@example.com', 'first_name' => null]);
+    }
+
+    public function test_sends_welcome_notification(): void
+    {
+        Notification::fake();
+
+        $this->postJson('/api/v1/register', $this->validPayload());
+
+        $user = User::where('email', 'new@example.com')->first();
+        Notification::assertSentTo($user, WelcomeNotification::class);
+    }
+}

--- a/tests/Feature/Api/V1/EquipmentTypeTest.php
+++ b/tests/Feature/Api/V1/EquipmentTypeTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Models\EquipmentType;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Laravel\Passport\Passport;
+use Tests\TestCase;
+use Database\Seeders\EquipmentTypeSeeder;
+
+class EquipmentTypeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function seedSystemTypes(): void
+    {
+        $this->seed(EquipmentTypeSeeder::class);
+    }
+
+    public function test_lists_system_and_own_custom_types(): void
+    {
+        $this->seedSystemTypes();
+        $user = User::factory()->create();
+        EquipmentType::create(['name' => 'My Rack', 'user_id' => $user->id, 'is_system' => false]);
+
+        $other = User::factory()->create();
+        EquipmentType::create(['name' => 'Other Gear', 'user_id' => $other->id, 'is_system' => false]);
+
+        Passport::actingAs($user);
+
+        $response = $this->getJson('/api/v1/equipment-types');
+
+        $response->assertOk();
+
+        $names = collect($response->json('data'))->pluck('name');
+        $this->assertTrue($names->contains('barbell'));
+        $this->assertTrue($names->contains('My Rack'));
+        $this->assertFalse($names->contains('Other Gear'));
+    }
+
+    public function test_creates_custom_equipment_type(): void
+    {
+        $user = User::factory()->create();
+        Passport::actingAs($user);
+
+        $this->postJson('/api/v1/equipment-types', ['name' => 'Trap Bar'])
+            ->assertStatus(201)
+            ->assertJsonPath('data.name', 'Trap Bar')
+            ->assertJsonPath('data.is_system', false);
+
+        $this->assertDatabaseHas('equipment_types', [
+            'name' => 'Trap Bar',
+            'user_id' => $user->id,
+            'is_system' => false,
+        ]);
+    }
+
+    public function test_rejects_duplicate_name_for_same_user(): void
+    {
+        $user = User::factory()->create();
+        EquipmentType::create(['name' => 'Trap Bar', 'user_id' => $user->id, 'is_system' => false]);
+        Passport::actingAs($user);
+
+        $this->postJson('/api/v1/equipment-types', ['name' => 'Trap Bar'])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors('name');
+    }
+
+    public function test_shows_single_equipment_type(): void
+    {
+        $this->seedSystemTypes();
+        $user = User::factory()->create();
+        Passport::actingAs($user);
+
+        $type = EquipmentType::where('name', 'barbell')->first();
+
+        $this->getJson("/api/v1/equipment-types/{$type->id}")
+            ->assertOk()
+            ->assertJsonPath('data.name', 'barbell');
+    }
+
+    public function test_updates_own_custom_type(): void
+    {
+        $user = User::factory()->create();
+        $type = EquipmentType::create(['name' => 'Old Name', 'user_id' => $user->id, 'is_system' => false]);
+        Passport::actingAs($user);
+
+        $this->putJson("/api/v1/equipment-types/{$type->id}", ['name' => 'New Name'])
+            ->assertOk()
+            ->assertJsonPath('data.name', 'New Name');
+    }
+
+    public function test_cannot_update_system_type(): void
+    {
+        $this->seedSystemTypes();
+        $user = User::factory()->create();
+        Passport::actingAs($user);
+
+        $type = EquipmentType::where('name', 'barbell')->first();
+
+        $this->putJson("/api/v1/equipment-types/{$type->id}", ['name' => 'Renamed'])
+            ->assertStatus(403);
+    }
+
+    public function test_cannot_update_other_users_type(): void
+    {
+        $other = User::factory()->create();
+        $type = EquipmentType::create(['name' => 'Their Gear', 'user_id' => $other->id, 'is_system' => false]);
+
+        Passport::actingAs(User::factory()->create());
+
+        $this->putJson("/api/v1/equipment-types/{$type->id}", ['name' => 'Stolen'])
+            ->assertStatus(403);
+    }
+
+    public function test_deletes_unused_custom_type(): void
+    {
+        $user = User::factory()->create();
+        $type = EquipmentType::create(['name' => 'To Delete', 'user_id' => $user->id, 'is_system' => false]);
+        Passport::actingAs($user);
+
+        $this->deleteJson("/api/v1/equipment-types/{$type->id}")
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('equipment_types', ['id' => $type->id]);
+    }
+
+    public function test_returns_409_when_deleting_referenced_type(): void
+    {
+        $user = User::factory()->create();
+        $type = EquipmentType::create(['name' => 'In Use', 'user_id' => $user->id, 'is_system' => false]);
+
+        DB::table('exercises')->insert([
+            'name' => 'Test Exercise',
+            'type' => 'resistance',
+            'user_id' => $user->id,
+            'equipment_type_id' => $type->id,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        Passport::actingAs($user);
+
+        $this->deleteJson("/api/v1/equipment-types/{$type->id}")
+            ->assertStatus(409);
+
+        $this->assertDatabaseHas('equipment_types', ['id' => $type->id]);
+    }
+
+    public function test_cannot_delete_system_type(): void
+    {
+        $this->seedSystemTypes();
+        $user = User::factory()->create();
+        Passport::actingAs($user);
+
+        $type = EquipmentType::where('name', 'barbell')->first();
+
+        $this->deleteJson("/api/v1/equipment-types/{$type->id}")
+            ->assertStatus(403);
+    }
+
+    public function test_unauthenticated_cannot_access_equipment(): void
+    {
+        $this->getJson('/api/v1/equipment-types')->assertStatus(401);
+        $this->postJson('/api/v1/equipment-types', ['name' => 'Nope'])->assertStatus(401);
+    }
+}

--- a/tests/Feature/Api/V1/UserTest.php
+++ b/tests/Feature/Api/V1/UserTest.php
@@ -8,11 +8,19 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
 use Laravel\Passport\Passport;
+use Tests\CreatesPassportToken;
 use Tests\TestCase;
 
 class UserTest extends TestCase
 {
+    use CreatesPassportToken;
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpPassport();
+    }
 
     public function test_returns_authenticated_user(): void
     {

--- a/tests/Feature/Api/V1/UserTest.php
+++ b/tests/Feature/Api/V1/UserTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Passport\Passport;
+use Tests\TestCase;
+
+class UserTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_returns_authenticated_user(): void
+    {
+        $user = User::factory()->create();
+        Passport::actingAs($user);
+
+        $response = $this->getJson('/api/v1/user');
+
+        $response->assertOk()
+            ->assertJsonPath('data.id', $user->id)
+            ->assertJsonPath('data.email', $user->email)
+            ->assertJsonStructure([
+                'data' => ['id', 'email', 'first_name', 'last_name', 'measurement_system', 'theme'],
+            ]);
+    }
+
+    public function test_rejects_unauthenticated(): void
+    {
+        $this->getJson('/api/v1/user')->assertStatus(401);
+    }
+
+    public function test_updates_profile_fields(): void
+    {
+        $user = User::factory()->create();
+        Passport::actingAs($user);
+
+        $this->putJson('/api/v1/user', [
+            'first_name' => 'Updated',
+            'last_name' => 'Name',
+            'measurement_system' => 'metric',
+            'theme' => 'dark',
+        ])->assertOk()
+            ->assertJsonPath('data.first_name', 'Updated')
+            ->assertJsonPath('data.measurement_system', 'metric')
+            ->assertJsonPath('data.theme', 'dark');
+    }
+
+    public function test_updates_email_with_uniqueness(): void
+    {
+        User::factory()->create(['email' => 'taken@example.com']);
+        $user = User::factory()->create();
+        Passport::actingAs($user);
+
+        $this->putJson('/api/v1/user', ['email' => 'taken@example.com'])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors('email');
+    }
+
+    public function test_allows_keeping_own_email(): void
+    {
+        $user = User::factory()->create(['email' => 'mine@example.com']);
+        Passport::actingAs($user);
+
+        $this->putJson('/api/v1/user', [
+            'email' => 'mine@example.com',
+            'first_name' => 'Updated',
+        ])->assertOk();
+    }
+
+    public function test_password_change_requires_current_password(): void
+    {
+        $user = User::factory()->create(['password' => 'oldpassword']);
+        Passport::actingAs($user);
+
+        $this->putJson('/api/v1/user', [
+            'password' => 'newpassword',
+            'password_confirmation' => 'newpassword',
+        ])->assertStatus(422)
+            ->assertJsonValidationErrors('current_password');
+    }
+
+    public function test_password_change_with_correct_current_password(): void
+    {
+        $user = User::factory()->create(['password' => 'oldpassword']);
+        Passport::actingAs($user);
+
+        $this->putJson('/api/v1/user', [
+            'current_password' => 'oldpassword',
+            'password' => 'newpassword',
+            'password_confirmation' => 'newpassword',
+        ])->assertOk();
+
+        $this->assertTrue(Hash::check('newpassword', $user->fresh()->password));
+    }
+
+    public function test_rejects_wrong_current_password(): void
+    {
+        $user = User::factory()->create(['password' => 'oldpassword']);
+        Passport::actingAs($user);
+
+        $this->putJson('/api/v1/user', [
+            'current_password' => 'wrongpassword',
+            'password' => 'newpassword',
+            'password_confirmation' => 'newpassword',
+        ])->assertStatus(422)
+            ->assertJsonValidationErrors('current_password');
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,8 +3,16 @@
 namespace Tests;
 
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Illuminate\Support\Facades\Artisan;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (! file_exists(storage_path('oauth-private.key'))) {
+            Artisan::call('passport:keys', ['--force' => true]);
+        }
+    }
 }


### PR DESCRIPTION
## Problem

The app had no authentication, no user management beyond a default factory, and no API for equipment types. The users table lacked fields for name, measurement preference, and theme. Passport was installed but not configured. The equipment_types table existed from Phase 2 but had no Eloquent model, policy, or REST endpoints.

## Solution

Added Passport personal access token auth with five endpoints: register (with required measurement_system), login (rate limited), logout (token revocation), forgot password, and reset password. The users table migration replaces the single `name` column with `first_name`/`last_name` and adds `measurement_system` and `theme` columns with PHP enum casts.

Added GET/PUT `/api/v1/user` for authenticated profile management, including password changes that require the current password.

Added an EquipmentType model on the existing table with a policy enforcing per-user isolation and system type protection. The full CRUD API (`apiResource`) returns system types alongside the user's custom types, blocks updates/deletes on system types, and returns 409 when deleting a type referenced by exercises.

A queued WelcomeNotification fires on registration via the Registered event. 42 new tests (53 total) cover all endpoints, validation rules, rate limiting, authorization, and the 409 delete guard.
