### PR TITLE
PS-59 - Adding exercise definitions API with CTI models, policy, and CRUD endpoints

### DIFF
--- a/app/Enums/DistanceUnit.php
+++ b/app/Enums/DistanceUnit.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum DistanceUnit: string
+{
+    case Meters = 'meters';
+    case Kilometers = 'kilometers';
+    case Miles = 'miles';
+    case Yards = 'yards';
+}

--- a/app/Enums/ExerciseType.php
+++ b/app/Enums/ExerciseType.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum ExerciseType: string
+{
+    case Resistance = 'resistance';
+    case TimedHold = 'timed_hold';
+    case Distance = 'distance';
+    case Interval = 'interval';
+}

--- a/app/Http/Controllers/Api/V1/ExerciseController.php
+++ b/app/Http/Controllers/Api/V1/ExerciseController.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Enums\ExerciseType;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\StoreExerciseRequest;
+use App\Http\Requests\Api\V1\UpdateExerciseRequest;
+use App\Http\Resources\Api\V1\ExerciseResource;
+use App\Models\Exercise;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\DB;
+
+class ExerciseController extends Controller
+{
+    use AuthorizesRequests;
+
+    private const EAGER_LOAD = ['resistance', 'timedHold', 'distance', 'interval', 'equipmentType'];
+
+    public function index(Request $request): AnonymousResourceCollection
+    {
+        $query = Exercise::where(function ($q) use ($request) {
+            $q->whereNull('user_id')
+                ->orWhere('user_id', $request->user()->id);
+        });
+
+        if ($request->has('type')) {
+            $query->where('type', $request->input('type'));
+        }
+
+        if ($request->has('equipment_type_id')) {
+            $query->where('equipment_type_id', $request->input('equipment_type_id'));
+        }
+
+        if ($request->filled('search')) {
+            $query->where('name', 'like', '%'.$request->input('search').'%');
+        }
+
+        $exercises = $query
+            ->with(self::EAGER_LOAD)
+            ->orderBy('name')
+            ->get();
+
+        return ExerciseResource::collection($exercises);
+    }
+
+    public function store(StoreExerciseRequest $request): JsonResponse
+    {
+        $exercise = DB::transaction(function () use ($request) {
+            $exercise = Exercise::create([
+                'name' => $request->validated('name'),
+                'type' => $request->validated('type'),
+                'user_id' => $request->user()->id,
+                'equipment_type_id' => $request->validated('equipment_type_id'),
+                'notes' => $request->validated('notes'),
+            ]);
+
+            $typeAttributes = $request->validated('type_attributes') ?? [];
+
+            $childRelation = match ($exercise->type) {
+                ExerciseType::Resistance => 'resistance',
+                ExerciseType::TimedHold => 'timedHold',
+                ExerciseType::Distance => 'distance',
+                ExerciseType::Interval => 'interval',
+            };
+
+            $exercise->$childRelation()->create($typeAttributes);
+
+            return $exercise;
+        });
+
+        $exercise->load(self::EAGER_LOAD);
+
+        return (new ExerciseResource($exercise))
+            ->response()
+            ->setStatusCode(201);
+    }
+
+    public function show(Exercise $exercise): ExerciseResource
+    {
+        $this->authorize('view', $exercise);
+
+        $exercise->load(self::EAGER_LOAD);
+
+        return new ExerciseResource($exercise);
+    }
+
+    public function update(UpdateExerciseRequest $request, Exercise $exercise): ExerciseResource
+    {
+        $this->authorize('update', $exercise);
+
+        DB::transaction(function () use ($request, $exercise) {
+            $exercise->update($request->safe()->only(['name', 'equipment_type_id', 'notes']));
+
+            $validated = $request->validated();
+            if (isset($validated['type_attributes'])) {
+                $childRelation = match ($exercise->type) {
+                    ExerciseType::Resistance => 'resistance',
+                    ExerciseType::TimedHold => 'timedHold',
+                    ExerciseType::Distance => 'distance',
+                    ExerciseType::Interval => 'interval',
+                };
+                $exercise->$childRelation->update($validated['type_attributes']);
+            }
+        });
+
+        $exercise->load(self::EAGER_LOAD);
+
+        return new ExerciseResource($exercise);
+    }
+
+    public function destroy(Exercise $exercise): Response
+    {
+        $this->authorize('delete', $exercise);
+
+        $exercise->delete();
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Requests/Api/V1/StoreExerciseRequest.php
+++ b/app/Http/Requests/Api/V1/StoreExerciseRequest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use App\Enums\DistanceUnit;
+use App\Enums\ExerciseType;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreExerciseRequest extends FormRequest
+{
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        $rules = [
+            'name' => [
+                'required',
+                'string',
+                'max:255',
+                Rule::unique('exercises')->where('user_id', $this->user()->id),
+            ],
+            'type' => ['required', Rule::enum(ExerciseType::class)],
+            'equipment_type_id' => [
+                'nullable',
+                'integer',
+                Rule::exists('equipment_types', 'id')->where(function ($query) {
+                    $query->where('is_system', true)
+                        ->orWhere('user_id', $this->user()->id);
+                }),
+            ],
+            'notes' => ['nullable', 'string'],
+            'type_attributes' => ['sometimes', 'array'],
+        ];
+
+        return array_merge($rules, $this->typeSpecificRules());
+    }
+
+    /** @return array<string, mixed> */
+    private function typeSpecificRules(): array
+    {
+        return match ($this->input('type')) {
+            'resistance' => [
+                'type_attributes.bodyweight_base' => ['boolean'],
+                'type_attributes.allows_added_weight' => ['boolean'],
+                'type_attributes.bilateral' => ['boolean'],
+            ],
+            'timed_hold' => [
+                'type_attributes.target_duration_seconds' => ['nullable', 'integer', 'min:1'],
+            ],
+            'distance' => [
+                'type_attributes.distance_unit' => ['required', Rule::enum(DistanceUnit::class)],
+                'type_attributes.tracks_elevation' => ['boolean'],
+            ],
+            'interval' => [
+                'type_attributes.default_work_seconds' => ['nullable', 'integer', 'min:1'],
+                'type_attributes.default_rest_seconds' => ['nullable', 'integer', 'min:1'],
+                'type_attributes.default_rounds' => ['nullable', 'integer', 'min:1'],
+            ],
+            default => [],
+        };
+    }
+}

--- a/app/Http/Requests/Api/V1/UpdateExerciseRequest.php
+++ b/app/Http/Requests/Api/V1/UpdateExerciseRequest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use App\Enums\DistanceUnit;
+use App\Enums\ExerciseType;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateExerciseRequest extends FormRequest
+{
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        $exercise = $this->route('exercise');
+
+        $rules = [
+            'name' => [
+                'required',
+                'string',
+                'max:255',
+                Rule::unique('exercises')
+                    ->where('user_id', $this->user()->id)
+                    ->ignore($exercise),
+            ],
+            'equipment_type_id' => [
+                'nullable',
+                'integer',
+                Rule::exists('equipment_types', 'id')->where(function ($query) {
+                    $query->where('is_system', true)
+                        ->orWhere('user_id', $this->user()->id);
+                }),
+            ],
+            'notes' => ['nullable', 'string'],
+            'type_attributes' => ['sometimes', 'array'],
+        ];
+
+        return array_merge($rules, $this->typeSpecificRules($exercise->type));
+    }
+
+    /** @return array<string, mixed> */
+    private function typeSpecificRules(ExerciseType $type): array
+    {
+        return match ($type) {
+            ExerciseType::Resistance => [
+                'type_attributes.bodyweight_base' => ['boolean'],
+                'type_attributes.allows_added_weight' => ['boolean'],
+                'type_attributes.bilateral' => ['boolean'],
+            ],
+            ExerciseType::TimedHold => [
+                'type_attributes.target_duration_seconds' => ['nullable', 'integer', 'min:1'],
+            ],
+            ExerciseType::Distance => [
+                'type_attributes.distance_unit' => [Rule::enum(DistanceUnit::class)],
+                'type_attributes.tracks_elevation' => ['boolean'],
+            ],
+            ExerciseType::Interval => [
+                'type_attributes.default_work_seconds' => ['nullable', 'integer', 'min:1'],
+                'type_attributes.default_rest_seconds' => ['nullable', 'integer', 'min:1'],
+                'type_attributes.default_rounds' => ['nullable', 'integer', 'min:1'],
+            ],
+        };
+    }
+}

