### PR TITLE
PS-61 - Adding workouts, entries, and composable metrics API with CRUD endpoints

### DIFF
--- a/app/Http/Controllers/Api/V1/ExerciseController.php
+++ b/app/Http/Controllers/Api/V1/ExerciseController.php
@@ -115,9 +115,18 @@ class ExerciseController extends Controller
         return new ExerciseResource($exercise);
     }
 
-    public function destroy(Exercise $exercise): Response
+    public function destroy(Exercise $exercise): Response|JsonResponse
     {
         $this->authorize('delete', $exercise);
+
+        $inUse = DB::table('exercise_workout')->where('exercise_id', $exercise->id)->exists()
+            || DB::table('workout_entries')->where('exercise_id', $exercise->id)->exists();
+
+        if ($inUse) {
+            return response()->json([
+                'message' => 'Exercise is in use by workouts.',
+            ], 409);
+        }
 
         $exercise->delete();
 

--- a/app/Http/Controllers/Api/V1/WorkoutController.php
+++ b/app/Http/Controllers/Api/V1/WorkoutController.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\StoreWorkoutRequest;
+use App\Http\Requests\Api\V1\UpdateWorkoutRequest;
+use App\Http\Resources\Api\V1\WorkoutListResource;
+use App\Http\Resources\Api\V1\WorkoutResource;
+use App\Models\Workout;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\Response;
+
+class WorkoutController extends Controller
+{
+    use AuthorizesRequests;
+
+    private const SHOW_EAGER_LOAD = [
+        'exercises',
+        'entries.exercise',
+        'entries.loadMetric',
+        'entries.repMetric',
+        'entries.durationMetric',
+        'entries.distanceMetric',
+        'entries.cardioSetting',
+        'entries.intervalHeader.rounds',
+        'entries.intensityMetric',
+    ];
+
+    public function index(Request $request): AnonymousResourceCollection
+    {
+        $workouts = Workout::where('user_id', $request->user()->id)
+            ->with('exercises')
+            ->latest('date')
+            ->paginate(15);
+
+        return WorkoutListResource::collection($workouts);
+    }
+
+    public function store(StoreWorkoutRequest $request): JsonResponse
+    {
+        $workout = Workout::create([
+            'name' => $request->validated('name'),
+            'user_id' => $request->user()->id,
+            'date' => $request->validated('date'),
+            'exhaustion' => $request->validated('exhaustion'),
+            'soreness' => $request->validated('soreness'),
+        ]);
+
+        $workout->load(self::SHOW_EAGER_LOAD);
+
+        return (new WorkoutResource($workout))
+            ->response()
+            ->setStatusCode(201);
+    }
+
+    public function show(Workout $workout): WorkoutResource
+    {
+        $this->authorize('view', $workout);
+
+        $workout->load(self::SHOW_EAGER_LOAD);
+
+        return new WorkoutResource($workout);
+    }
+
+    public function update(UpdateWorkoutRequest $request, Workout $workout): WorkoutResource
+    {
+        $this->authorize('update', $workout);
+
+        $workout->update($request->validated());
+        $workout->load(self::SHOW_EAGER_LOAD);
+
+        return new WorkoutResource($workout);
+    }
+
+    public function destroy(Workout $workout): Response
+    {
+        $this->authorize('delete', $workout);
+
+        $workout->delete();
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/Api/V1/WorkoutEntryController.php
+++ b/app/Http/Controllers/Api/V1/WorkoutEntryController.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\ReorderRequest;
+use App\Http\Requests\Api\V1\StoreWorkoutEntryRequest;
+use App\Http\Requests\Api\V1\UpdateWorkoutEntryRequest;
+use App\Http\Resources\Api\V1\WorkoutEntryResource;
+use App\Models\Workout;
+use App\Models\WorkoutEntry;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\DB;
+
+class WorkoutEntryController extends Controller
+{
+    use AuthorizesRequests;
+
+    private const METRIC_EAGER_LOAD = [
+        'loadMetric',
+        'repMetric',
+        'durationMetric',
+        'distanceMetric',
+        'cardioSetting',
+        'intervalHeader.rounds',
+        'intensityMetric',
+    ];
+
+    public function index(Request $request, Workout $workout): AnonymousResourceCollection
+    {
+        $this->authorize('view', $workout);
+
+        $entries = $workout->entries()
+            ->with(self::METRIC_EAGER_LOAD)
+            ->orderBy('set_order')
+            ->get();
+
+        return WorkoutEntryResource::collection($entries);
+    }
+
+    public function store(StoreWorkoutEntryRequest $request, Workout $workout): JsonResponse
+    {
+        $this->authorize('update', $workout);
+
+        $entry = DB::transaction(function () use ($request, $workout) {
+            $entry = $workout->entries()->create([
+                'exercise_id' => $request->validated('exercise_id'),
+                'set_order' => $request->validated('set_order'),
+                'notes' => $request->validated('notes'),
+            ]);
+
+            $metrics = $request->validated('metrics') ?? [];
+            if ($metrics) {
+                $this->syncMetrics($entry, $metrics);
+            }
+
+            return $entry;
+        });
+
+        $entry->load(self::METRIC_EAGER_LOAD);
+
+        return (new WorkoutEntryResource($entry))
+            ->response()
+            ->setStatusCode(201);
+    }
+
+    public function show(Workout $workout, WorkoutEntry $entry): WorkoutEntryResource
+    {
+        $this->authorize('view', $workout);
+
+        $entry->load(self::METRIC_EAGER_LOAD);
+
+        return new WorkoutEntryResource($entry);
+    }
+
+    public function update(UpdateWorkoutEntryRequest $request, Workout $workout, WorkoutEntry $entry): WorkoutEntryResource
+    {
+        $this->authorize('update', $workout);
+
+        DB::transaction(function () use ($request, $entry) {
+            $entry->update($request->safe()->only(['set_order', 'notes']));
+
+            $metrics = $request->validated('metrics') ?? [];
+            if ($metrics) {
+                $this->syncMetrics($entry, $metrics);
+            }
+        });
+
+        $entry->load(self::METRIC_EAGER_LOAD);
+
+        return new WorkoutEntryResource($entry);
+    }
+
+    public function destroy(Workout $workout, WorkoutEntry $entry): Response
+    {
+        $this->authorize('update', $workout);
+
+        $entry->delete();
+
+        return response()->noContent();
+    }
+
+    public function reorder(ReorderRequest $request, Workout $workout): AnonymousResourceCollection
+    {
+        $this->authorize('update', $workout);
+
+        DB::transaction(function () use ($request, $workout) {
+            $ids = $request->validated('ids');
+            foreach ($ids as $index => $id) {
+                $workout->entries()->where('id', $id)->update(['set_order' => $index]);
+            }
+        });
+
+        $entries = $workout->entries()
+            ->with(self::METRIC_EAGER_LOAD)
+            ->orderBy('set_order')
+            ->get();
+
+        return WorkoutEntryResource::collection($entries);
+    }
+
+    /** @param array<string, mixed> $metrics */
+    private function syncMetrics(WorkoutEntry $entry, array $metrics): void
+    {
+        $metricMap = [
+            'load' => 'loadMetric',
+            'reps' => 'repMetric',
+            'duration' => 'durationMetric',
+            'distance' => 'distanceMetric',
+            'cardio_settings' => 'cardioSetting',
+            'interval_header' => 'intervalHeader',
+            'intensity' => 'intensityMetric',
+        ];
+
+        foreach ($metrics as $type => $data) {
+            if (! isset($metricMap[$type])) {
+                continue;
+            }
+
+            $relation = $metricMap[$type];
+
+            if ($type === 'interval_header') {
+                $rounds = $data['rounds'] ?? [];
+                unset($data['rounds']);
+                $header = $entry->$relation()->updateOrCreate([], $data);
+                $header->rounds()->delete();
+                foreach ($rounds as $round) {
+                    $header->rounds()->create($round);
+                }
+            } else {
+                $entry->$relation()->updateOrCreate([], $data);
+            }
+        }
+    }
+}

--- a/app/Http/Controllers/Api/V1/WorkoutExerciseController.php
+++ b/app/Http/Controllers/Api/V1/WorkoutExerciseController.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\AttachExerciseRequest;
+use App\Http\Requests\Api\V1\ReorderRequest;
+use App\Http\Resources\Api\V1\WorkoutResource;
+use App\Models\Exercise;
+use App\Models\Workout;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\DB;
+
+class WorkoutExerciseController extends Controller
+{
+    use AuthorizesRequests;
+
+    private const SHOW_EAGER_LOAD = [
+        'exercises',
+        'entries.exercise',
+        'entries.loadMetric',
+        'entries.repMetric',
+        'entries.durationMetric',
+        'entries.distanceMetric',
+        'entries.cardioSetting',
+        'entries.intervalHeader.rounds',
+        'entries.intensityMetric',
+    ];
+
+    public function attach(AttachExerciseRequest $request, Workout $workout): JsonResponse
+    {
+        $this->authorize('update', $workout);
+
+        $exerciseId = $request->validated('exercise_id');
+
+        if ($workout->exercises()->where('exercises.id', $exerciseId)->exists()) {
+            return response()->json([
+                'message' => 'Exercise is already attached to this workout.',
+            ], 409);
+        }
+
+        $nextOrder = $workout->exercises()->max('exercise_order') ?? -1;
+        $nextOrder++;
+
+        $workout->exercises()->attach($exerciseId, ['exercise_order' => $nextOrder]);
+        $workout->load(self::SHOW_EAGER_LOAD);
+
+        return (new WorkoutResource($workout))
+            ->response()
+            ->setStatusCode(201);
+    }
+
+    public function detach(Workout $workout, Exercise $exercise): Response
+    {
+        $this->authorize('update', $workout);
+
+        $workout->entries()->where('exercise_id', $exercise->id)->delete();
+        $workout->exercises()->detach($exercise->id);
+
+        return response()->noContent();
+    }
+
+    public function reorder(ReorderRequest $request, Workout $workout): WorkoutResource
+    {
+        $this->authorize('update', $workout);
+
+        DB::transaction(function () use ($request, $workout) {
+            $ids = $request->validated('ids');
+            foreach ($ids as $index => $id) {
+                $workout->exercises()->updateExistingPivot($id, ['exercise_order' => $index]);
+            }
+        });
+
+        $workout->load(self::SHOW_EAGER_LOAD);
+
+        return new WorkoutResource($workout);
+    }
+}

--- a/app/Http/Requests/Api/V1/AttachExerciseRequest.php
+++ b/app/Http/Requests/Api/V1/AttachExerciseRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class AttachExerciseRequest extends FormRequest
+{
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        return [
+            'exercise_id' => [
+                'required',
+                Rule::exists('exercises', 'id')->where(function ($query) {
+                    $query->whereNull('user_id')
+                        ->orWhere('user_id', $this->user()->id);
+                }),
+            ],
+        ];
+    }
+}

--- a/app/Http/Requests/Api/V1/ReorderRequest.php
+++ b/app/Http/Requests/Api/V1/ReorderRequest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ReorderRequest extends FormRequest
+{
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        return [
+            'ids' => ['required', 'array', 'min:1'],
+            'ids.*' => ['required', 'integer'],
+        ];
+    }
+}

--- a/app/Http/Requests/Api/V1/StoreWorkoutEntryRequest.php
+++ b/app/Http/Requests/Api/V1/StoreWorkoutEntryRequest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use App\Enums\DistanceUnit;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreWorkoutEntryRequest extends FormRequest
+{
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        return array_merge([
+            'exercise_id' => [
+                'required',
+                Rule::exists('exercises', 'id')->where(function ($query) {
+                    $query->whereNull('user_id')
+                        ->orWhere('user_id', $this->user()->id);
+                }),
+            ],
+            'set_order' => ['required', 'integer', 'min:0'],
+            'notes' => ['sometimes', 'nullable', 'string'],
+            'metrics' => ['sometimes', 'array'],
+        ], $this->metricRules());
+    }
+
+    /** @return array<string, mixed> */
+    private function metricRules(): array
+    {
+        return [
+            'metrics.load' => ['sometimes', 'array'],
+            'metrics.load.target_weight' => ['sometimes', 'nullable', 'numeric', 'min:0'],
+            'metrics.load.actual_weight' => ['sometimes', 'nullable', 'numeric', 'min:0'],
+            'metrics.load.bodyweight_only' => ['sometimes', 'boolean'],
+
+            'metrics.reps' => ['sometimes', 'array'],
+            'metrics.reps.target_reps' => ['sometimes', 'nullable', 'integer', 'min:0'],
+            'metrics.reps.actual_reps' => ['sometimes', 'nullable', 'integer', 'min:0'],
+            'metrics.reps.to_failure' => ['sometimes', 'boolean'],
+            'metrics.reps.failure_rep' => ['sometimes', 'nullable', 'integer', 'min:1'],
+
+            'metrics.duration' => ['sometimes', 'array'],
+            'metrics.duration.target_duration_seconds' => ['sometimes', 'nullable', 'integer', 'min:0'],
+            'metrics.duration.actual_duration_seconds' => ['sometimes', 'nullable', 'integer', 'min:0'],
+
+            'metrics.distance' => ['sometimes', 'array'],
+            'metrics.distance.target_distance' => ['sometimes', 'nullable', 'numeric', 'min:0'],
+            'metrics.distance.actual_distance' => ['sometimes', 'nullable', 'numeric', 'min:0'],
+            'metrics.distance.distance_unit' => ['sometimes', Rule::enum(DistanceUnit::class)],
+            'metrics.distance.lap_count' => ['sometimes', 'nullable', 'integer', 'min:0'],
+            'metrics.distance.stroke_count' => ['sometimes', 'nullable', 'integer', 'min:0'],
+
+            'metrics.cardio_settings' => ['sometimes', 'array'],
+            'metrics.cardio_settings.resistance_level' => ['sometimes', 'nullable', 'integer', 'min:0'],
+            'metrics.cardio_settings.incline' => ['sometimes', 'nullable', 'numeric'],
+            'metrics.cardio_settings.speed' => ['sometimes', 'nullable', 'numeric', 'min:0'],
+            'metrics.cardio_settings.cadence' => ['sometimes', 'nullable', 'integer', 'min:0'],
+
+            'metrics.interval_header' => ['sometimes', 'array'],
+            'metrics.interval_header.programmed_rounds' => ['sometimes', 'nullable', 'integer', 'min:1'],
+            'metrics.interval_header.completed_rounds' => ['sometimes', 'nullable', 'integer', 'min:0'],
+            'metrics.interval_header.target_work_seconds' => ['sometimes', 'nullable', 'integer', 'min:0'],
+            'metrics.interval_header.target_rest_seconds' => ['sometimes', 'nullable', 'integer', 'min:0'],
+            'metrics.interval_header.rounds' => ['sometimes', 'array'],
+            'metrics.interval_header.rounds.*.round_number' => ['required_with:metrics.interval_header.rounds', 'integer', 'min:1'],
+            'metrics.interval_header.rounds.*.actual_work_seconds' => ['sometimes', 'nullable', 'integer', 'min:0'],
+            'metrics.interval_header.rounds.*.actual_rest_seconds' => ['sometimes', 'nullable', 'integer', 'min:0'],
+            'metrics.interval_header.rounds.*.heart_rate_avg' => ['sometimes', 'nullable', 'integer', 'min:0'],
+            'metrics.interval_header.rounds.*.heart_rate_peak' => ['sometimes', 'nullable', 'integer', 'min:0'],
+
+            'metrics.intensity' => ['sometimes', 'array'],
+            'metrics.intensity.rpe' => ['sometimes', 'nullable', 'integer', 'min:1', 'max:10'],
+            'metrics.intensity.avg_hr' => ['sometimes', 'nullable', 'integer', 'min:0'],
+            'metrics.intensity.max_hr' => ['sometimes', 'nullable', 'integer', 'min:0'],
+        ];
+    }
+}

