### PR TITLE
PS-58 - Wiring auth, profile, and equipment UI to real API

### DIFF
--- a/resources/js/api/auth.ts
+++ b/resources/js/api/auth.ts
@@ -1,0 +1,57 @@
+import { api, setToken, clearToken } from './client'
+import { toUser } from './transformers'
+import type { User } from './types'
+
+interface AuthResponse {
+  user: User
+  token: string
+}
+
+interface LoginPayload {
+  email: string
+  password: string
+}
+
+interface RegisterPayload {
+  email: string
+  password: string
+  password_confirmation: string
+  measurement_system: string
+  first_name?: string
+  last_name?: string
+}
+
+export async function login(payload: LoginPayload): Promise<AuthResponse> {
+  const { data } = await api.post('/login', payload)
+  const user = toUser(data.user)
+  setToken(data.token)
+  return { user, token: data.token }
+}
+
+export async function register(payload: RegisterPayload): Promise<AuthResponse> {
+  const { data } = await api.post('/register', payload)
+  const user = toUser(data.user)
+  setToken(data.token)
+  return { user, token: data.token }
+}
+
+export async function logout(): Promise<void> {
+  try {
+    await api.post('/logout')
+  } finally {
+    clearToken()
+  }
+}
+
+export async function forgotPassword(email: string): Promise<void> {
+  await api.post('/password/forgot', { email })
+}
+
+export async function resetPassword(payload: {
+  email: string
+  token: string
+  password: string
+  password_confirmation: string
+}): Promise<void> {
+  await api.post('/password/reset', payload)
+}