--- a/app/Http/Resources/Api/V1/ExerciseResource.php
+++ b/app/Http/Resources/Api/V1/ExerciseResource.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Enums\ExerciseType;
+use App\Models\Exercise;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin Exercise */
+class ExerciseResource extends JsonResource
+{
+    /** @return array<string, mixed> */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'type' => $this->type,
+            'notes' => $this->notes,
+            'user_id' => $this->user_id,
+            'equipment_type_id' => $this->equipment_type_id,
+            'equipment_type' => $this->whenLoaded('equipmentType', fn () => new EquipmentTypeResource($this->equipmentType)),
+            'type_attributes' => $this->typeAttributes(),
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+
+    /** @return array<string, mixed>|null */
+    private function typeAttributes(): ?array
+    {
+        $child = match ($this->type) {
+            ExerciseType::Resistance => $this->resistance,
+            ExerciseType::TimedHold => $this->timedHold,
+            ExerciseType::Distance => $this->distance,
+            ExerciseType::Interval => $this->interval,
+        };
+
+        if ($child === null) {
+            return null;
+        }
+
+        return collect($child->toArray())
+            ->except(['id', 'exercise_id', 'created_at', 'updated_at'])
+            ->all();
+    }
+}

--- a/app/Models/Exercise.php
+++ b/app/Models/Exercise.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\ExerciseType;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+/** @property ExerciseType $type */
+class Exercise extends Model
+{
+    /** @var list<string> */
+    protected $fillable = [
+        'name',
+        'type',
+        'user_id',
+        'equipment_type_id',
+        'notes',
+    ];
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'type' => ExerciseType::class,
+        ];
+    }
+
+    /** @return BelongsTo<User, $this> */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /** @return BelongsTo<EquipmentType, $this> */
+    public function equipmentType(): BelongsTo
+    {
+        return $this->belongsTo(EquipmentType::class);
+    }
+
+    /** @return HasOne<ExerciseResistance, $this> */
+    public function resistance(): HasOne
+    {
+        return $this->hasOne(ExerciseResistance::class);
+    }
+
+    /** @return HasOne<ExerciseTimedHold, $this> */
+    public function timedHold(): HasOne
+    {
+        return $this->hasOne(ExerciseTimedHold::class);
+    }
+
+    /** @return HasOne<ExerciseDistance, $this> */
+    public function distance(): HasOne
+    {
+        return $this->hasOne(ExerciseDistance::class);
+    }
+
+    /** @return HasOne<ExerciseInterval, $this> */
+    public function interval(): HasOne
+    {
+        return $this->hasOne(ExerciseInterval::class);
+    }
+}