--- a/app/Http/Requests/Api/V1/StoreWorkoutRequest.php
+++ b/app/Http/Requests/Api/V1/StoreWorkoutRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreWorkoutRequest extends FormRequest
+{
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'date' => ['required', 'date'],
+            'exhaustion' => ['sometimes', 'nullable', 'integer', 'min:1', 'max:10'],
+            'soreness' => ['sometimes', 'nullable', 'integer', 'min:1', 'max:10'],
+        ];
+    }
+}

--- a/app/Http/Requests/Api/V1/UpdateWorkoutEntryRequest.php
+++ b/app/Http/Requests/Api/V1/UpdateWorkoutEntryRequest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use App\Enums\DistanceUnit;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateWorkoutEntryRequest extends FormRequest
+{
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        return array_merge([
+            'set_order' => ['sometimes', 'integer', 'min:0'],
+            'notes' => ['sometimes', 'nullable', 'string'],
+            'metrics' => ['sometimes', 'array'],
+        ], $this->metricRules());
+    }
+
+    /** @return array<string, mixed> */
+    private function metricRules(): array
+    {
+        return [
+            'metrics.load' => ['sometimes', 'array'],
+            'metrics.load.target_weight' => ['sometimes', 'nullable', 'numeric', 'min:0'],
+            'metrics.load.actual_weight' => ['sometimes', 'nullable', 'numeric', 'min:0'],
+            'metrics.load.bodyweight_only' => ['sometimes', 'boolean'],
+
+            'metrics.reps' => ['sometimes', 'array'],
+            'metrics.reps.target_reps' => ['sometimes', 'nullable', 'integer', 'min:0'],
+            'metrics.reps.actual_reps' => ['sometimes', 'nullable', 'integer', 'min:0'],
+            'metrics.reps.to_failure' => ['sometimes', 'boolean'],
+            'metrics.reps.failure_rep' => ['sometimes', 'nullable', 'integer', 'min:1'],
+
+            'metrics.duration' => ['sometimes', 'array'],
+            'metrics.duration.target_duration_seconds' => ['sometimes', 'nullable', 'integer', 'min:0'],
+            'metrics.duration.actual_duration_seconds' => ['sometimes', 'nullable', 'integer', 'min:0'],
+
+            'metrics.distance' => ['sometimes', 'array'],
+            'metrics.distance.target_distance' => ['sometimes', 'nullable', 'numeric', 'min:0'],
+            'metrics.distance.actual_distance' => ['sometimes', 'nullable', 'numeric', 'min:0'],
+            'metrics.distance.distance_unit' => ['sometimes', Rule::enum(DistanceUnit::class)],
+            'metrics.distance.lap_count' => ['sometimes', 'nullable', 'integer', 'min:0'],
+            'metrics.distance.stroke_count' => ['sometimes', 'nullable', 'integer', 'min:0'],
+
+            'metrics.cardio_settings' => ['sometimes', 'array'],
+            'metrics.cardio_settings.resistance_level' => ['sometimes', 'nullable', 'integer', 'min:0'],
+            'metrics.cardio_settings.incline' => ['sometimes', 'nullable', 'numeric'],
+            'metrics.cardio_settings.speed' => ['sometimes', 'nullable', 'numeric', 'min:0'],
+            'metrics.cardio_settings.cadence' => ['sometimes', 'nullable', 'integer', 'min:0'],
+
+            'metrics.interval_header' => ['sometimes', 'array'],
+            'metrics.interval_header.programmed_rounds' => ['sometimes', 'nullable', 'integer', 'min:1'],
+            'metrics.interval_header.completed_rounds' => ['sometimes', 'nullable', 'integer', 'min:0'],
+            'metrics.interval_header.target_work_seconds' => ['sometimes', 'nullable', 'integer', 'min:0'],
+            'metrics.interval_header.target_rest_seconds' => ['sometimes', 'nullable', 'integer', 'min:0'],
+            'metrics.interval_header.rounds' => ['sometimes', 'array'],
+            'metrics.interval_header.rounds.*.round_number' => ['required_with:metrics.interval_header.rounds', 'integer', 'min:1'],
+            'metrics.interval_header.rounds.*.actual_work_seconds' => ['sometimes', 'nullable', 'integer', 'min:0'],
+            'metrics.interval_header.rounds.*.actual_rest_seconds' => ['sometimes', 'nullable', 'integer', 'min:0'],
+            'metrics.interval_header.rounds.*.heart_rate_avg' => ['sometimes', 'nullable', 'integer', 'min:0'],
+            'metrics.interval_header.rounds.*.heart_rate_peak' => ['sometimes', 'nullable', 'integer', 'min:0'],
+
+            'metrics.intensity' => ['sometimes', 'array'],
+            'metrics.intensity.rpe' => ['sometimes', 'nullable', 'integer', 'min:1', 'max:10'],
+            'metrics.intensity.avg_hr' => ['sometimes', 'nullable', 'integer', 'min:0'],
+            'metrics.intensity.max_hr' => ['sometimes', 'nullable', 'integer', 'min:0'],
+        ];
+    }
+}