--- a/resources/js/api/client.ts
+++ b/resources/js/api/client.ts
@@ -1,0 +1,39 @@
+import axios from 'axios'
+
+const TOKEN_KEY = 'ps_token'
+
+export const api = axios.create({
+  baseURL: '/api/v1',
+  headers: { Accept: 'application/json' },
+})
+
+api.interceptors.request.use(config => {
+  const token = localStorage.getItem(TOKEN_KEY)
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`
+  }
+  return config
+})
+
+api.interceptors.response.use(
+  response => response,
+  error => {
+    if (error.response?.status === 401 && localStorage.getItem(TOKEN_KEY)) {
+      localStorage.removeItem(TOKEN_KEY)
+      window.location.href = '/login'
+    }
+    return Promise.reject(error)
+  }
+)
+
+export function setToken(token: string): void {
+  localStorage.setItem(TOKEN_KEY, token)
+}
+
+export function clearToken(): void {
+  localStorage.removeItem(TOKEN_KEY)
+}
+
+export function hasToken(): boolean {
+  return !!localStorage.getItem(TOKEN_KEY)
+}

--- a/resources/js/api/equipment.ts
+++ b/resources/js/api/equipment.ts
@@ -1,0 +1,17 @@
+import { api } from './client'
+import { toEquipmentType, type RawEquipmentType } from './transformers'
+import type { EquipmentType } from './types'
+
+export async function listEquipment(): Promise<EquipmentType[]> {
+  const { data } = await api.get('/equipment-types')
+  return (data.data as RawEquipmentType[]).map(toEquipmentType)
+}
+
+export async function createEquipment(name: string): Promise<EquipmentType> {
+  const { data } = await api.post('/equipment-types', { name })
+  return toEquipmentType(data.data)
+}
+
+export async function deleteEquipment(id: string): Promise<void> {
+  await api.delete(`/equipment-types/${id}`)
+}

--- a/resources/js/api/transformers.ts
+++ b/resources/js/api/transformers.ts
@@ -1,0 +1,36 @@
+import type { User, EquipmentType } from '@/api/types'
+import type { MeasurementSystem } from '@/lib/units'
+
+export interface RawUser {
+  id: number
+  email: string
+  first_name: string | null
+  last_name: string | null
+  measurement_system: MeasurementSystem
+  theme: 'light' | 'dark' | 'system'
+}
+
+export interface RawEquipmentType {
+  id: number
+  name: string
+  is_system: boolean
+}
+
+export function toUser(raw: RawUser): User {
+  return {
+    id: String(raw.id),
+    firstName: raw.first_name ?? '',
+    lastName: raw.last_name ?? '',
+    email: raw.email,
+    measurementSystem: raw.measurement_system,
+    theme: raw.theme,
+  }
+}
+
+export function toEquipmentType(raw: RawEquipmentType): EquipmentType {
+  return {
+    id: String(raw.id),
+    name: raw.name,
+    isSystem: raw.is_system,
+  }
+}

--- a/resources/js/api/user.ts
+++ b/resources/js/api/user.ts
@@ -1,0 +1,24 @@
+import { api } from './client'
+import { toUser } from './transformers'
+import type { User } from './types'
+
+export async function getProfile(): Promise<User> {
+  const { data } = await api.get('/user')
+  return toUser(data.data)
+}
+
+interface UpdateProfilePayload {
+  first_name?: string
+  last_name?: string
+  email?: string
+  measurement_system?: string
+  theme?: string
+  current_password?: string
+  password?: string
+  password_confirmation?: string
+}
+
+export async function updateProfile(payload: UpdateProfilePayload): Promise<User> {
+  const { data } = await api.put('/user', payload)
+  return toUser(data.data)
+}

--- a/resources/js/app-root.tsx
+++ b/resources/js/app-root.tsx
@@ -1,7 +1,8 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { BrowserRouter, Route, Routes, Navigate, useLocation } from 'react-router-dom'
+import { BrowserRouter, Route, Routes, Navigate } from 'react-router-dom'
 import { AppProvider } from '@/lib/store'
-import { useApp } from '@/lib/use-app'
+import { AuthProvider } from '@/lib/auth-provider'
+import { useAuth } from '@/hooks/use-auth'
 import { Shell } from '@/components/shell/shell'
 import {
   LoginPage,
@@ -26,17 +27,16 @@ const queryClient = new QueryClient({
 })
 
 function AuthGate({ children }: { children: React.ReactNode }) {
-  const { authed } = useApp()
-  const location = useLocation()
+  const { user, isLoading } = useAuth()
+  if (isLoading) return null
+  if (!user) return <Navigate to="/login" replace />
+  return <>{children}</>
+}
 
-  if (!authed) {
-    return <Navigate to="/login" replace />
-  }
-
-  if (location.pathname === '/login' || location.pathname === '/register') {
-    return <Navigate to="/workouts" replace />
-  }
-
+function GuestGate({ children }: { children: React.ReactNode }) {
+  const { user, isLoading } = useAuth()
+  if (isLoading) return null
+  if (user) return <Navigate to="/workouts" replace />
   return <>{children}</>
 }
 
@@ -44,33 +44,49 @@ export function AppRoot() {
   return (
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
-        <AppProvider>
-          <Routes>
-            <Route path="/login" element={<LoginPage />} />
-            <Route path="/register" element={<RegisterPage />} />
-            <Route path="/password/reset" element={<PasswordResetRequestPage />} />
-            <Route path="/password/reset/:token" element={<PasswordResetFormPage />} />
-            <Route
-              path="/*"
-              element={
-                <AuthGate>
-                  <Shell />
-                </AuthGate>
-              }
-            >
-              <Route path="workouts" element={<WorkoutsPage />} />
-              <Route path="workouts/:id" element={<WorkoutDetailPage />} />
-              <Route path="templates/:id" element={<TemplateEditorPage />} />
-              <Route path="exercises" element={<ExercisesPage />} />
-              <Route path="exercises/:id" element={<ExerciseDetailPage />} />
-              <Route path="exercises/:id/progress" element={<ExerciseProgressPage />} />
-              <Route path="progress" element={<ProgressPage />} />
-              <Route path="equipment" element={<EquipmentPage />} />
-              <Route path="profile" element={<ProfilePage />} />
-              <Route path="*" element={<Navigate to="/workouts" replace />} />
-            </Route>
-          </Routes>
-        </AppProvider>
+        <AuthProvider>
+          <AppProvider>
+            <Routes>
+              <Route
+                path="/login"
+                element={
+                  <GuestGate>
+                    <LoginPage />
+                  </GuestGate>
+                }
+              />
+              <Route
+                path="/register"
+                element={
+                  <GuestGate>
+                    <RegisterPage />
+                  </GuestGate>
+                }
+              />
+              <Route path="/password/reset" element={<PasswordResetRequestPage />} />
+              <Route path="/password/reset/:token" element={<PasswordResetFormPage />} />
+              <Route
+                path="/*"
+                element={
+                  <AuthGate>
+                    <Shell />
+                  </AuthGate>
+                }
+              >
+                <Route path="workouts" element={<WorkoutsPage />} />
+                <Route path="workouts/:id" element={<WorkoutDetailPage />} />
+                <Route path="templates/:id" element={<TemplateEditorPage />} />
+                <Route path="exercises" element={<ExercisesPage />} />
+                <Route path="exercises/:id" element={<ExerciseDetailPage />} />
+                <Route path="exercises/:id/progress" element={<ExerciseProgressPage />} />
+                <Route path="progress" element={<ProgressPage />} />
+                <Route path="equipment" element={<EquipmentPage />} />
+                <Route path="profile" element={<ProfilePage />} />
+                <Route path="*" element={<Navigate to="/workouts" replace />} />
+              </Route>
+            </Routes>
+          </AppProvider>
+        </AuthProvider>
       </BrowserRouter>
     </QueryClientProvider>
   )

--- a/resources/js/components/shell/shell.tsx
+++ b/resources/js/components/shell/shell.tsx
@@ -1,6 +1,6 @@
 import { useLocation, useNavigate, Outlet } from 'react-router-dom'
 import { Dumbbell, List, TrendingUp, LayoutGrid } from 'lucide-react'
-import { useApp } from '@/lib/use-app'
+import { useAuth } from '@/hooks/use-auth'
 import { Avatar } from '@/components/ui/avatar'
 
 interface NavItem {
@@ -29,7 +29,8 @@ function getActiveKey(pathname: string): string {
 export function Shell() {
   const location = useLocation()
   const navigate = useNavigate()
-  const { user } = useApp()
+  const { user } = useAuth()
+  if (!user) return null
   const activeKey = getActiveKey(location.pathname)
   const fullName = `${user.firstName} ${user.lastName}`
 

--- a/resources/js/hooks/use-auth.ts
+++ b/resources/js/hooks/use-auth.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react'
+import { AuthContext, type AuthContextValue } from '@/lib/auth-context'
+
+export function useAuth(): AuthContextValue {
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider')
+  }
+  return context
+}

--- a/resources/js/lib/auth-context.ts
+++ b/resources/js/lib/auth-context.ts
@@ -1,0 +1,11 @@
+import { createContext } from 'react'
+import type { User } from '@/api/types'
+
+export interface AuthContextValue {
+  user: User | null
+  isLoading: boolean
+  setUser: (user: User) => void
+  handleLogout: () => Promise<void>
+}
+
+export const AuthContext = createContext<AuthContextValue | null>(null)

--- a/resources/js/lib/auth-provider.tsx
+++ b/resources/js/lib/auth-provider.tsx
@@ -1,0 +1,58 @@
+import { useCallback, useState, useEffect, type ReactNode } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
+import { hasToken, clearToken } from '@/api/client'
+import { getProfile } from '@/api/user'
+import { logout as logoutApi } from '@/api/auth'
+import { AuthContext } from './auth-context'
+import type { User } from '@/api/types'
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null)
+  const [isLoading, setIsLoading] = useState(hasToken())
+  const queryClient = useQueryClient()
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    if (!hasToken()) return
+    getProfile()
+      .then(setUser)
+      .catch(() => {
+        clearToken()
+        setUser(null)
+      })
+      .finally(() => setIsLoading(false))
+  }, [])
+
+  const theme = user?.theme
+  useEffect(() => {
+    if (!theme) return
+    let resolved = theme
+    if (resolved === 'system') {
+      resolved = window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+    }
+    document.documentElement.classList.toggle('dark', resolved === 'dark')
+
+    if (theme !== 'system') return
+    const mq = window.matchMedia('(prefers-color-scheme: dark)')
+    const onChange = () => {
+      const dark = mq.matches
+      document.documentElement.classList.toggle('dark', dark)
+    }
+    mq.addEventListener('change', onChange)
+    return () => mq.removeEventListener('change', onChange)
+  }, [theme])
+
+  const handleLogout = useCallback(async () => {
+    await logoutApi()
+    setUser(null)
+    queryClient.clear()
+    navigate('/login')
+  }, [queryClient, navigate])
+
+  return (
+    <AuthContext.Provider value={{ user, isLoading, setUser, handleLogout }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}

--- a/resources/js/pages/auth.tsx
+++ b/resources/js/pages/auth.tsx
@@ -1,8 +1,10 @@
-import { type ReactNode, useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { type FormEvent, type ReactNode, useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { isAxiosError } from 'axios'
 import { Button } from '@/components/ui/button'
 import { SegmentedControl } from '@/components/ui/segmented-control'
-import { useApp } from '@/lib/use-app'
+import { useAuth } from '@/hooks/use-auth'
+import { login, register, forgotPassword, resetPassword } from '@/api/auth'
 
 interface AuthLayoutProps {
   title: string
@@ -41,9 +43,18 @@ interface FieldProps {
   onChange: (value: string) => void
   placeholder?: string
   name?: string
+  error?: string
 }
 
-export function Field({ label, type = 'text', value, onChange, placeholder, name }: FieldProps) {
+export function Field({
+  label,
+  type = 'text',
+  value,
+  onChange,
+  placeholder,
+  name,
+  error,
+}: FieldProps) {
   return (
     <label className="block">
       <span className="label-caps text-text-secondary block mb-1.5">{label}</span>
@@ -53,22 +64,60 @@ export function Field({ label, type = 'text', value, onChange, placeholder, name
         value={value}
         placeholder={placeholder}
         onChange={e => onChange(e.target.value)}
-        className="ps-input w-full px-3 py-2.5 text-sm"
+        className={`ps-input w-full px-3 py-2.5 text-sm${error ? ' border-destructive' : ''}`}
       />
+      {error && <p className="text-destructive text-xs mt-1">{error}</p>}
     </label>
   )
 }
 
-export function LoginPage() {
-  const { login } = useApp()
-  const navigate = useNavigate()
-  const [email, setEmail] = useState('justin@physistrong.app')
-  const [password, setPassword] = useState('password')
+function extractFieldErrors(error: unknown): Record<string, string> {
+  if (!isAxiosError(error) || error.response?.status !== 422) return {}
+  const fieldErrors = error.response.data?.errors as Record<string, string[]> | undefined
+  if (!fieldErrors) return {}
+  const result: Record<string, string> = {}
+  for (const [key, messages] of Object.entries(fieldErrors)) {
+    const first = messages[0]
+    if (first) result[key] = first
+  }
+  return result
+}
 
-  const handleSubmit = (e: React.FormEvent) => {
+function extractMessage(error: unknown): string {
+  if (isAxiosError(error) && error.response?.data?.message) {
+    return error.response.data.message as string
+  }
+  return 'Something went wrong. Try again.'
+}
+
+export function LoginPage() {
+  const { setUser } = useAuth()
+  const navigate = useNavigate()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [errors, setErrors] = useState<Record<string, string>>({})
+  const [generalError, setGeneralError] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
-    login()
-    navigate('/workouts')
+    setErrors({})
+    setGeneralError('')
+    setSubmitting(true)
+    try {
+      const { user } = await login({ email, password })
+      setUser(user)
+      navigate('/workouts')
+    } catch (err) {
+      const fieldErrors = extractFieldErrors(err)
+      if (Object.keys(fieldErrors).length > 0) {
+        setErrors(fieldErrors)
+      } else {
+        setGeneralError(extractMessage(err))
+      }
+    } finally {
+      setSubmitting(false)
+    }
   }
 
   return (
@@ -85,12 +134,14 @@ export function LoginPage() {
       }
     >
       <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        {generalError && <p className="text-destructive text-sm text-center">{generalError}</p>}
         <Field
           label="Email"
           type="email"
           value={email}
           onChange={setEmail}
           placeholder="you@example.com"
+          error={errors.email}
         />
         <div>
           <Field
@@ -99,6 +150,7 @@ export function LoginPage() {
             value={password}
             onChange={setPassword}
             placeholder="••••••••"
+            error={errors.password}
           />
           <div className="text-right mt-1.5">
             <Link to="/password/reset" className="text-[13px] text-secondary font-medium">
@@ -106,8 +158,8 @@ export function LoginPage() {
             </Link>
           </div>
         </div>
-        <Button type="submit" full size="lg">
-          Log In
+        <Button type="submit" full size="lg" disabled={submitting}>
+          {submitting ? 'Logging in...' : 'Log In'}
         </Button>
       </form>
     </AuthLayout>
@@ -123,7 +175,7 @@ interface RegisterFormState {
 }
 
 export function RegisterPage() {
-  const { login, updateUser } = useApp()
+  const { setUser } = useAuth()
   const navigate = useNavigate()
   const [form, setForm] = useState<RegisterFormState>({
     first: '',
@@ -133,29 +185,44 @@ export function RegisterPage() {
     passwordConfirm: '',
   })
   const [measurementSystem, setMeasurementSystem] = useState<'imperial' | 'metric' | null>(null)
+  const [errors, setErrors] = useState<Record<string, string>>({})
+  const [generalError, setGeneralError] = useState('')
+  const [submitting, setSubmitting] = useState(false)
 
   const updateField = (key: keyof RegisterFormState) => (value: string) => {
     setForm(prev => ({ ...prev, [key]: value }))
   }
 
   const isValid =
-    form.first &&
-    form.email &&
-    form.password &&
-    form.password === form.passwordConfirm &&
-    measurementSystem
+    form.email && form.password && form.password === form.passwordConfirm && measurementSystem
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
     if (!isValid) return
-    updateUser({
-      firstName: form.first,
-      lastName: form.last,
-      email: form.email,
-      measurementSystem,
-    })
-    login()
-    navigate('/workouts')
+    setErrors({})
+    setGeneralError('')
+    setSubmitting(true)
+    try {
+      const { user } = await register({
+        email: form.email,
+        password: form.password,
+        password_confirmation: form.passwordConfirm,
+        measurement_system: measurementSystem,
+        first_name: form.first || undefined,
+        last_name: form.last || undefined,
+      })
+      setUser(user)
+      navigate('/workouts')
+    } catch (err) {
+      const fieldErrors = extractFieldErrors(err)
+      if (Object.keys(fieldErrors).length > 0) {
+        setErrors(fieldErrors)
+      } else {
+        setGeneralError(extractMessage(err))
+      }
+    } finally {
+      setSubmitting(false)
+    }
   }
 
   return (
@@ -172,18 +239,21 @@ export function RegisterPage() {
       }
     >
       <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        {generalError && <p className="text-destructive text-sm text-center">{generalError}</p>}
         <div className="grid grid-cols-2 gap-3">
           <Field
             label="First name"
             value={form.first}
             onChange={updateField('first')}
             placeholder="Justin"
+            error={errors.first_name}
           />
           <Field
             label="Last name"
             value={form.last}
             onChange={updateField('last')}
             placeholder="Carter"
+            error={errors.last_name}
           />
         </div>
 
@@ -193,6 +263,7 @@ export function RegisterPage() {
           value={form.email}
           onChange={updateField('email')}
           placeholder="you@example.com"
+          error={errors.email}
         />
 
         <div className="grid grid-cols-2 gap-3">
@@ -202,6 +273,7 @@ export function RegisterPage() {
             value={form.password}
             onChange={updateField('password')}
             placeholder="••••••••"
+            error={errors.password}
           />
           <Field
             label="Confirm"
@@ -224,13 +296,16 @@ export function RegisterPage() {
               { value: 'metric', label: 'Metric (kg, km)' },
             ]}
           />
+          {errors.measurement_system && (
+            <p className="text-destructive text-xs mt-1">{errors.measurement_system}</p>
+          )}
           <p className="text-[12px] text-text-muted mt-2">
             Controls unit labels across the app. You can change it later.
           </p>
         </div>
 
-        <Button type="submit" full size="lg" disabled={!isValid}>
-          Create Account
+        <Button type="submit" full size="lg" disabled={!isValid || submitting}>
+          {submitting ? 'Creating account...' : 'Create Account'}
         </Button>
       </form>
     </AuthLayout>
@@ -240,10 +315,21 @@ export function RegisterPage() {
 export function PasswordResetRequestPage() {
   const [email, setEmail] = useState('')
   const [sent, setSent] = useState(false)
+  const [error, setError] = useState('')
+  const [submitting, setSubmitting] = useState(false)
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
-    setSent(true)
+    setError('')
+    setSubmitting(true)
+    try {
+      await forgotPassword(email)
+      setSent(true)
+    } catch (err) {
+      setError(extractMessage(err))
+    } finally {
+      setSubmitting(false)
+    }
   }
 
   return (
@@ -276,6 +362,7 @@ export function PasswordResetRequestPage() {
         </div>
       ) : (
         <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          {error && <p className="text-destructive text-sm text-center">{error}</p>}
           <Field
             label="Email"
             type="email"
@@ -283,8 +370,8 @@ export function PasswordResetRequestPage() {
             onChange={setEmail}
             placeholder="you@example.com"
           />
-          <Button type="submit" full size="lg">
-            Send Reset Link
+          <Button type="submit" full size="lg" disabled={submitting}>
+            {submitting ? 'Sending...' : 'Send Reset Link'}
           </Button>
         </form>
       )}
@@ -294,14 +381,38 @@ export function PasswordResetRequestPage() {
 
 export function PasswordResetFormPage() {
   const navigate = useNavigate()
+  const { token } = useParams<{ token: string }>()
+  const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [passwordConfirm, setPasswordConfirm] = useState('')
   const [done, setDone] = useState(false)
+  const [errors, setErrors] = useState<Record<string, string>>({})
+  const [generalError, setGeneralError] = useState('')
+  const [submitting, setSubmitting] = useState(false)
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
-    if (password && password === passwordConfirm) {
+    if (!password || password !== passwordConfirm || !token) return
+    setErrors({})
+    setGeneralError('')
+    setSubmitting(true)
+    try {
+      await resetPassword({
+        email,
+        token,
+        password,
+        password_confirmation: passwordConfirm,
+      })
       setDone(true)
+    } catch (err) {
+      const fieldErrors = extractFieldErrors(err)
+      if (Object.keys(fieldErrors).length > 0) {
+        setErrors(fieldErrors)
+      } else {
+        setGeneralError(extractMessage(err))
+      }
+    } finally {
+      setSubmitting(false)
     }
   }
 
@@ -326,12 +437,22 @@ export function PasswordResetFormPage() {
         </div>
       ) : (
         <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          {generalError && <p className="text-destructive text-sm text-center">{generalError}</p>}
+          <Field
+            label="Email"
+            type="email"
+            value={email}
+            onChange={setEmail}
+            placeholder="you@example.com"
+            error={errors.email}
+          />
           <Field
             label="New password"
             type="password"
             value={password}
             onChange={setPassword}
             placeholder="••••••••"
+            error={errors.password}
           />
           <Field
             label="Confirm password"
@@ -340,8 +461,13 @@ export function PasswordResetFormPage() {
             onChange={setPasswordConfirm}
             placeholder="••••••••"
           />
-          <Button type="submit" full size="lg" disabled={!password || password !== passwordConfirm}>
-            Update Password
+          <Button
+            type="submit"
+            full
+            size="lg"
+            disabled={!email || !password || password !== passwordConfirm || submitting}
+          >
+            {submitting ? 'Updating...' : 'Update Password'}
           </Button>
         </form>
       )}

--- a/resources/js/pages/equipment.tsx
+++ b/resources/js/pages/equipment.tsx
@@ -1,4 +1,6 @@
-import { useState } from 'react'
+import { useState, type KeyboardEvent } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { isAxiosError } from 'axios'
 import { Dumbbell, Plus, Trash2 } from 'lucide-react'
 import { PageHeader } from '@/components/ui/page-header'
 import { Badge } from '@/components/ui/badge'
@@ -7,16 +9,41 @@ import { Card } from '@/components/ui/card'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { Sheet } from '@/components/ui/sheet'
 import { EmptyState } from '@/components/ui/empty-state'
-import { useEquipment } from '@/hooks/use-equipment'
-import { useExercises } from '@/hooks/use-exercises'
 import { useApp } from '@/lib/use-app'
-import { equipmentUsageCount } from '@/lib/domain'
+import { listEquipment, createEquipment, deleteEquipment } from '@/api/equipment'
 import type { EquipmentType } from '@/api/types'
 
 export function EquipmentPage() {
-  const { data: equipment } = useEquipment()
-  const { data: exercises } = useExercises()
-  const { addEquipment, deleteEquipment, toast } = useApp()
+  const queryClient = useQueryClient()
+  const { toast } = useApp()
+  const { data: equipment = [], isLoading } = useQuery({
+    queryKey: ['equipment'],
+    queryFn: listEquipment,
+  })
+
+  const createMutation = useMutation({
+    mutationFn: createEquipment,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['equipment'] })
+      toast('Equipment added.')
+    },
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteEquipment,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['equipment'] })
+      toast('Equipment deleted.')
+    },
+    onError: error => {
+      if (isAxiosError(error) && error.response?.status === 409) {
+        toast(error.response.data?.message ?? 'Equipment is in use.')
+      } else {
+        toast('Could not delete. Try again.')
+      }
+    },
+  })
+
   const [addOpen, setAddOpen] = useState(false)
   const [name, setName] = useState('')
   const [deleteTarget, setDeleteTarget] = useState<EquipmentType | null>(null)
@@ -24,23 +51,30 @@ export function EquipmentPage() {
   const handleCreate = () => {
     const trimmed = name.trim()
     if (!trimmed) return
-    addEquipment(trimmed)
+    createMutation.mutate(trimmed)
     setName('')
     setAddOpen(false)
-    toast('Equipment added.')
   }
 
   const handleDelete = () => {
     if (!deleteTarget) return
-    deleteEquipment(deleteTarget.id)
+    deleteMutation.mutate(deleteTarget.id)
     setDeleteTarget(null)
-    toast('Equipment deleted.')
   }
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' && name.trim()) {
       handleCreate()
     }
+  }
+
+  if (isLoading) {
+    return (
+      <>
+        <PageHeader title="Equipment" />
+        <p className="text-text-secondary text-sm">Loading...</p>
+      </>
+    )
   }
 
   return (
@@ -76,11 +110,7 @@ export function EquipmentPage() {
       ) : (
         <div className="flex flex-col gap-2.5">
           {equipment.map(eq => {
-            const usage = equipmentUsageCount(exercises, eq.id)
-            const inUse = usage > 0
-            const ariaLabel = inUse
-              ? `${eq.name} in use by ${usage} exercises`
-              : `Delete ${eq.name}`
+            const canDelete = !eq.isSystem
             return (
               <Card key={eq.id} className="p-4 flex items-center gap-3">
                 <span
@@ -100,17 +130,15 @@ export function EquipmentPage() {
                 </Badge>
                 <button
                   onClick={() => {
-                    if (!inUse) setDeleteTarget(eq)
+                    if (canDelete) setDeleteTarget(eq)
                   }}
-                  disabled={inUse}
+                  disabled={!canDelete}
                   title={
-                    inUse
-                      ? `${eq.name} in use by ${usage} exercise${usage === 1 ? '' : 's'} and cannot be deleted.`
-                      : 'Delete equipment'
+                    eq.isSystem ? 'System equipment types cannot be deleted.' : 'Delete equipment'
                   }
-                  aria-label={ariaLabel}
+                  aria-label={eq.isSystem ? `${eq.name} is a system type` : `Delete ${eq.name}`}
                   className={`h-10 w-10 flex items-center justify-center rounded-lg shrink-0 transition-colors ${
-                    inUse
+                    !canDelete
                       ? 'text-text-muted opacity-50 cursor-not-allowed'
                       : 'text-text-muted hover:text-destructive hover:bg-surface-muted'
                   }`}

--- a/resources/js/pages/profile.tsx
+++ b/resources/js/pages/profile.tsx
@@ -1,14 +1,25 @@
+import type { ReactNode } from 'react'
 import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { isAxiosError } from 'axios'
 import { LogOut } from 'lucide-react'
 import { PageHeader } from '@/components/ui/page-header'
 import { Avatar } from '@/components/ui/avatar'
 import { Card } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { SegmentedControl } from '@/components/ui/segmented-control'
+import { useAuth } from '@/hooks/use-auth'
 import { useApp } from '@/lib/use-app'
+import { updateProfile } from '@/api/user'
 
-function Row({ label, children }: { label: string; children: React.ReactNode }) {
+function applyTheme(theme: string) {
+  let resolved = theme
+  if (theme === 'system') {
+    resolved = window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  }
+  document.documentElement.classList.toggle('dark', resolved === 'dark')
+}
+
+function Row({ label, children }: { label: string; children: ReactNode }) {
   return (
     <div className="flex items-center justify-between gap-3 py-3 border-b border-border last:border-0">
       <span className="text-sm text-text-secondary shrink-0">{label}</span>
@@ -18,29 +29,79 @@ function Row({ label, children }: { label: string; children: React.ReactNode }) 
 }
 
 export function ProfilePage() {
-  const navigate = useNavigate()
-  const { user, updateUser, logout, toast } = useApp()
-  const [first, setFirst] = useState(user.firstName)
-  const [last, setLast] = useState(user.lastName)
-  const [email, setEmail] = useState(user.email)
+  const { user, setUser, handleLogout } = useAuth()
+  const { toast } = useApp()
+  const [first, setFirst] = useState(user?.firstName ?? '')
+  const [last, setLast] = useState(user?.lastName ?? '')
+  const [email, setEmail] = useState(user?.email ?? '')
   const [password, setPassword] = useState({ current: '', next: '', confirm: '' })
+  const [saving, setSaving] = useState(false)
+  const [passwordError, setPasswordError] = useState('')
+
+  if (!user) return null
 
   const isDirty = first !== user.firstName || last !== user.lastName || email !== user.email
 
-  const handleSaveInfo = () => {
-    updateUser({ firstName: first, lastName: last, email })
-    toast('Profile saved.')
+  const handleSaveInfo = async () => {
+    setSaving(true)
+    try {
+      const updated = await updateProfile({
+        first_name: first,
+        last_name: last,
+        email,
+      })
+      setUser(updated)
+      toast('Profile saved.')
+    } catch (err) {
+      if (isAxiosError(err) && err.response?.status === 422) {
+        const fieldErrors = err.response.data?.errors as Record<string, string[]> | undefined
+        const msg = fieldErrors ? Object.values(fieldErrors).flat()[0] : 'Could not save.'
+        toast(msg ?? 'Could not save.')
+      } else {
+        toast('Could not save. Try again.')
+      }
+    } finally {
+      setSaving(false)
+    }
   }
 
-  const handleChangePassword = () => {
+  const handleChangePassword = async () => {
     if (!password.current || !password.next || password.next !== password.confirm) return
-    setPassword({ current: '', next: '', confirm: '' })
-    toast('Password changed.')
+    setPasswordError('')
+    setSaving(true)
+    try {
+      await updateProfile({
+        current_password: password.current,
+        password: password.next,
+        password_confirmation: password.confirm,
+      })
+      setPassword({ current: '', next: '', confirm: '' })
+      toast('Password changed.')
+    } catch (err) {
+      if (isAxiosError(err) && err.response?.status === 422) {
+        const fieldErrors = err.response.data?.errors as Record<string, string[]> | undefined
+        setPasswordError(
+          fieldErrors?.current_password?.[0] ??
+            fieldErrors?.password?.[0] ??
+            'Could not change password.'
+        )
+      } else {
+        setPasswordError('Could not change password. Try again.')
+      }
+    } finally {
+      setSaving(false)
+    }
   }
 
-  const handleLogout = () => {
-    logout()
-    navigate('/login')
+  const handlePreferenceChange = async (field: string, value: string) => {
+    if (field === 'theme') applyTheme(value)
+    try {
+      const updated = await updateProfile({ [field]: value })
+      setUser(updated)
+      toast(field === 'theme' ? 'Theme updated.' : 'Measurement system updated.')
+    } catch {
+      toast('Could not save preference. Try again.')
+    }
   }
 
   const fullName = `${user.firstName} ${user.lastName}`
@@ -48,7 +109,7 @@ export function ProfilePage() {
 
   return (
     <>
-      <PageHeader back onBack={() => navigate('/workouts')} title="Profile" />
+      <PageHeader title="Profile" />
 
       <div className="flex items-center gap-3 mb-6">
         <Avatar name={fullName} size={56} />
@@ -83,7 +144,7 @@ export function ProfilePage() {
         </Row>
         {isDirty && (
           <div className="py-3">
-            <Button size="sm" onClick={handleSaveInfo}>
+            <Button size="sm" onClick={handleSaveInfo} disabled={saving}>
               Save Changes
             </Button>
           </div>
@@ -96,10 +157,7 @@ export function ProfilePage() {
           <div className="text-sm font-medium mb-2">Measurement system</div>
           <SegmentedControl
             value={user.measurementSystem}
-            onChange={v => {
-              updateUser({ measurementSystem: v as 'imperial' | 'metric' })
-              toast('Measurement system updated.')
-            }}
+            onChange={v => handlePreferenceChange('measurement_system', v)}
             options={[
               { value: 'imperial', label: 'Imperial (lb, mi)' },
               { value: 'metric', label: 'Metric (kg, km)' },
@@ -110,10 +168,7 @@ export function ProfilePage() {
           <div className="text-sm font-medium mb-2">Theme</div>
           <SegmentedControl
             value={user.theme}
-            onChange={v => {
-              updateUser({ theme: v as 'light' | 'dark' | 'system' })
-              toast('Theme updated.')
-            }}
+            onChange={v => handlePreferenceChange('theme', v)}
             options={[
               { value: 'light', label: 'Light' },
               { value: 'dark', label: 'Dark' },
@@ -125,6 +180,7 @@ export function ProfilePage() {
 
       <h2 className="label-caps text-text-secondary mb-2">Security</h2>
       <Card className="px-4 mb-6">
+        {passwordError && <p className="text-destructive text-xs pt-3">{passwordError}</p>}
         <Row label="Current">
           <input
             type="password"
@@ -156,7 +212,7 @@ export function ProfilePage() {
           <Button
             size="sm"
             variant="secondary"
-            disabled={!canChangePassword}
+            disabled={!canChangePassword || saving}
             onClick={handleChangePassword}
           >
             Change Password


### PR DESCRIPTION
## Problem

The React prototype from Phase 3 had all UI pages built but backed by in-memory fixture data. Auth was a boolean toggle, profile edits vanished on refresh, and the equipment page operated against a hardcoded array. None of it talked to the API built in Phase 4a.

## Solution

Added an API client layer (Axios with Bearer token interceptor, 401 auto-redirect) and an AuthProvider that manages the JWT in localStorage and loads the user profile on mount. Login, register, password reset request, and password reset form pages now call the real endpoints and display validation errors from 422 responses. The equipment page uses TanStack Query for listing, creating, and deleting equipment types, with the server-side 409 guard surfaced via toast. The profile page persists name, email, measurement system, theme, and password changes through the user API. The shell reads the authenticated user for the nav avatar and name display.

Key files:
- `api/client.ts`, `api/auth.ts`, `api/user.ts`, `api/equipment.ts` for the HTTP layer
- `lib/auth-provider.tsx` + `hooks/use-auth.ts` for auth state
- `api/transformers.ts` for snake_case to camelCase response mapping
- `pages/auth.tsx`, `pages/equipment.tsx`, `pages/profile.tsx` for the wired pages

AppProvider and all fixture-backed hooks remain intact for workouts, exercises, templates, and progress pages (wired in later phases).