--- a/app/Models/ExerciseDistance.php
+++ b/app/Models/ExerciseDistance.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\DistanceUnit;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ExerciseDistance extends Model
+{
+    protected $table = 'exercise_distance';
+
+    /** @var list<string> */
+    protected $fillable = [
+        'distance_unit',
+        'tracks_elevation',
+    ];
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'distance_unit' => DistanceUnit::class,
+            'tracks_elevation' => 'boolean',
+        ];
+    }
+
+    /** @return BelongsTo<Exercise, $this> */
+    public function exercise(): BelongsTo
+    {
+        return $this->belongsTo(Exercise::class);
+    }
+}

--- a/app/Models/ExerciseInterval.php
+++ b/app/Models/ExerciseInterval.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ExerciseInterval extends Model
+{
+    protected $table = 'exercise_interval';
+
+    /** @var list<string> */
+    protected $fillable = [
+        'default_work_seconds',
+        'default_rest_seconds',
+        'default_rounds',
+    ];
+
+    /** @return BelongsTo<Exercise, $this> */
+    public function exercise(): BelongsTo
+    {
+        return $this->belongsTo(Exercise::class);
+    }
+}

--- a/app/Models/ExerciseResistance.php
+++ b/app/Models/ExerciseResistance.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ExerciseResistance extends Model
+{
+    protected $table = 'exercise_resistance';
+
+    /** @var list<string> */
+    protected $fillable = [
+        'bodyweight_base',
+        'allows_added_weight',
+        'bilateral',
+    ];
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'bodyweight_base' => 'boolean',
+            'allows_added_weight' => 'boolean',
+            'bilateral' => 'boolean',
+        ];
+    }
+
+    /** @return BelongsTo<Exercise, $this> */
+    public function exercise(): BelongsTo
+    {
+        return $this->belongsTo(Exercise::class);
+    }
+}