--- a/app/Http/Requests/Api/V1/UpdateWorkoutRequest.php
+++ b/app/Http/Requests/Api/V1/UpdateWorkoutRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateWorkoutRequest extends FormRequest
+{
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        return [
+            'name' => ['sometimes', 'string', 'max:255'],
+            'date' => ['sometimes', 'date'],
+            'exhaustion' => ['sometimes', 'nullable', 'integer', 'min:1', 'max:10'],
+            'soreness' => ['sometimes', 'nullable', 'integer', 'min:1', 'max:10'],
+        ];
+    }
+}

--- a/app/Http/Resources/Api/V1/WorkoutEntryResource.php
+++ b/app/Http/Resources/Api/V1/WorkoutEntryResource.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Models\WorkoutEntry;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin WorkoutEntry */
+class WorkoutEntryResource extends JsonResource
+{
+    /** @return array<string, mixed> */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'workout_id' => $this->workout_id,
+            'exercise_id' => $this->exercise_id,
+            'set_order' => $this->set_order,
+            'notes' => $this->notes,
+            'exercise' => $this->whenLoaded('exercise', fn () => [
+                'id' => $this->exercise->id,
+                'name' => $this->exercise->name,
+                'type' => $this->exercise->type,
+            ]),
+            'metrics' => $this->metricData(),
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function metricData(): array
+    {
+        $metrics = [];
+
+        if ($this->relationLoaded('loadMetric') && $this->loadMetric) {
+            $metrics['load'] = collect($this->loadMetric->toArray())
+                ->except(['id', 'entry_id', 'created_at', 'updated_at'])
+                ->all();
+        }
+
+        if ($this->relationLoaded('repMetric') && $this->repMetric) {
+            $metrics['reps'] = collect($this->repMetric->toArray())
+                ->except(['id', 'entry_id', 'created_at', 'updated_at'])
+                ->all();
+        }
+
+        if ($this->relationLoaded('durationMetric') && $this->durationMetric) {
+            $metrics['duration'] = collect($this->durationMetric->toArray())
+                ->except(['id', 'entry_id', 'created_at', 'updated_at'])
+                ->all();
+        }
+
+        if ($this->relationLoaded('distanceMetric') && $this->distanceMetric) {
+            $metrics['distance'] = collect($this->distanceMetric->toArray())
+                ->except(['id', 'entry_id', 'created_at', 'updated_at'])
+                ->all();
+        }
+
+        if ($this->relationLoaded('cardioSetting') && $this->cardioSetting) {
+            $metrics['cardio_settings'] = collect($this->cardioSetting->toArray())
+                ->except(['id', 'entry_id', 'created_at', 'updated_at'])
+                ->all();
+        }
+
+        if ($this->relationLoaded('intensityMetric') && $this->intensityMetric) {
+            $metrics['intensity'] = collect($this->intensityMetric->toArray())
+                ->except(['id', 'entry_id', 'created_at', 'updated_at'])
+                ->all();
+        }
+
+        if ($this->relationLoaded('intervalHeader') && $this->intervalHeader) {
+            $header = collect($this->intervalHeader->toArray())
+                ->except(['id', 'entry_id', 'created_at', 'updated_at'])
+                ->all();
+            if ($this->intervalHeader->relationLoaded('rounds')) {
+                $header['rounds'] = $this->intervalHeader->rounds->map(
+                    fn ($round) => collect($round->toArray())
+                        ->except(['id', 'interval_header_id', 'created_at', 'updated_at'])
+                        ->all()
+                )->all();
+            }
+            $metrics['interval_header'] = $header;
+        }
+
+        return $metrics;
+    }
+}

--- a/app/Http/Resources/Api/V1/WorkoutListResource.php
+++ b/app/Http/Resources/Api/V1/WorkoutListResource.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Models\Workout;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin Workout */
+class WorkoutListResource extends JsonResource
+{
+    /** @return array<string, mixed> */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'date' => $this->date->toDateString(),
+            'exhaustion' => $this->exhaustion,
+            'soreness' => $this->soreness,
+            'exercises' => $this->whenLoaded('exercises', fn () => $this->exercises->map(fn ($exercise) => [
+                'id' => $exercise->id,
+                'name' => $exercise->name,
+                'type' => $exercise->type,
+            ])),
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/app/Http/Resources/Api/V1/WorkoutResource.php
+++ b/app/Http/Resources/Api/V1/WorkoutResource.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Models\Workout;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin Workout */
+class WorkoutResource extends JsonResource
+{
+    /** @return array<string, mixed> */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'date' => $this->date->toDateString(),
+            'exhaustion' => $this->exhaustion,
+            'soreness' => $this->soreness,
+            'exercises' => $this->whenLoaded('exercises', fn () => $this->exercises->map(fn ($exercise) => [
+                'id' => $exercise->id,
+                'name' => $exercise->name,
+                'type' => $exercise->type,
+                'equipment_type_id' => $exercise->equipment_type_id,
+                'exercise_order' => $exercise->pivot->exercise_order,
+            ])),
+            'entries' => $this->whenLoaded('entries', fn () => WorkoutEntryResource::collection($this->entries)),
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/app/Models/Exercise.php
+++ b/app/Models/Exercise.php
@@ -8,8 +8,12 @@ use App\Enums\ExerciseType;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use App\Models\Pivots\ExerciseWorkoutPivot;
 
-/** @property ExerciseType $type */
+/**
+ * @property ExerciseType $type
+ * @property ExerciseWorkoutPivot|null $pivot
+ */
 class Exercise extends Model
 {
     /** @var list<string> */

--- a/app/Models/LogCardioSetting.php
+++ b/app/Models/LogCardioSetting.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class LogCardioSetting extends Model
+{
+    protected $table = 'log_cardio_settings';
+
+    /** @var list<string> */
+    protected $fillable = [
+        'entry_id',
+        'resistance_level',
+        'incline',
+        'speed',
+        'cadence',
+    ];
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'incline' => 'decimal:2',
+            'speed' => 'decimal:2',
+        ];
+    }
+
+    /** @return BelongsTo<WorkoutEntry, $this> */
+    public function entry(): BelongsTo
+    {
+        return $this->belongsTo(WorkoutEntry::class);
+    }
+}

--- a/app/Models/LogDistanceMetric.php
+++ b/app/Models/LogDistanceMetric.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\DistanceUnit;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class LogDistanceMetric extends Model
+{
+    protected $table = 'log_distance_metrics';
+
+    /** @var list<string> */
+    protected $fillable = [
+        'entry_id',
+        'target_distance',
+        'actual_distance',
+        'distance_unit',
+        'lap_count',
+        'stroke_count',
+    ];
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'distance_unit' => DistanceUnit::class,
+            'target_distance' => 'decimal:2',
+            'actual_distance' => 'decimal:2',
+        ];
+    }
+
+    /** @return BelongsTo<WorkoutEntry, $this> */
+    public function entry(): BelongsTo
+    {
+        return $this->belongsTo(WorkoutEntry::class);
+    }
+}

--- a/app/Models/LogDurationMetric.php
+++ b/app/Models/LogDurationMetric.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class LogDurationMetric extends Model
+{
+    protected $table = 'log_duration_metrics';
+
+    /** @var list<string> */
+    protected $fillable = [
+        'entry_id',
+        'target_duration_seconds',
+        'actual_duration_seconds',
+    ];
+
+    /** @return BelongsTo<WorkoutEntry, $this> */
+    public function entry(): BelongsTo
+    {
+        return $this->belongsTo(WorkoutEntry::class);
+    }
+}