--- a/app/Models/ExerciseTimedHold.php
+++ b/app/Models/ExerciseTimedHold.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ExerciseTimedHold extends Model
+{
+    protected $table = 'exercise_timed_hold';
+
+    /** @var list<string> */
+    protected $fillable = [
+        'target_duration_seconds',
+    ];
+
+    /** @return BelongsTo<Exercise, $this> */
+    public function exercise(): BelongsTo
+    {
+        return $this->belongsTo(Exercise::class);
+    }
+}

--- a/app/Policies/ExercisePolicy.php
+++ b/app/Policies/ExercisePolicy.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\Exercise;
+use App\Models\User;
+use Illuminate\Auth\Access\Response;
+
+class ExercisePolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    public function view(User $user, Exercise $exercise): bool
+    {
+        return $exercise->user_id === null || $exercise->user_id === $user->id;
+    }
+
+    public function create(User $user): bool
+    {
+        return true;
+    }
+
+    public function update(User $user, Exercise $exercise): Response
+    {
+        if ($exercise->user_id === null) {
+            return Response::deny('System exercises cannot be modified.');
+        }
+
+        return $exercise->user_id === $user->id
+            ? Response::allow()
+            : Response::deny();
+    }
+
+    public function delete(User $user, Exercise $exercise): Response
+    {
+        if ($exercise->user_id === null) {
+            return Response::deny('System exercises cannot be deleted.');
+        }
+
+        return $exercise->user_id === $user->id
+            ? Response::allow()
+            : Response::deny();
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Api\V1\Auth\LogoutController;
 use App\Http\Controllers\Api\V1\Auth\RegisterController;
 use App\Http\Controllers\Api\V1\Auth\ResetPasswordController;
 use App\Http\Controllers\Api\V1\EquipmentTypeController;
+use App\Http\Controllers\Api\V1\ExerciseController;
 use App\Http\Controllers\Api\V1\UserController;
 use Illuminate\Support\Facades\Route;
 
@@ -21,4 +22,5 @@ Route::middleware('auth:api')->group(function () {
     Route::get('/user', [UserController::class, 'show']);
     Route::put('/user', [UserController::class, 'update']);
     Route::apiResource('equipment-types', EquipmentTypeController::class);
+    Route::apiResource('exercises', ExerciseController::class);
 });

--- a/tests/Feature/Api/V1/ExerciseTest.php
+++ b/tests/Feature/Api/V1/ExerciseTest.php
@@ -1,0 +1,409 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Models\EquipmentType;
+use App\Models\Exercise;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+class ExerciseTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createExercise(
+        ?User $user,
+        string $type = 'resistance',
+        array $overrides = [],
+        array $typeAttributes = [],
+    ): Exercise {
+        $exercise = Exercise::create(array_merge([
+            'name' => 'Test Exercise',
+            'type' => $type,
+            'user_id' => $user?->id,
+        ], $overrides));
+
+        $defaults = match ($type) {
+            'resistance' => [],
+            'timed_hold' => [],
+            'distance' => ['distance_unit' => 'meters'],
+            'interval' => [],
+        };
+
+        $childRelation = match ($type) {
+            'resistance' => 'resistance',
+            'timed_hold' => 'timedHold',
+            'distance' => 'distance',
+            'interval' => 'interval',
+        };
+
+        $exercise->$childRelation()->create(array_merge($defaults, $typeAttributes));
+
+        return $exercise;
+    }
+
+    // -- Index --
+
+    public function test_lists_system_and_own_exercises(): void
+    {
+        $user = User::factory()->create();
+        $other = User::factory()->create();
+
+        $this->createExercise(null, 'resistance', ['name' => 'System Bench Press']);
+        $this->createExercise($user, 'resistance', ['name' => 'My Custom Exercise']);
+        $this->createExercise($other, 'resistance', ['name' => 'Other User Exercise']);
+
+        Passport::actingAs($user);
+
+        $response = $this->getJson('/api/v1/exercises');
+
+        $response->assertOk();
+
+        $names = collect($response->json('data'))->pluck('name');
+        $this->assertTrue($names->contains('System Bench Press'));
+        $this->assertTrue($names->contains('My Custom Exercise'));
+        $this->assertFalse($names->contains('Other User Exercise'));
+    }
+
+    public function test_filters_exercises_by_type(): void
+    {
+        $user = User::factory()->create();
+        $this->createExercise(null, 'resistance', ['name' => 'Bench Press']);
+        $this->createExercise(null, 'distance', ['name' => 'Treadmill Run']);
+
+        Passport::actingAs($user);
+
+        $response = $this->getJson('/api/v1/exercises?type=resistance');
+
+        $response->assertOk();
+        $names = collect($response->json('data'))->pluck('name');
+        $this->assertTrue($names->contains('Bench Press'));
+        $this->assertFalse($names->contains('Treadmill Run'));
+    }
+
+    public function test_filters_exercises_by_equipment_type(): void
+    {
+        $barbell = EquipmentType::create(['name' => 'barbell', 'user_id' => null, 'is_system' => true]);
+        $dumbbell = EquipmentType::create(['name' => 'dumbbell', 'user_id' => null, 'is_system' => true]);
+
+        $user = User::factory()->create();
+        $this->createExercise(null, 'resistance', ['name' => 'Barbell Curl', 'equipment_type_id' => $barbell->id]);
+        $this->createExercise(null, 'resistance', ['name' => 'Dumbbell Curl', 'equipment_type_id' => $dumbbell->id]);
+
+        Passport::actingAs($user);
+
+        $response = $this->getJson("/api/v1/exercises?equipment_type_id={$barbell->id}");
+
+        $response->assertOk();
+        $names = collect($response->json('data'))->pluck('name');
+        $this->assertTrue($names->contains('Barbell Curl'));
+        $this->assertFalse($names->contains('Dumbbell Curl'));
+    }
+
+    public function test_searches_exercises_by_name(): void
+    {
+        $user = User::factory()->create();
+        $this->createExercise(null, 'resistance', ['name' => 'Bench Press']);
+        $this->createExercise(null, 'resistance', ['name' => 'Deadlift']);
+
+        Passport::actingAs($user);
+
+        $response = $this->getJson('/api/v1/exercises?search=bench');
+
+        $response->assertOk();
+        $names = collect($response->json('data'))->pluck('name');
+        $this->assertTrue($names->contains('Bench Press'));
+        $this->assertFalse($names->contains('Deadlift'));
+    }
+
+    // -- Show --
+
+    public function test_shows_exercise_with_type_attributes(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise(null, 'resistance', ['name' => 'Pull-up'], [
+            'bodyweight_base' => true,
+            'allows_added_weight' => true,
+            'bilateral' => true,
+        ]);
+
+        Passport::actingAs($user);
+
+        $response = $this->getJson("/api/v1/exercises/{$exercise->id}");
+
+        $response->assertOk()
+            ->assertJsonPath('data.name', 'Pull-up')
+            ->assertJsonPath('data.type', 'resistance')
+            ->assertJsonPath('data.type_attributes.bodyweight_base', true)
+            ->assertJsonPath('data.type_attributes.allows_added_weight', true)
+            ->assertJsonPath('data.type_attributes.bilateral', true);
+    }
+
+    public function test_cannot_view_other_users_exercise(): void
+    {
+        $owner = User::factory()->create();
+        $exercise = $this->createExercise($owner, 'resistance', ['name' => 'Secret Exercise']);
+
+        Passport::actingAs(User::factory()->create());
+
+        $this->getJson("/api/v1/exercises/{$exercise->id}")
+            ->assertStatus(403);
+    }
+
+    // -- Store --
+
+    public static function exerciseTypeProvider(): array
+    {
+        return [
+            'resistance' => [
+                'resistance',
+                ['bodyweight_base' => true, 'allows_added_weight' => true, 'bilateral' => false],
+            ],
+            'timed_hold' => [
+                'timed_hold',
+                ['target_duration_seconds' => 60],
+            ],
+            'distance' => [
+                'distance',
+                ['distance_unit' => 'miles', 'tracks_elevation' => true],
+            ],
+            'interval' => [
+                'interval',
+                ['default_work_seconds' => 30, 'default_rest_seconds' => 15, 'default_rounds' => 8],
+            ],
+        ];
+    }
+
+    #[DataProvider('exerciseTypeProvider')]
+    public function test_creates_exercise_for_each_cti_type(string $type, array $typeAttributes): void
+    {
+        $user = User::factory()->create();
+        Passport::actingAs($user);
+
+        $response = $this->postJson('/api/v1/exercises', [
+            'name' => "Test {$type} exercise",
+            'type' => $type,
+            'type_attributes' => $typeAttributes,
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.type', $type)
+            ->assertJsonPath('data.name', "Test {$type} exercise")
+            ->assertJsonPath('data.user_id', $user->id);
+
+        $this->assertDatabaseHas('exercises', [
+            'name' => "Test {$type} exercise",
+            'type' => $type,
+            'user_id' => $user->id,
+        ]);
+
+        $exerciseId = $response->json('data.id');
+        $childTable = match ($type) {
+            'resistance' => 'exercise_resistance',
+            'timed_hold' => 'exercise_timed_hold',
+            'distance' => 'exercise_distance',
+            'interval' => 'exercise_interval',
+        };
+        $this->assertDatabaseHas($childTable, ['exercise_id' => $exerciseId]);
+
+        foreach ($typeAttributes as $key => $value) {
+            $response->assertJsonPath("data.type_attributes.{$key}", $value);
+        }
+    }
+
+    public function test_creates_resistance_with_defaults_when_no_attributes(): void
+    {
+        $user = User::factory()->create();
+        Passport::actingAs($user);
+
+        $response = $this->postJson('/api/v1/exercises', [
+            'name' => 'Basic Push-up',
+            'type' => 'resistance',
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.type_attributes.bodyweight_base', false)
+            ->assertJsonPath('data.type_attributes.allows_added_weight', false)
+            ->assertJsonPath('data.type_attributes.bilateral', true);
+    }
+
+    public function test_creates_exercise_with_equipment_type(): void
+    {
+        $barbell = EquipmentType::create(['name' => 'barbell', 'user_id' => null, 'is_system' => true]);
+        $user = User::factory()->create();
+        Passport::actingAs($user);
+
+        $response = $this->postJson('/api/v1/exercises', [
+            'name' => 'Barbell Squat',
+            'type' => 'resistance',
+            'equipment_type_id' => $barbell->id,
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.equipment_type_id', $barbell->id)
+            ->assertJsonPath('data.equipment_type.name', 'barbell');
+    }
+
+    public function test_allows_same_name_as_system_exercise(): void
+    {
+        $this->createExercise(null, 'resistance', ['name' => 'Bench Press']);
+        $user = User::factory()->create();
+        Passport::actingAs($user);
+
+        $this->postJson('/api/v1/exercises', [
+            'name' => 'Bench Press',
+            'type' => 'resistance',
+        ])->assertStatus(201);
+    }
+
+    public function test_rejects_duplicate_name_for_same_user(): void
+    {
+        $user = User::factory()->create();
+        $this->createExercise($user, 'resistance', ['name' => 'My Exercise']);
+        Passport::actingAs($user);
+
+        $this->postJson('/api/v1/exercises', [
+            'name' => 'My Exercise',
+            'type' => 'resistance',
+        ])->assertStatus(422)
+            ->assertJsonValidationErrors('name');
+    }
+
+    public function test_validates_required_fields_for_store(): void
+    {
+        Passport::actingAs(User::factory()->create());
+
+        $this->postJson('/api/v1/exercises', [])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['name', 'type']);
+    }
+
+    public function test_validates_distance_unit_required_for_distance_type(): void
+    {
+        Passport::actingAs(User::factory()->create());
+
+        $this->postJson('/api/v1/exercises', [
+            'name' => 'Run',
+            'type' => 'distance',
+        ])->assertStatus(422)
+            ->assertJsonValidationErrors('type_attributes.distance_unit');
+    }
+
+    public function test_rejects_inaccessible_equipment_type(): void
+    {
+        $otherUser = User::factory()->create();
+        $otherEquipment = EquipmentType::create([
+            'name' => 'Other Gear',
+            'user_id' => $otherUser->id,
+            'is_system' => false,
+        ]);
+
+        Passport::actingAs(User::factory()->create());
+
+        $this->postJson('/api/v1/exercises', [
+            'name' => 'Bad Exercise',
+            'type' => 'resistance',
+            'equipment_type_id' => $otherEquipment->id,
+        ])->assertStatus(422)
+            ->assertJsonValidationErrors('equipment_type_id');
+    }
+
+    // -- Update --
+
+    public function test_updates_own_exercise(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance', ['name' => 'Old Name']);
+        Passport::actingAs($user);
+
+        $this->putJson("/api/v1/exercises/{$exercise->id}", ['name' => 'New Name'])
+            ->assertOk()
+            ->assertJsonPath('data.name', 'New Name');
+    }
+
+    public function test_updates_type_specific_attributes(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance', ['name' => 'Pull-up'], [
+            'bodyweight_base' => false,
+        ]);
+        Passport::actingAs($user);
+
+        $this->putJson("/api/v1/exercises/{$exercise->id}", [
+            'name' => 'Pull-up',
+            'type_attributes' => ['bodyweight_base' => true, 'allows_added_weight' => true],
+        ])->assertOk()
+            ->assertJsonPath('data.type_attributes.bodyweight_base', true)
+            ->assertJsonPath('data.type_attributes.allows_added_weight', true);
+    }
+
+    public function test_cannot_update_system_exercise(): void
+    {
+        $exercise = $this->createExercise(null, 'resistance', ['name' => 'System Exercise']);
+
+        Passport::actingAs(User::factory()->create());
+
+        $this->putJson("/api/v1/exercises/{$exercise->id}", ['name' => 'Renamed'])
+            ->assertStatus(403);
+    }
+
+    public function test_cannot_update_other_users_exercise(): void
+    {
+        $owner = User::factory()->create();
+        $exercise = $this->createExercise($owner, 'resistance', ['name' => 'Their Exercise']);
+
+        Passport::actingAs(User::factory()->create());
+
+        $this->putJson("/api/v1/exercises/{$exercise->id}", ['name' => 'Stolen'])
+            ->assertStatus(403);
+    }
+
+    // -- Destroy --
+
+    public function test_deletes_own_exercise(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance', ['name' => 'To Delete']);
+        Passport::actingAs($user);
+
+        $this->deleteJson("/api/v1/exercises/{$exercise->id}")
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('exercises', ['id' => $exercise->id]);
+        $this->assertDatabaseMissing('exercise_resistance', ['exercise_id' => $exercise->id]);
+    }
+
+    public function test_cannot_delete_system_exercise(): void
+    {
+        $exercise = $this->createExercise(null, 'resistance', ['name' => 'System Exercise']);
+
+        Passport::actingAs(User::factory()->create());
+
+        $this->deleteJson("/api/v1/exercises/{$exercise->id}")
+            ->assertStatus(403);
+    }
+
+    public function test_cannot_delete_other_users_exercise(): void
+    {
+        $owner = User::factory()->create();
+        $exercise = $this->createExercise($owner, 'resistance', ['name' => 'Their Exercise']);
+
+        Passport::actingAs(User::factory()->create());
+
+        $this->deleteJson("/api/v1/exercises/{$exercise->id}")
+            ->assertStatus(403);
+    }
+
+    // -- Auth --
+
+    public function test_unauthenticated_cannot_access_exercises(): void
+    {
+        $this->getJson('/api/v1/exercises')->assertStatus(401);
+        $this->postJson('/api/v1/exercises', ['name' => 'Nope'])->assertStatus(401);
+    }
+}


### PR DESCRIPTION
## Problem

The exercise database schema (base table + 4 CTI child tables) and seed data were created in Phase 2, but there were no Eloquent models, authorization, or API endpoints to interact with them. Users and the frontend had no way to list, create, update, or delete exercises.

## Solution

Added the full Exercise CRUD API using Class Table Inheritance on top of the existing schema.

- `ExerciseType` and `DistanceUnit` backed string enums for type safety
- `Exercise` base model with `hasOne` relationships to 4 CTI child models (`ExerciseResistance`, `ExerciseTimedHold`, `ExerciseDistance`, `ExerciseInterval`), each with an explicit singular `$table` name
- `ExercisePolicy` enforcing per-user data isolation: system exercises (null `user_id`) are readable by all but block modification; user exercises are owner-only
- `ExerciseResource` with a `typeAttributes()` helper that extracts the matching CTI child's fields into a nested `type_attributes` key
- `StoreExerciseRequest` and `UpdateExerciseRequest` with conditional validation rules per exercise type (e.g., `distance_unit` required for distance exercises)
- `ExerciseController` with index filtering (type, equipment, name search), transactional store/update for base + child rows, and policy-gated show/update/destroy
- `apiResource` route registered inside the `auth:api` middleware group
- 25 feature tests covering all endpoints, authorization boundaries, validation, and all 4 exercise types via a data provider