--- a/app/Models/LogIntensityMetric.php
+++ b/app/Models/LogIntensityMetric.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class LogIntensityMetric extends Model
+{
+    protected $table = 'log_intensity_metrics';
+
+    /** @var list<string> */
+    protected $fillable = [
+        'entry_id',
+        'rpe',
+        'avg_hr',
+        'max_hr',
+    ];
+
+    /** @return BelongsTo<WorkoutEntry, $this> */
+    public function entry(): BelongsTo
+    {
+        return $this->belongsTo(WorkoutEntry::class);
+    }
+}

--- a/app/Models/LogIntervalHeader.php
+++ b/app/Models/LogIntervalHeader.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class LogIntervalHeader extends Model
+{
+    protected $table = 'log_interval_headers';
+
+    /** @var list<string> */
+    protected $fillable = [
+        'entry_id',
+        'programmed_rounds',
+        'completed_rounds',
+        'target_work_seconds',
+        'target_rest_seconds',
+    ];
+
+    /** @return BelongsTo<WorkoutEntry, $this> */
+    public function entry(): BelongsTo
+    {
+        return $this->belongsTo(WorkoutEntry::class);
+    }
+
+    /** @return HasMany<LogIntervalRound, $this> */
+    public function rounds(): HasMany
+    {
+        return $this->hasMany(LogIntervalRound::class, 'interval_header_id');
+    }
+}

--- a/app/Models/LogIntervalRound.php
+++ b/app/Models/LogIntervalRound.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class LogIntervalRound extends Model
+{
+    protected $table = 'log_interval_rounds';
+
+    /** @var list<string> */
+    protected $fillable = [
+        'interval_header_id',
+        'round_number',
+        'actual_work_seconds',
+        'actual_rest_seconds',
+        'heart_rate_avg',
+        'heart_rate_peak',
+    ];
+
+    /** @return BelongsTo<LogIntervalHeader, $this> */
+    public function header(): BelongsTo
+    {
+        return $this->belongsTo(LogIntervalHeader::class, 'interval_header_id');
+    }
+}

--- a/app/Models/LogLoadMetric.php
+++ b/app/Models/LogLoadMetric.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class LogLoadMetric extends Model
+{
+    protected $table = 'log_load_metrics';
+
+    /** @var list<string> */
+    protected $fillable = [
+        'entry_id',
+        'target_weight',
+        'actual_weight',
+        'bodyweight_only',
+    ];
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'bodyweight_only' => 'boolean',
+            'target_weight' => 'decimal:2',
+            'actual_weight' => 'decimal:2',
+        ];
+    }
+
+    /** @return BelongsTo<WorkoutEntry, $this> */
+    public function entry(): BelongsTo
+    {
+        return $this->belongsTo(WorkoutEntry::class);
+    }
+}

--- a/app/Models/LogRepMetric.php
+++ b/app/Models/LogRepMetric.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class LogRepMetric extends Model
+{
+    protected $table = 'log_rep_metrics';
+
+    /** @var list<string> */
+    protected $fillable = [
+        'entry_id',
+        'target_reps',
+        'actual_reps',
+        'to_failure',
+        'failure_rep',
+    ];
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'to_failure' => 'boolean',
+        ];
+    }
+
+    /** @return BelongsTo<WorkoutEntry, $this> */
+    public function entry(): BelongsTo
+    {
+        return $this->belongsTo(WorkoutEntry::class);
+    }
+}

--- a/app/Models/Pivots/ExerciseWorkoutPivot.php
+++ b/app/Models/Pivots/ExerciseWorkoutPivot.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Pivots;
+
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+/** @property int $exercise_order */
+class ExerciseWorkoutPivot extends Pivot
+{
+    public $timestamps = false;
+
+    protected $table = 'exercise_workout';
+}

--- a/app/Models/Workout.php
+++ b/app/Models/Workout.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use App\Models\Pivots\ExerciseWorkoutPivot;
+use Database\Factories\WorkoutFactory;
+use Illuminate\Support\Carbon;
+
+/** @property Carbon $date */
+class Workout extends Model
+{
+    /** @use HasFactory<WorkoutFactory> */
+    use HasFactory;
+
+    /** @var list<string> */
+    protected $fillable = [
+        'name',
+        'user_id',
+        'date',
+        'exhaustion',
+        'soreness',
+    ];
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'date' => 'date',
+            'exhaustion' => 'integer',
+            'soreness' => 'integer',
+        ];
+    }
+
+    /** @return BelongsTo<User, $this> */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /** @return BelongsToMany<Exercise, $this, ExerciseWorkoutPivot, 'pivot'> */
+    public function exercises(): BelongsToMany
+    {
+        return $this->belongsToMany(Exercise::class)
+            ->using(ExerciseWorkoutPivot::class)
+            ->withPivot('exercise_order')
+            ->orderByPivot('exercise_order');
+    }
+
+    /** @return HasMany<WorkoutEntry, $this> */
+    public function entries(): HasMany
+    {
+        return $this->hasMany(WorkoutEntry::class);
+    }
+}

--- a/app/Models/WorkoutEntry.php
+++ b/app/Models/WorkoutEntry.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+class WorkoutEntry extends Model
+{
+    /** @var list<string> */
+    protected $fillable = [
+        'workout_id',
+        'exercise_id',
+        'set_order',
+        'notes',
+    ];
+
+    /** @return BelongsTo<Workout, $this> */
+    public function workout(): BelongsTo
+    {
+        return $this->belongsTo(Workout::class);
+    }
+
+    /** @return BelongsTo<Exercise, $this> */
+    public function exercise(): BelongsTo
+    {
+        return $this->belongsTo(Exercise::class);
+    }
+
+    /** @return HasOne<LogLoadMetric, $this> */
+    public function loadMetric(): HasOne
+    {
+        return $this->hasOne(LogLoadMetric::class, 'entry_id');
+    }
+
+    /** @return HasOne<LogRepMetric, $this> */
+    public function repMetric(): HasOne
+    {
+        return $this->hasOne(LogRepMetric::class, 'entry_id');
+    }
+
+    /** @return HasOne<LogDurationMetric, $this> */
+    public function durationMetric(): HasOne
+    {
+        return $this->hasOne(LogDurationMetric::class, 'entry_id');
+    }
+
+    /** @return HasOne<LogDistanceMetric, $this> */
+    public function distanceMetric(): HasOne
+    {
+        return $this->hasOne(LogDistanceMetric::class, 'entry_id');
+    }
+
+    /** @return HasOne<LogCardioSetting, $this> */
+    public function cardioSetting(): HasOne
+    {
+        return $this->hasOne(LogCardioSetting::class, 'entry_id');
+    }
+
+    /** @return HasOne<LogIntervalHeader, $this> */
+    public function intervalHeader(): HasOne
+    {
+        return $this->hasOne(LogIntervalHeader::class, 'entry_id');
+    }
+
+    /** @return HasOne<LogIntensityMetric, $this> */
+    public function intensityMetric(): HasOne
+    {
+        return $this->hasOne(LogIntensityMetric::class, 'entry_id');
+    }
+}

--- a/app/Policies/WorkoutPolicy.php
+++ b/app/Policies/WorkoutPolicy.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\User;
+use App\Models\Workout;
+
+class WorkoutPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    public function view(User $user, Workout $workout): bool
+    {
+        return $workout->user_id === $user->id;
+    }
+
+    public function create(User $user): bool
+    {
+        return true;
+    }
+
+    public function update(User $user, Workout $workout): bool
+    {
+        return $workout->user_id === $user->id;
+    }
+
+    public function delete(User $user, Workout $workout): bool
+    {
+        return $workout->user_id === $user->id;
+    }
+}

--- a/config/metric-mapping.php
+++ b/config/metric-mapping.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+    'resistance' => [
+        'required' => ['load', 'reps'],
+        'optional' => ['intensity'],
+    ],
+    'timed_hold' => [
+        'required' => ['duration'],
+        'optional' => ['load', 'intensity'],
+    ],
+    'distance' => [
+        'required' => ['distance'],
+        'optional' => ['duration', 'cardio_settings', 'intensity'],
+    ],
+    'interval' => [
+        'required' => ['interval_header'],
+        'optional' => ['cardio_settings', 'distance', 'intensity'],
+    ],
+];

--- a/database/factories/WorkoutFactory.php
+++ b/database/factories/WorkoutFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use App\Models\Workout;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<Workout> */
+class WorkoutFactory extends Factory
+{
+    /** @return array<string, mixed> */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'name' => fake()->words(3, true),
+            'date' => fake()->date(),
+        ];
+    }
+
+    public function withExhaustion(int $level = 5): static
+    {
+        return $this->state(fn () => ['exhaustion' => $level]);
+    }
+
+    public function withSoreness(int $level = 5): static
+    {
+        return $this->state(fn () => ['soreness' => $level]);
+    }
+}

--- a/database/migrations/2026_06_28_200001_create_workouts_table.php
+++ b/database/migrations/2026_06_28_200001_create_workouts_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('workouts', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->date('date');
+            $table->tinyInteger('exhaustion')->nullable();
+            $table->tinyInteger('soreness')->nullable();
+            $table->timestamps();
+            $table->index(['user_id', 'date']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('workouts');
+    }
+};

--- a/database/migrations/2026_06_28_200002_create_exercise_workout_table.php
+++ b/database/migrations/2026_06_28_200002_create_exercise_workout_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('exercise_workout', function (Blueprint $table) {
+            $table->foreignId('workout_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('exercise_id')->constrained()->restrictOnDelete();
+            $table->unsignedInteger('exercise_order');
+            $table->primary(['workout_id', 'exercise_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('exercise_workout');
+    }
+};

--- a/database/migrations/2026_06_28_200003_create_workout_entries_table.php
+++ b/database/migrations/2026_06_28_200003_create_workout_entries_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('workout_entries', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('workout_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('exercise_id')->constrained()->restrictOnDelete();
+            $table->unsignedInteger('set_order');
+            $table->text('notes')->nullable();
+            $table->timestamps();
+            $table->index(['workout_id', 'set_order']);
+            $table->index(['exercise_id', 'created_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('workout_entries');
+    }
+};

--- a/database/migrations/2026_06_28_200004_create_log_load_metrics_table.php
+++ b/database/migrations/2026_06_28_200004_create_log_load_metrics_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('log_load_metrics', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('entry_id')->unique()->constrained('workout_entries')->cascadeOnDelete();
+            $table->decimal('target_weight', 8, 2)->nullable();
+            $table->decimal('actual_weight', 8, 2)->nullable();
+            $table->boolean('bodyweight_only')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('log_load_metrics');
+    }
+};

--- a/database/migrations/2026_06_28_200005_create_log_rep_metrics_table.php
+++ b/database/migrations/2026_06_28_200005_create_log_rep_metrics_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('log_rep_metrics', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('entry_id')->unique()->constrained('workout_entries')->cascadeOnDelete();
+            $table->unsignedInteger('target_reps')->nullable();
+            $table->unsignedInteger('actual_reps')->nullable();
+            $table->boolean('to_failure')->default(false);
+            $table->unsignedInteger('failure_rep')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('log_rep_metrics');
+    }
+};

--- a/database/migrations/2026_06_28_200006_create_log_duration_metrics_table.php
+++ b/database/migrations/2026_06_28_200006_create_log_duration_metrics_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('log_duration_metrics', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('entry_id')->unique()->constrained('workout_entries')->cascadeOnDelete();
+            $table->unsignedInteger('target_duration_seconds')->nullable();
+            $table->unsignedInteger('actual_duration_seconds')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('log_duration_metrics');
+    }
+};

--- a/database/migrations/2026_06_28_200007_create_log_distance_metrics_table.php
+++ b/database/migrations/2026_06_28_200007_create_log_distance_metrics_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('log_distance_metrics', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('entry_id')->unique()->constrained('workout_entries')->cascadeOnDelete();
+            $table->decimal('target_distance', 10, 2)->nullable();
+            $table->decimal('actual_distance', 10, 2)->nullable();
+            $table->enum('distance_unit', ['meters', 'kilometers', 'miles', 'yards']);
+            $table->unsignedInteger('lap_count')->nullable();
+            $table->unsignedInteger('stroke_count')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('log_distance_metrics');
+    }
+};

--- a/database/migrations/2026_06_28_200008_create_log_cardio_settings_table.php
+++ b/database/migrations/2026_06_28_200008_create_log_cardio_settings_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('log_cardio_settings', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('entry_id')->unique()->constrained('workout_entries')->cascadeOnDelete();
+            $table->unsignedInteger('resistance_level')->nullable();
+            $table->decimal('incline', 5, 2)->nullable();
+            $table->decimal('speed', 5, 2)->nullable();
+            $table->unsignedInteger('cadence')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('log_cardio_settings');
+    }
+};

--- a/database/migrations/2026_06_28_200009_create_log_interval_headers_table.php
+++ b/database/migrations/2026_06_28_200009_create_log_interval_headers_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('log_interval_headers', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('entry_id')->unique()->constrained('workout_entries')->cascadeOnDelete();
+            $table->unsignedInteger('programmed_rounds')->nullable();
+            $table->unsignedInteger('completed_rounds')->nullable();
+            $table->unsignedInteger('target_work_seconds')->nullable();
+            $table->unsignedInteger('target_rest_seconds')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('log_interval_headers');
+    }
+};

--- a/database/migrations/2026_06_28_200010_create_log_interval_rounds_table.php
+++ b/database/migrations/2026_06_28_200010_create_log_interval_rounds_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('log_interval_rounds', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('interval_header_id')->constrained('log_interval_headers')->cascadeOnDelete();
+            $table->unsignedInteger('round_number');
+            $table->unsignedInteger('actual_work_seconds')->nullable();
+            $table->unsignedInteger('actual_rest_seconds')->nullable();
+            $table->unsignedInteger('heart_rate_avg')->nullable();
+            $table->unsignedInteger('heart_rate_peak')->nullable();
+            $table->timestamps();
+            $table->unique(['interval_header_id', 'round_number']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('log_interval_rounds');
+    }
+};

--- a/database/migrations/2026_06_28_200011_create_log_intensity_metrics_table.php
+++ b/database/migrations/2026_06_28_200011_create_log_intensity_metrics_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('log_intensity_metrics', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('entry_id')->unique()->constrained('workout_entries')->cascadeOnDelete();
+            $table->tinyInteger('rpe')->nullable();
+            $table->unsignedInteger('avg_hr')->nullable();
+            $table->unsignedInteger('max_hr')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('log_intensity_metrics');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,6 +8,9 @@ use App\Http\Controllers\Api\V1\Auth\ResetPasswordController;
 use App\Http\Controllers\Api\V1\EquipmentTypeController;
 use App\Http\Controllers\Api\V1\ExerciseController;
 use App\Http\Controllers\Api\V1\UserController;
+use App\Http\Controllers\Api\V1\WorkoutController;
+use App\Http\Controllers\Api\V1\WorkoutEntryController;
+use App\Http\Controllers\Api\V1\WorkoutExerciseController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/health', fn () => response()->json(['status' => 'ok']));
@@ -23,4 +26,10 @@ Route::middleware('auth:api')->group(function () {
     Route::put('/user', [UserController::class, 'update']);
     Route::apiResource('equipment-types', EquipmentTypeController::class);
     Route::apiResource('exercises', ExerciseController::class);
+    Route::apiResource('workouts', WorkoutController::class);
+    Route::post('workouts/{workout}/exercises', [WorkoutExerciseController::class, 'attach']);
+    Route::delete('workouts/{workout}/exercises/{exercise}', [WorkoutExerciseController::class, 'detach']);
+    Route::put('workouts/{workout}/exercises/reorder', [WorkoutExerciseController::class, 'reorder']);
+    Route::put('workouts/{workout}/entries/reorder', [WorkoutEntryController::class, 'reorder']);
+    Route::apiResource('workouts.entries', WorkoutEntryController::class)->scoped();
 });

--- a/tests/Feature/Api/V1/ExerciseTest.php
+++ b/tests/Feature/Api/V1/ExerciseTest.php
@@ -7,6 +7,7 @@ namespace Tests\Feature\Api\V1;
 use App\Models\EquipmentType;
 use App\Models\Exercise;
 use App\Models\User;
+use App\Models\Workout;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Passport\Passport;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -397,6 +398,21 @@ class ExerciseTest extends TestCase
 
         $this->deleteJson("/api/v1/exercises/{$exercise->id}")
             ->assertStatus(403);
+    }
+
+    public function test_returns_409_when_deleting_exercise_in_use_by_workout(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance', ['name' => 'In Use']);
+        Passport::actingAs($user);
+
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+        $workout->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+
+        $this->deleteJson("/api/v1/exercises/{$exercise->id}")
+            ->assertStatus(409);
+
+        $this->assertDatabaseHas('exercises', ['id' => $exercise->id]);
     }
 
     // -- Auth --

--- a/tests/Feature/Api/V1/WorkoutEntryTest.php
+++ b/tests/Feature/Api/V1/WorkoutEntryTest.php
@@ -1,0 +1,504 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Models\Exercise;
+use App\Models\User;
+use App\Models\Workout;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
+use Tests\TestCase;
+
+class WorkoutEntryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createExercise(
+        ?User $user,
+        string $type = 'resistance',
+        array $overrides = [],
+    ): Exercise {
+        $exercise = Exercise::create(array_merge([
+            'name' => 'Test Exercise',
+            'type' => $type,
+            'user_id' => $user?->id,
+        ], $overrides));
+
+        $defaults = match ($type) {
+            'resistance' => [],
+            'timed_hold' => [],
+            'distance' => ['distance_unit' => 'meters'],
+            'interval' => [],
+            default => [],
+        };
+
+        $childRelation = match ($type) {
+            'resistance' => 'resistance',
+            'timed_hold' => 'timedHold',
+            'distance' => 'distance',
+            'interval' => 'interval',
+            default => 'resistance',
+        };
+
+        $exercise->$childRelation()->create($defaults);
+
+        return $exercise;
+    }
+
+    // -- Store --
+
+    public function test_creates_entry_with_resistance_metrics(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance', ['name' => 'Bench Press']);
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+        $workout->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+
+        Passport::actingAs($user);
+
+        $response = $this->postJson("/api/v1/workouts/{$workout->id}/entries", [
+            'exercise_id' => $exercise->id,
+            'set_order' => 0,
+            'metrics' => [
+                'load' => [
+                    'target_weight' => 185.5,
+                    'actual_weight' => 180.0,
+                ],
+                'reps' => [
+                    'target_reps' => 10,
+                    'actual_reps' => 8,
+                ],
+            ],
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.metrics.load.target_weight', '185.50')
+            ->assertJsonPath('data.metrics.load.actual_weight', '180.00')
+            ->assertJsonPath('data.metrics.reps.target_reps', 10)
+            ->assertJsonPath('data.metrics.reps.actual_reps', 8);
+
+        $this->assertDatabaseHas('workout_entries', [
+            'workout_id' => $workout->id,
+            'exercise_id' => $exercise->id,
+            'set_order' => 0,
+        ]);
+    }
+
+    public function test_creates_entry_with_duration_metrics(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'timed_hold', ['name' => 'Plank']);
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+        $workout->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+
+        Passport::actingAs($user);
+
+        $response = $this->postJson("/api/v1/workouts/{$workout->id}/entries", [
+            'exercise_id' => $exercise->id,
+            'set_order' => 0,
+            'metrics' => [
+                'duration' => [
+                    'target_duration_seconds' => 120,
+                    'actual_duration_seconds' => 115,
+                ],
+            ],
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.metrics.duration.target_duration_seconds', 120)
+            ->assertJsonPath('data.metrics.duration.actual_duration_seconds', 115);
+    }
+
+    public function test_creates_entry_with_distance_metrics(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'distance', ['name' => 'Run']);
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+        $workout->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+
+        Passport::actingAs($user);
+
+        $response = $this->postJson("/api/v1/workouts/{$workout->id}/entries", [
+            'exercise_id' => $exercise->id,
+            'set_order' => 0,
+            'metrics' => [
+                'distance' => [
+                    'target_distance' => 5.0,
+                    'actual_distance' => 4.8,
+                    'distance_unit' => 'kilometers',
+                ],
+            ],
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.metrics.distance.target_distance', '5.00')
+            ->assertJsonPath('data.metrics.distance.actual_distance', '4.80')
+            ->assertJsonPath('data.metrics.distance.distance_unit', 'kilometers');
+    }
+
+    public function test_creates_entry_with_interval_metrics(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'interval', ['name' => 'HIIT']);
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+        $workout->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+
+        Passport::actingAs($user);
+
+        $response = $this->postJson("/api/v1/workouts/{$workout->id}/entries", [
+            'exercise_id' => $exercise->id,
+            'set_order' => 0,
+            'metrics' => [
+                'interval_header' => [
+                    'programmed_rounds' => 8,
+                    'completed_rounds' => 8,
+                    'target_work_seconds' => 30,
+                    'target_rest_seconds' => 15,
+                    'rounds' => [
+                        [
+                            'round_number' => 1,
+                            'actual_work_seconds' => 30,
+                            'actual_rest_seconds' => 15,
+                        ],
+                        [
+                            'round_number' => 2,
+                            'actual_work_seconds' => 31,
+                            'actual_rest_seconds' => 14,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.metrics.interval_header.programmed_rounds', 8)
+            ->assertJsonPath('data.metrics.interval_header.completed_rounds', 8)
+            ->assertJsonPath('data.metrics.interval_header.rounds.0.round_number', 1)
+            ->assertJsonPath('data.metrics.interval_header.rounds.1.round_number', 2);
+    }
+
+    public function test_creates_entry_without_metrics(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance');
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+        $workout->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+
+        Passport::actingAs($user);
+
+        $response = $this->postJson("/api/v1/workouts/{$workout->id}/entries", [
+            'exercise_id' => $exercise->id,
+            'set_order' => 0,
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.metrics', []);
+    }
+
+    public function test_validates_exercise_id_required(): void
+    {
+        $user = User::factory()->create();
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+
+        Passport::actingAs($user);
+
+        $this->postJson("/api/v1/workouts/{$workout->id}/entries", [
+            'set_order' => 0,
+        ])->assertStatus(422)
+            ->assertJsonValidationErrors('exercise_id');
+    }
+
+    public function test_validates_set_order_required(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance');
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+        $workout->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+
+        Passport::actingAs($user);
+
+        $this->postJson("/api/v1/workouts/{$workout->id}/entries", [
+            'exercise_id' => $exercise->id,
+        ])->assertStatus(422)
+            ->assertJsonValidationErrors('set_order');
+    }
+
+    // -- Index --
+
+    public function test_lists_entries_for_workout(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance');
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+        $workout->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+
+        $workout->entries()->create(['exercise_id' => $exercise->id, 'set_order' => 0]);
+        $workout->entries()->create(['exercise_id' => $exercise->id, 'set_order' => 1]);
+        $workout->entries()->create(['exercise_id' => $exercise->id, 'set_order' => 2]);
+
+        Passport::actingAs($user);
+
+        $response = $this->getJson("/api/v1/workouts/{$workout->id}/entries");
+
+        $response->assertOk();
+        $this->assertCount(3, $response->json('data'));
+        $this->assertEquals(0, $response->json('data.0.set_order'));
+        $this->assertEquals(1, $response->json('data.1.set_order'));
+        $this->assertEquals(2, $response->json('data.2.set_order'));
+    }
+
+    // -- Show --
+
+    public function test_shows_single_entry_with_metrics(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance');
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+        $workout->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+
+        $entry = $workout->entries()->create([
+            'exercise_id' => $exercise->id,
+            'set_order' => 0,
+        ]);
+
+        $entry->loadMetric()->create([
+            'target_weight' => 100,
+            'actual_weight' => 95,
+        ]);
+
+        Passport::actingAs($user);
+
+        $response = $this->getJson("/api/v1/workouts/{$workout->id}/entries/{$entry->id}");
+
+        $response->assertOk()
+            ->assertJsonPath('data.id', $entry->id)
+            ->assertJsonPath('data.metrics.load.target_weight', '100.00')
+            ->assertJsonPath('data.metrics.load.actual_weight', '95.00');
+    }
+
+    // -- Update --
+
+    public function test_updates_entry_base_fields(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance');
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+        $workout->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+
+        $entry = $workout->entries()->create([
+            'exercise_id' => $exercise->id,
+            'set_order' => 0,
+            'notes' => 'Old notes',
+        ]);
+
+        Passport::actingAs($user);
+
+        $this->putJson("/api/v1/workouts/{$workout->id}/entries/{$entry->id}", [
+            'set_order' => 1,
+            'notes' => 'New notes',
+        ])->assertOk()
+            ->assertJsonPath('data.set_order', 1)
+            ->assertJsonPath('data.notes', 'New notes');
+    }
+
+    public function test_updates_entry_metrics_via_upsert(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance');
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+        $workout->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+
+        $entry = $workout->entries()->create([
+            'exercise_id' => $exercise->id,
+            'set_order' => 0,
+        ]);
+
+        $entry->loadMetric()->create([
+            'target_weight' => 100,
+            'actual_weight' => 95,
+        ]);
+
+        Passport::actingAs($user);
+
+        $this->putJson("/api/v1/workouts/{$workout->id}/entries/{$entry->id}", [
+            'set_order' => 0,
+            'metrics' => [
+                'load' => [
+                    'target_weight' => 110,
+                    'actual_weight' => 105,
+                ],
+            ],
+        ])->assertOk()
+            ->assertJsonPath('data.metrics.load.target_weight', '110.00')
+            ->assertJsonPath('data.metrics.load.actual_weight', '105.00');
+
+        $this->assertDatabaseMissing('log_load_metrics', [
+            'entry_id' => $entry->id,
+            'target_weight' => 100,
+        ]);
+
+        $this->assertDatabaseHas('log_load_metrics', [
+            'entry_id' => $entry->id,
+            'target_weight' => 110,
+        ]);
+    }
+
+    public function test_adds_new_metric_on_update(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance');
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+        $workout->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+
+        $entry = $workout->entries()->create([
+            'exercise_id' => $exercise->id,
+            'set_order' => 0,
+        ]);
+
+        $entry->loadMetric()->create([
+            'target_weight' => 100,
+        ]);
+
+        Passport::actingAs($user);
+
+        $this->putJson("/api/v1/workouts/{$workout->id}/entries/{$entry->id}", [
+            'set_order' => 0,
+            'metrics' => [
+                'load' => [
+                    'target_weight' => 100,
+                ],
+                'reps' => [
+                    'target_reps' => 10,
+                    'actual_reps' => 8,
+                ],
+            ],
+        ])->assertOk()
+            ->assertJsonPath('data.metrics.load.target_weight', '100.00')
+            ->assertJsonPath('data.metrics.reps.target_reps', 10)
+            ->assertJsonPath('data.metrics.reps.actual_reps', 8);
+
+        $this->assertDatabaseHas('log_load_metrics', ['entry_id' => $entry->id]);
+        $this->assertDatabaseHas('log_rep_metrics', ['entry_id' => $entry->id]);
+    }
+
+    // -- Destroy --
+
+    public function test_deletes_entry(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance');
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+        $workout->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+
+        $entry = $workout->entries()->create([
+            'exercise_id' => $exercise->id,
+            'set_order' => 0,
+        ]);
+
+        Passport::actingAs($user);
+
+        $this->deleteJson("/api/v1/workouts/{$workout->id}/entries/{$entry->id}")
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('workout_entries', ['id' => $entry->id]);
+    }
+
+    public function test_delete_cascades_metrics(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance');
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+        $workout->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+
+        $entry = $workout->entries()->create([
+            'exercise_id' => $exercise->id,
+            'set_order' => 0,
+        ]);
+
+        $loadMetric = $entry->loadMetric()->create(['target_weight' => 100]);
+        $repMetric = $entry->repMetric()->create(['target_reps' => 10]);
+
+        Passport::actingAs($user);
+
+        $this->deleteJson("/api/v1/workouts/{$workout->id}/entries/{$entry->id}")
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('workout_entries', ['id' => $entry->id]);
+        $this->assertDatabaseMissing('log_load_metrics', ['id' => $loadMetric->id]);
+        $this->assertDatabaseMissing('log_rep_metrics', ['id' => $repMetric->id]);
+    }
+
+    // -- Reorder --
+
+    public function test_reorders_entries(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance');
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+        $workout->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+
+        $entry1 = $workout->entries()->create(['exercise_id' => $exercise->id, 'set_order' => 0]);
+        $entry2 = $workout->entries()->create(['exercise_id' => $exercise->id, 'set_order' => 1]);
+        $entry3 = $workout->entries()->create(['exercise_id' => $exercise->id, 'set_order' => 2]);
+
+        Passport::actingAs($user);
+
+        $this->putJson("/api/v1/workouts/{$workout->id}/entries/reorder", [
+            'ids' => [$entry3->id, $entry1->id, $entry2->id],
+        ])->assertOk();
+
+        $this->assertDatabaseHas('workout_entries', [
+            'id' => $entry3->id,
+            'set_order' => 0,
+        ]);
+
+        $this->assertDatabaseHas('workout_entries', [
+            'id' => $entry1->id,
+            'set_order' => 1,
+        ]);
+
+        $this->assertDatabaseHas('workout_entries', [
+            'id' => $entry2->id,
+            'set_order' => 2,
+        ]);
+    }
+
+    // -- Scoped Binding --
+
+    public function test_scoped_binding_rejects_entry_from_other_workout(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance');
+
+        $workout1 = Workout::factory()->create(['user_id' => $user->id]);
+        $workout1->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+        $entry1 = $workout1->entries()->create(['exercise_id' => $exercise->id, 'set_order' => 0]);
+
+        $workout2 = Workout::factory()->create(['user_id' => $user->id]);
+        $workout2->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+
+        Passport::actingAs($user);
+
+        $this->getJson("/api/v1/workouts/{$workout2->id}/entries/{$entry1->id}")
+            ->assertStatus(404);
+    }
+
+    // -- Auth --
+
+    public function test_cannot_create_entry_on_other_users_workout(): void
+    {
+        $owner = User::factory()->create();
+        $creator = User::factory()->create();
+        $exercise = $this->createExercise($creator, 'resistance');
+        $workout = Workout::factory()->create(['user_id' => $owner->id]);
+
+        Passport::actingAs($creator);
+
+        $this->postJson("/api/v1/workouts/{$workout->id}/entries", [
+            'exercise_id' => $exercise->id,
+            'set_order' => 0,
+        ])->assertStatus(403);
+    }
+}

--- a/tests/Feature/Api/V1/WorkoutExerciseTest.php
+++ b/tests/Feature/Api/V1/WorkoutExerciseTest.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Models\Exercise;
+use App\Models\User;
+use App\Models\Workout;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
+use Tests\TestCase;
+
+class WorkoutExerciseTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createExercise(
+        ?User $user,
+        string $type = 'resistance',
+        array $overrides = [],
+    ): Exercise {
+        $exercise = Exercise::create(array_merge([
+            'name' => 'Test Exercise',
+            'type' => $type,
+            'user_id' => $user?->id,
+        ], $overrides));
+
+        $defaults = match ($type) {
+            'resistance' => [],
+            'timed_hold' => [],
+            'distance' => ['distance_unit' => 'meters'],
+            'interval' => [],
+            default => [],
+        };
+
+        $childRelation = match ($type) {
+            'resistance' => 'resistance',
+            'timed_hold' => 'timedHold',
+            'distance' => 'distance',
+            'interval' => 'interval',
+            default => 'resistance',
+        };
+
+        $exercise->$childRelation()->create($defaults);
+
+        return $exercise;
+    }
+
+    // -- Attach --
+
+    public function test_attaches_exercise_to_workout(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance', ['name' => 'Bench Press']);
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+
+        Passport::actingAs($user);
+
+        $response = $this->postJson("/api/v1/workouts/{$workout->id}/exercises", [
+            'exercise_id' => $exercise->id,
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.exercises.0.id', $exercise->id)
+            ->assertJsonPath('data.exercises.0.name', 'Bench Press');
+
+        $this->assertDatabaseHas('exercise_workout', [
+            'workout_id' => $workout->id,
+            'exercise_id' => $exercise->id,
+            'exercise_order' => 0,
+        ]);
+    }
+
+    public function test_rejects_duplicate_exercise_attachment(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance');
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+        $workout->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+
+        Passport::actingAs($user);
+
+        $this->postJson("/api/v1/workouts/{$workout->id}/exercises", [
+            'exercise_id' => $exercise->id,
+        ])->assertStatus(409);
+    }
+
+    public function test_auto_assigns_exercise_order(): void
+    {
+        $user = User::factory()->create();
+        $exercise1 = $this->createExercise($user, 'resistance', ['name' => 'Exercise 1']);
+        $exercise2 = $this->createExercise($user, 'resistance', ['name' => 'Exercise 2']);
+        $exercise3 = $this->createExercise($user, 'resistance', ['name' => 'Exercise 3']);
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+
+        Passport::actingAs($user);
+
+        $this->postJson("/api/v1/workouts/{$workout->id}/exercises", [
+            'exercise_id' => $exercise1->id,
+        ])->assertStatus(201);
+
+        $this->postJson("/api/v1/workouts/{$workout->id}/exercises", [
+            'exercise_id' => $exercise2->id,
+        ])->assertStatus(201);
+
+        $this->postJson("/api/v1/workouts/{$workout->id}/exercises", [
+            'exercise_id' => $exercise3->id,
+        ])->assertStatus(201);
+
+        $this->assertDatabaseHas('exercise_workout', [
+            'exercise_id' => $exercise1->id,
+            'exercise_order' => 0,
+        ]);
+
+        $this->assertDatabaseHas('exercise_workout', [
+            'exercise_id' => $exercise2->id,
+            'exercise_order' => 1,
+        ]);
+
+        $this->assertDatabaseHas('exercise_workout', [
+            'exercise_id' => $exercise3->id,
+            'exercise_order' => 2,
+        ]);
+    }
+
+    public function test_validates_exercise_belongs_to_user_or_system(): void
+    {
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $otherExercise = $this->createExercise($otherUser, 'resistance');
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+
+        Passport::actingAs($user);
+
+        $this->postJson("/api/v1/workouts/{$workout->id}/exercises", [
+            'exercise_id' => $otherExercise->id,
+        ])->assertStatus(422)
+            ->assertJsonValidationErrors('exercise_id');
+
+        $systemExercise = $this->createExercise(null, 'resistance', ['name' => 'System Exercise']);
+
+        $this->postJson("/api/v1/workouts/{$workout->id}/exercises", [
+            'exercise_id' => $systemExercise->id,
+        ])->assertStatus(201);
+    }
+
+    // -- Detach --
+
+    public function test_detaches_exercise_from_workout(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance');
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+        $workout->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+
+        Passport::actingAs($user);
+
+        $this->deleteJson("/api/v1/workouts/{$workout->id}/exercises/{$exercise->id}")
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('exercise_workout', [
+            'workout_id' => $workout->id,
+            'exercise_id' => $exercise->id,
+        ]);
+    }
+
+    public function test_detach_cascades_entries_and_metrics(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance');
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+        $workout->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+
+        $entry = $workout->entries()->create([
+            'exercise_id' => $exercise->id,
+            'set_order' => 0,
+        ]);
+
+        $metric = $entry->loadMetric()->create([
+            'target_weight' => 100,
+        ]);
+
+        Passport::actingAs($user);
+
+        $this->deleteJson("/api/v1/workouts/{$workout->id}/exercises/{$exercise->id}")
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('exercise_workout', [
+            'exercise_id' => $exercise->id,
+        ]);
+
+        $this->assertDatabaseMissing('workout_entries', ['id' => $entry->id]);
+        $this->assertDatabaseMissing('log_load_metrics', ['id' => $metric->id]);
+
+        $this->assertDatabaseHas('workouts', ['id' => $workout->id]);
+    }
+
+    // -- Reorder --
+
+    public function test_reorders_exercises(): void
+    {
+        $user = User::factory()->create();
+        $exercise1 = $this->createExercise($user, 'resistance', ['name' => 'Exercise 1']);
+        $exercise2 = $this->createExercise($user, 'resistance', ['name' => 'Exercise 2']);
+        $exercise3 = $this->createExercise($user, 'resistance', ['name' => 'Exercise 3']);
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+
+        $workout->exercises()->attach($exercise1->id, ['exercise_order' => 0]);
+        $workout->exercises()->attach($exercise2->id, ['exercise_order' => 1]);
+        $workout->exercises()->attach($exercise3->id, ['exercise_order' => 2]);
+
+        Passport::actingAs($user);
+
+        $this->putJson("/api/v1/workouts/{$workout->id}/exercises/reorder", [
+            'ids' => [$exercise3->id, $exercise1->id, $exercise2->id],
+        ])->assertOk();
+
+        $this->assertDatabaseHas('exercise_workout', [
+            'exercise_id' => $exercise3->id,
+            'exercise_order' => 0,
+        ]);
+
+        $this->assertDatabaseHas('exercise_workout', [
+            'exercise_id' => $exercise1->id,
+            'exercise_order' => 1,
+        ]);
+
+        $this->assertDatabaseHas('exercise_workout', [
+            'exercise_id' => $exercise2->id,
+            'exercise_order' => 2,
+        ]);
+    }
+
+    // -- Authorization --
+
+    public function test_cannot_attach_to_other_users_workout(): void
+    {
+        $owner = User::factory()->create();
+        $attacher = User::factory()->create();
+        $exercise = $this->createExercise($attacher, 'resistance');
+        $workout = Workout::factory()->create(['user_id' => $owner->id]);
+
+        Passport::actingAs($attacher);
+
+        $this->postJson("/api/v1/workouts/{$workout->id}/exercises", [
+            'exercise_id' => $exercise->id,
+        ])->assertStatus(403);
+    }
+
+    public function test_cannot_detach_from_other_users_workout(): void
+    {
+        $owner = User::factory()->create();
+        $detacher = User::factory()->create();
+        $exercise = $this->createExercise($owner, 'resistance');
+        $workout = Workout::factory()->create(['user_id' => $owner->id]);
+        $workout->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+
+        Passport::actingAs($detacher);
+
+        $this->deleteJson("/api/v1/workouts/{$workout->id}/exercises/{$exercise->id}")
+            ->assertStatus(403);
+    }
+}

--- a/tests/Feature/Api/V1/WorkoutTest.php
+++ b/tests/Feature/Api/V1/WorkoutTest.php
@@ -1,0 +1,258 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Models\Exercise;
+use App\Models\User;
+use App\Models\Workout;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
+use Tests\TestCase;
+
+class WorkoutTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createExercise(
+        ?User $user,
+        string $type = 'resistance',
+        array $overrides = [],
+    ): Exercise {
+        $exercise = Exercise::create(array_merge([
+            'name' => 'Test Exercise',
+            'type' => $type,
+            'user_id' => $user?->id,
+        ], $overrides));
+
+        $defaults = match ($type) {
+            'resistance' => [],
+            'timed_hold' => [],
+            'distance' => ['distance_unit' => 'meters'],
+            'interval' => [],
+            default => [],
+        };
+
+        $childRelation = match ($type) {
+            'resistance' => 'resistance',
+            'timed_hold' => 'timedHold',
+            'distance' => 'distance',
+            'interval' => 'interval',
+            default => 'resistance',
+        };
+
+        $exercise->$childRelation()->create($defaults);
+
+        return $exercise;
+    }
+
+    // -- Store --
+
+    public function test_creates_workout(): void
+    {
+        $user = User::factory()->create();
+        Passport::actingAs($user);
+
+        $response = $this->postJson('/api/v1/workouts', [
+            'name' => 'Leg Day',
+            'date' => '2026-01-15',
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.name', 'Leg Day')
+            ->assertJsonPath('data.date', '2026-01-15');
+
+        $this->assertDatabaseHas('workouts', [
+            'name' => 'Leg Day',
+            'user_id' => $user->id,
+        ]);
+    }
+
+    public function test_validates_required_fields_for_store(): void
+    {
+        $user = User::factory()->create();
+        Passport::actingAs($user);
+
+        $this->postJson('/api/v1/workouts', [])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['name', 'date']);
+    }
+
+    public function test_validates_exhaustion_range(): void
+    {
+        $user = User::factory()->create();
+        Passport::actingAs($user);
+
+        $this->postJson('/api/v1/workouts', [
+            'name' => 'Test',
+            'date' => '2026-01-15',
+            'exhaustion' => 0,
+        ])->assertStatus(422)
+            ->assertJsonValidationErrors('exhaustion');
+
+        $this->postJson('/api/v1/workouts', [
+            'name' => 'Test',
+            'date' => '2026-01-15',
+            'exhaustion' => 11,
+        ])->assertStatus(422)
+            ->assertJsonValidationErrors('exhaustion');
+
+        $this->postJson('/api/v1/workouts', [
+            'name' => 'Test',
+            'date' => '2026-01-15',
+            'exhaustion' => 1,
+        ])->assertStatus(201);
+
+        $this->postJson('/api/v1/workouts', [
+            'name' => 'Test 2',
+            'date' => '2026-01-15',
+            'exhaustion' => 10,
+        ])->assertStatus(201);
+    }
+
+    // -- Index --
+
+    public function test_lists_own_workouts_paginated(): void
+    {
+        $user = User::factory()->create();
+        $other = User::factory()->create();
+
+        Workout::factory(3)->create(['user_id' => $user->id]);
+        Workout::factory(1)->create(['user_id' => $other->id]);
+
+        Passport::actingAs($user);
+
+        $response = $this->getJson('/api/v1/workouts');
+
+        $response->assertOk()
+            ->assertJsonPath('meta.current_page', 1)
+            ->assertJsonPath('meta.total', 3);
+
+        $this->assertCount(3, $response->json('data'));
+    }
+
+    // -- Show --
+
+    public function test_shows_workout_with_exercises_and_entries(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance');
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+        $workout->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+
+        $entry = $workout->entries()->create([
+            'exercise_id' => $exercise->id,
+            'set_order' => 0,
+        ]);
+
+        $entry->loadMetric()->create([
+            'target_weight' => 100,
+            'actual_weight' => 95,
+        ]);
+
+        $entry->repMetric()->create([
+            'target_reps' => 10,
+            'actual_reps' => 8,
+        ]);
+
+        Passport::actingAs($user);
+
+        $response = $this->getJson("/api/v1/workouts/{$workout->id}");
+
+        $response->assertOk()
+            ->assertJsonPath('data.id', $workout->id)
+            ->assertJsonPath('data.exercises.0.exercise_order', 0)
+            ->assertJsonPath('data.entries.0.metrics.load.target_weight', '100.00')
+            ->assertJsonPath('data.entries.0.metrics.reps.target_reps', 10);
+    }
+
+    public function test_cannot_view_other_users_workout(): void
+    {
+        $owner = User::factory()->create();
+        $viewer = User::factory()->create();
+        $workout = Workout::factory()->create(['user_id' => $owner->id]);
+
+        Passport::actingAs($viewer);
+
+        $this->getJson("/api/v1/workouts/{$workout->id}")
+            ->assertStatus(403);
+    }
+
+    // -- Update --
+
+    public function test_updates_workout(): void
+    {
+        $user = User::factory()->create();
+        $workout = Workout::factory()->create(['user_id' => $user->id, 'name' => 'Old Name']);
+        Passport::actingAs($user);
+
+        $this->putJson("/api/v1/workouts/{$workout->id}", ['name' => 'New Name'])
+            ->assertOk()
+            ->assertJsonPath('data.name', 'New Name');
+    }
+
+    public function test_cannot_update_other_users_workout(): void
+    {
+        $owner = User::factory()->create();
+        $updater = User::factory()->create();
+        $workout = Workout::factory()->create(['user_id' => $owner->id]);
+
+        Passport::actingAs($updater);
+
+        $this->putJson("/api/v1/workouts/{$workout->id}", ['name' => 'Hacked'])
+            ->assertStatus(403);
+    }
+
+    // -- Destroy --
+
+    public function test_deletes_workout(): void
+    {
+        $user = User::factory()->create();
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+        Passport::actingAs($user);
+
+        $this->deleteJson("/api/v1/workouts/{$workout->id}")
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('workouts', ['id' => $workout->id]);
+    }
+
+    public function test_delete_cascades_entries_and_metrics(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance');
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+        $workout->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+
+        $entry = $workout->entries()->create([
+            'exercise_id' => $exercise->id,
+            'set_order' => 0,
+        ]);
+
+        $metric = $entry->loadMetric()->create([
+            'target_weight' => 100,
+            'actual_weight' => 95,
+        ]);
+
+        Passport::actingAs($user);
+
+        $this->deleteJson("/api/v1/workouts/{$workout->id}")
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('workouts', ['id' => $workout->id]);
+        $this->assertDatabaseMissing('workout_entries', ['id' => $entry->id]);
+        $this->assertDatabaseMissing('log_load_metrics', ['id' => $metric->id]);
+    }
+
+    // -- Auth --
+
+    public function test_unauthenticated_cannot_access_workouts(): void
+    {
+        $this->getJson('/api/v1/workouts')
+            ->assertStatus(401);
+
+        $this->postJson('/api/v1/workouts', ['name' => 'Nope', 'date' => '2026-01-15'])
+            ->assertStatus(401);
+    }
+}


### PR DESCRIPTION
## Problem

The app had no way to log workouts. Exercise definitions and equipment types existed, but there was no model for a workout session, no way to record sets (entries), and no way to attach the composable metric dimensions (load, reps, duration, distance, cardio settings, intervals, intensity) that each exercise type requires.

Exercises also could not be blocked from deletion when referenced by workout data, so a user could delete an exercise that had logged history.

## Solution

Added the full workout logging API: Workout model with date, exhaustion, and soreness fields; an exercise-workout pivot for attaching exercises in order; WorkoutEntry for individual sets; and 8 composable metric tables (log_load_metrics, log_rep_metrics, log_duration_metrics, log_distance_metrics, log_cardio_settings, log_interval_headers, log_interval_rounds, log_intensity_metrics), each with a unique FK to workout_entries.

Three controllers handle the surface area: WorkoutController for standard CRUD with paginated listing, WorkoutExerciseController for attach/detach/reorder of exercises within a workout (detach cascades entries and metrics), and WorkoutEntryController for nested entry CRUD with a `syncMetrics()` method that upserts metric records from a nested `metrics` request key. Interval rounds are nested inside the interval header and synced as a batch.

ExerciseController's destroy method now checks both exercise_workout and workout_entries before allowing deletion, returning 409 when the exercise is in use.

36 feature tests cover CRUD, cascade behavior across all deletion paths, metric composition for all four exercise types, reorder transactions, scoped route binding, and multi-user isolation.
