### PR TITLE
PS-60 - Wiring exercise definitions UI to real API with TanStack Query

### DIFF
--- a/resources/js/api/exercises.ts
+++ b/resources/js/api/exercises.ts
@@ -1,0 +1,45 @@
+import { api } from './client'
+import { toExercise, type RawExercise } from './transformers'
+import type { Exercise, ExerciseType } from './types'
+
+export interface CreateExercisePayload {
+  name: string
+  type: ExerciseType
+  equipment_type_id: number | null
+  notes: string | null
+  type_attributes: Record<string, unknown>
+}
+
+export interface UpdateExercisePayload {
+  name: string
+  equipment_type_id: number | null
+  notes: string | null
+  type_attributes?: Record<string, unknown>
+}
+
+export async function listExercises(): Promise<Exercise[]> {
+  const { data } = await api.get('/exercises')
+  return (data.data as RawExercise[]).map(toExercise)
+}
+
+export async function getExercise(id: string): Promise<Exercise> {
+  const { data } = await api.get(`/exercises/${id}`)
+  return toExercise(data.data as RawExercise)
+}
+
+export async function createExercise(payload: CreateExercisePayload): Promise<Exercise> {
+  const { data } = await api.post('/exercises', payload)
+  return toExercise(data.data as RawExercise)
+}
+
+export async function updateExercise(
+  id: string,
+  payload: UpdateExercisePayload
+): Promise<Exercise> {
+  const { data } = await api.put(`/exercises/${id}`, payload)
+  return toExercise(data.data as RawExercise)
+}
+
+export async function deleteExercise(id: string): Promise<void> {
+  await api.delete(`/exercises/${id}`)
+}

--- a/resources/js/api/transformers.ts
+++ b/resources/js/api/transformers.ts
@@ -1,4 +1,4 @@
-import type { User, EquipmentType } from '@/api/types'
+import type { User, EquipmentType, Exercise, ExerciseType } from '@/api/types'
 import type { MeasurementSystem } from '@/lib/units'
 
 export interface RawUser {
@@ -33,4 +33,52 @@ export function toEquipmentType(raw: RawEquipmentType): EquipmentType {
     name: raw.name,
     isSystem: raw.is_system,
   }
+}
+
+export interface RawExercise {
+  id: number
+  name: string
+  type: string
+  notes: string | null
+  user_id: number | null
+  equipment_type_id: number | null
+  type_attributes: Record<string, unknown> | null
+  created_at: string
+  updated_at: string
+}
+
+export function toExercise(raw: RawExercise): Exercise {
+  const exercise: Exercise = {
+    id: String(raw.id),
+    userId: raw.user_id !== null ? String(raw.user_id) : null,
+    name: raw.name,
+    type: raw.type as ExerciseType,
+    equipmentTypeId: raw.equipment_type_id !== null ? String(raw.equipment_type_id) : null,
+    notes: raw.notes,
+  }
+
+  const attrs = raw.type_attributes
+  if (!attrs) return exercise
+
+  switch (raw.type) {
+    case 'resistance':
+      exercise.bodyweightBase = attrs.bodyweight_base as boolean
+      exercise.allowsAddedWeight = attrs.allows_added_weight as boolean
+      exercise.bilateral = attrs.bilateral as boolean
+      break
+    case 'timed_hold':
+      exercise.targetDurationSeconds = (attrs.target_duration_seconds as number) ?? null
+      break
+    case 'distance':
+      exercise.distanceUnit = attrs.distance_unit as string
+      exercise.tracksElevation = attrs.tracks_elevation as boolean
+      break
+    case 'interval':
+      exercise.defaultWorkSeconds = (attrs.default_work_seconds as number) ?? null
+      exercise.defaultRestSeconds = (attrs.default_rest_seconds as number) ?? null
+      exercise.defaultRounds = (attrs.default_rounds as number) ?? null
+      break
+  }
+
+  return exercise
 }

--- a/resources/js/api/types.ts
+++ b/resources/js/api/types.ts
@@ -19,7 +19,7 @@ export type ExerciseType = 'resistance' | 'timed_hold' | 'distance' | 'interval'
 
 export interface Exercise {
   id: string
-  userId: string
+  userId: string | null
   name: string
   type: ExerciseType
   equipmentTypeId: string | null
@@ -27,10 +27,12 @@ export interface Exercise {
   bodyweightBase?: boolean
   allowsAddedWeight?: boolean
   bilateral?: boolean
+  targetDurationSeconds?: number | null
+  distanceUnit?: string
   tracksElevation?: boolean
-  defaultWorkSeconds?: number
-  defaultRestSeconds?: number
-  defaultRounds?: number
+  defaultWorkSeconds?: number | null
+  defaultRestSeconds?: number | null
+  defaultRounds?: number | null
 }
 
 export interface LoadMetric {

--- a/resources/js/pages/exercise-detail.tsx
+++ b/resources/js/pages/exercise-detail.tsx
@@ -1,17 +1,30 @@
 import { useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { isAxiosError } from 'axios'
 import { Trash2 } from 'lucide-react'
 import { PageHeader } from '@/components/ui/page-header'
 import { Card } from '@/components/ui/card'
 import { TypeBadge } from '@/components/ui/type-badge'
 import { InlineEdit } from '@/components/ui/inline-edit'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
-import { useExercise } from '@/hooks/use-exercises'
-import { useEquipment } from '@/hooks/use-equipment'
-import { useWorkouts } from '@/hooks/use-workouts'
 import { useApp } from '@/lib/use-app'
-import { equipmentName, exerciseUsageCount } from '@/lib/domain'
+import { equipmentName } from '@/lib/domain'
 import { formatDuration } from '@/lib/formatters'
+import {
+  getExercise,
+  updateExercise as updateExerciseApi,
+  deleteExercise as deleteExerciseApi,
+} from '@/api/exercises'
+import { listEquipment } from '@/api/equipment'
+import type { UpdateExercisePayload } from '@/api/exercises'
+
+const DISTANCE_UNIT_LABELS: Record<string, string> = {
+  meters: 'Meters',
+  kilometers: 'Kilometers',
+  miles: 'Miles',
+  yards: 'Yards',
+}
 
 function AttrRow({ label, value }: { label: string; value: string }) {
   return (
@@ -24,12 +37,66 @@ function AttrRow({ label, value }: { label: string; value: string }) {
 
 export function ExerciseDetailPage() {
   const { id } = useParams<{ id: string }>()
-  const { data: ex } = useExercise(id || '')
-  const { data: equipment } = useEquipment()
-  const { data: workouts } = useWorkouts()
-  const { updateExercise, deleteExercise, toast, user } = useApp()
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const { toast } = useApp()
   const [deleting, setDeleting] = useState(false)
+
+  const { data: ex, isLoading } = useQuery({
+    queryKey: ['exercises', id],
+    queryFn: () => {
+      if (!id) throw new Error('Exercise ID is required')
+      return getExercise(id)
+    },
+    enabled: !!id,
+  })
+
+  const { data: equipment = [] } = useQuery({
+    queryKey: ['equipment'],
+    queryFn: listEquipment,
+  })
+
+  const updateMutation = useMutation({
+    mutationFn: (payload: UpdateExercisePayload) => {
+      if (!id) throw new Error('Exercise ID is required')
+      return updateExerciseApi(id, payload)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['exercises'] })
+      toast('Exercise updated.')
+    },
+    onError: () => {
+      toast('Could not update. Try again.')
+    },
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: () => {
+      if (!id) throw new Error('Exercise ID is required')
+      return deleteExerciseApi(id)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['exercises'] })
+      toast('Exercise deleted.')
+      navigate('/exercises')
+    },
+    onError: error => {
+      if (isAxiosError(error) && error.response?.status === 409) {
+        toast(error.response.data?.message ?? 'Exercise is in use.')
+      } else {
+        toast('Could not delete. Try again.')
+      }
+    },
+  })
+
+  if (isLoading) {
+    return (
+      <>
+        <PageHeader back onBack={() => navigate('/exercises')} title="Loading..." />
+        <p className="text-text-secondary text-sm">Loading exercise...</p>
+      </>
+    )
+  }
 
   if (!ex) {
     return (
@@ -46,16 +113,22 @@ export function ExerciseDetailPage() {
     )
   }
 
-  const usage = exerciseUsageCount(workouts, ex.id)
-  const inUse = usage > 0
-
+  const isOwned = ex.userId !== null
   const attrs: Array<[string, string]> = []
+
   if (ex.type === 'resistance') {
     attrs.push(['Bodyweight base', ex.bodyweightBase ? 'Yes' : 'No'])
     attrs.push(['Allows added weight', ex.allowsAddedWeight ? 'Yes' : 'No'])
     attrs.push(['Bilateral', ex.bilateral ? 'Yes' : 'No (single-arm/leg)'])
+  } else if (ex.type === 'timed_hold') {
+    if (ex.targetDurationSeconds) {
+      attrs.push(['Target duration', formatDuration(ex.targetDurationSeconds)])
+    }
   } else if (ex.type === 'distance') {
-    attrs.push(['Distance unit', user.measurementSystem === 'metric' ? 'Kilometers' : 'Miles'])
+    attrs.push([
+      'Distance unit',
+      DISTANCE_UNIT_LABELS[ex.distanceUnit ?? ''] ?? ex.distanceUnit ?? '',
+    ])
     attrs.push(['Tracks elevation', ex.tracksElevation ? 'Yes' : 'No'])
   } else if (ex.type === 'interval') {
     attrs.push(['Default work', formatDuration(ex.defaultWorkSeconds)])
@@ -69,20 +142,27 @@ export function ExerciseDetailPage() {
         back
         onBack={() => navigate('/exercises')}
         title={
-          <InlineEdit
-            value={ex.name}
-            onChange={v => updateExercise(ex.id, { name: v })}
-            ariaLabel="Exercise name"
-          />
+          isOwned ? (
+            <InlineEdit
+              value={ex.name}
+              onChange={v =>
+                updateMutation.mutate({
+                  name: v,
+                  equipment_type_id: ex.equipmentTypeId ? Number(ex.equipmentTypeId) : null,
+                  notes: ex.notes,
+                })
+              }
+              ariaLabel="Exercise name"
+            />
+          ) : (
+            ex.name
+          )
         }
       />
 
       <div className="flex items-center gap-2 mb-5">
         <TypeBadge type={ex.type} />
-        <span className="text-sm text-text-secondary inline-flex items-center gap-1.5">
-          <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor">
-            <path d="M7 4h10v2H7V4zm-1 6h1v7H6v-7zm3 0h1v7H9v-7zm3 0h1v7h-1v-7zm3 0h1v7h-1v-7zm3 0h1v7h-1v-7zm1-2c1.1 0 2-.9 2-2h-2c0 1.1.9 2 2 2s2-.9 2-2h-2c0 1.1.9 2 2 2s2-.9 2-2h2c0 1.1-.9 2-2 2h-2V4z" />
-          </svg>
+        <span className="text-sm text-text-secondary">
           {equipmentName(equipment, ex.equipmentTypeId)}
         </span>
       </div>
@@ -140,43 +220,29 @@ export function ExerciseDetailPage() {
         </svg>
       </button>
 
-      <div className="flex items-center gap-2">
-        <button
-          onClick={() => {
-            if (!inUse) setDeleting(true)
-          }}
-          disabled={inUse}
-          title={
-            inUse
-              ? `In use by ${usage} workout${usage === 1 ? '' : 's'} and cannot be deleted.`
-              : 'Delete exercise'
-          }
-          className={`inline-flex items-center gap-2 text-sm font-semibold px-3 h-11 rounded-lg ${
-            inUse
-              ? 'text-text-muted opacity-50 cursor-not-allowed'
-              : 'text-destructive hover:bg-surface-muted'
-          }`}
-        >
-          <Trash2 size={17} /> Delete
-        </button>
-        {inUse && (
-          <span className="text-[12px] text-text-muted">
-            In use by {usage} workout{usage === 1 ? '' : 's'}
-          </span>
-        )}
-      </div>
+      {isOwned && (
+        <>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => setDeleting(true)}
+              className="inline-flex items-center gap-2 text-sm font-semibold px-3 h-11 rounded-lg text-destructive hover:bg-surface-muted"
+            >
+              <Trash2 size={17} /> Delete
+            </button>
+          </div>
 
-      <ConfirmDialog
-        open={deleting}
-        title="Delete exercise?"
-        message={`"${ex.name}" will be removed from your catalog.`}
-        onCancel={() => setDeleting(false)}
-        onConfirm={() => {
-          deleteExercise(ex.id)
-          toast('Exercise deleted.')
-          navigate('/exercises')
-        }}
-      />
+          <ConfirmDialog
+            open={deleting}
+            title="Delete exercise?"
+            message={`"${ex.name}" will be removed from your catalog.`}
+            onCancel={() => setDeleting(false)}
+            onConfirm={() => {
+              setDeleting(false)
+              deleteMutation.mutate()
+            }}
+          />
+        </>
+      )}
     </>
   )
 }

--- a/resources/js/pages/exercises.tsx
+++ b/resources/js/pages/exercises.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { isAxiosError } from 'axios'
 import { Search, Plus, Trash2 } from 'lucide-react'
 import { PageHeader } from '@/components/ui/page-header'
 import { Button } from '@/components/ui/button'
@@ -10,12 +12,12 @@ import { EmptyState } from '@/components/ui/empty-state'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { Sheet } from '@/components/ui/sheet'
 import { Toggle } from '@/components/ui/toggle'
-import { useExercises } from '@/hooks/use-exercises'
-import { useEquipment } from '@/hooks/use-equipment'
-import { useWorkouts } from '@/hooks/use-workouts'
 import { useApp } from '@/lib/use-app'
-import { equipmentName, exerciseUsageCount, TYPE_LABELS } from '@/lib/domain'
+import { equipmentName, TYPE_LABELS } from '@/lib/domain'
+import { listExercises, createExercise, deleteExercise as deleteExerciseApi } from '@/api/exercises'
+import { listEquipment } from '@/api/equipment'
 import type { Exercise, ExerciseType, EquipmentType } from '@/api/types'
+import type { CreateExercisePayload } from '@/api/exercises'
 
 const TYPES: Array<{ value: string; label: string }> = [
   { value: 'all', label: 'All' },
@@ -25,55 +27,105 @@ const TYPES: Array<{ value: string; label: string }> = [
   { value: 'interval', label: 'Interval' },
 ]
 
-function CreateExerciseSheet({ open, onClose }: { open: boolean; onClose: () => void }) {
-  const { addExercise, toast } = useApp()
-  const { data: equipment } = useEquipment()
+function CreateExerciseSheet({ onClose }: { onClose: () => void }) {
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const { toast } = useApp()
+
+  const { data: equipment = [] } = useQuery({
+    queryKey: ['equipment'],
+    queryFn: listEquipment,
+  })
+
   const [name, setName] = useState('')
+  const [notes, setNotes] = useState('')
   const [type, setType] = useState<ExerciseType>('resistance')
   const [equip, setEquip] = useState('')
   const [bodyweight, setBodyweight] = useState(false)
   const [addedWeight, setAddedWeight] = useState(true)
   const [bilateral, setBilateral] = useState(true)
+  const [targetDurationSeconds, setTargetDurationSeconds] = useState('')
+  const [distanceUnit, setDistanceUnit] = useState('meters')
+  const [tracksElevation, setTracksElevation] = useState(false)
+  const [defaultWorkSeconds, setDefaultWorkSeconds] = useState('')
+  const [defaultRestSeconds, setDefaultRestSeconds] = useState('')
+  const [defaultRounds, setDefaultRounds] = useState('')
+  const [errors, setErrors] = useState<Record<string, string>>({})
 
-  if (open && name === '') {
-    setName('')
-    setType('resistance')
-    setEquip('')
-    setBodyweight(false)
-    setAddedWeight(true)
-    setBilateral(true)
-  }
+  const createMutation = useMutation({
+    mutationFn: createExercise,
+    onSuccess: exercise => {
+      queryClient.invalidateQueries({ queryKey: ['exercises'] })
+      toast('Exercise created.')
+      onClose()
+      navigate(`/exercises/${exercise.id}`)
+    },
+    onError: error => {
+      if (isAxiosError(error) && error.response?.status === 422) {
+        const fieldErrors = error.response.data?.errors as Record<string, string[]> | undefined
+        if (fieldErrors) {
+          const mapped: Record<string, string> = {}
+          for (const [key, messages] of Object.entries(fieldErrors)) {
+            if (messages[0]) mapped[key] = messages[0]
+          }
+          setErrors(mapped)
+          return
+        }
+      }
+      toast('Could not create exercise. Try again.')
+    },
+  })
 
   const create = () => {
-    const ex: Partial<Exercise> & { name: string; type: ExerciseType } = {
-      name: name.trim(),
-      type,
-      equipmentTypeId: equip || null,
-    }
+    const trimmed = name.trim()
+    if (!trimmed) return
+
+    setErrors({})
+
+    const typeAttributes: Record<string, unknown> = {}
+
     if (type === 'resistance') {
-      Object.assign(ex, { bodyweightBase: bodyweight, allowsAddedWeight: addedWeight, bilateral })
+      typeAttributes.bodyweight_base = bodyweight
+      typeAttributes.allows_added_weight = addedWeight
+      typeAttributes.bilateral = bilateral
+    } else if (type === 'timed_hold') {
+      if (targetDurationSeconds) {
+        typeAttributes.target_duration_seconds = parseInt(targetDurationSeconds)
+      }
+    } else if (type === 'distance') {
+      typeAttributes.distance_unit = distanceUnit
+      typeAttributes.tracks_elevation = tracksElevation
+    } else if (type === 'interval') {
+      if (defaultWorkSeconds) {
+        typeAttributes.default_work_seconds = parseInt(defaultWorkSeconds)
+      }
+      if (defaultRestSeconds) {
+        typeAttributes.default_rest_seconds = parseInt(defaultRestSeconds)
+      }
+      if (defaultRounds) {
+        typeAttributes.default_rounds = parseInt(defaultRounds)
+      }
     }
-    if (type === 'distance') {
-      Object.assign(ex, { tracksElevation: false })
+
+    const payload: CreateExercisePayload = {
+      name: trimmed,
+      type,
+      equipment_type_id: equip ? Number(equip) : null,
+      notes: notes.trim() || null,
+      type_attributes: typeAttributes,
     }
-    if (type === 'interval') {
-      Object.assign(ex, { defaultWorkSeconds: 60, defaultRestSeconds: 60, defaultRounds: 8 })
-    }
-    const created = addExercise(ex)
-    onClose()
-    toast('Exercise created.')
-    navigate(`/exercises/${created.id}`)
+
+    createMutation.mutate(payload)
   }
 
   return (
     <Sheet
-      open={open}
+      open={true}
       onClose={onClose}
       title="Create Exercise"
       footer={
-        <Button full disabled={!name.trim()} onClick={create}>
-          Create Exercise
+        <Button full disabled={!name.trim() || createMutation.isPending} onClick={create}>
+          {createMutation.isPending ? 'Creating...' : 'Create Exercise'}
         </Button>
       }
     >
@@ -87,9 +139,25 @@ function CreateExerciseSheet({ open, onClose }: { open: boolean; onClose: () => 
             value={name}
             onChange={e => setName(e.target.value)}
             placeholder="e.g. Incline Bench Press"
-            className="ps-input w-full px-3 py-2.5 text-sm"
+            className={`ps-input w-full px-3 py-2.5 text-sm ${errors.name ? 'border-destructive' : ''}`}
+          />
+          {errors.name && <p className="text-destructive text-xs mt-1">{errors.name}</p>}
+        </div>
+
+        <div>
+          <label htmlFor="exercise-notes" className="label-caps text-text-secondary block mb-1.5">
+            Notes (optional)
+          </label>
+          <textarea
+            id="exercise-notes"
+            value={notes}
+            onChange={e => setNotes(e.target.value)}
+            placeholder="e.g. Variations, form cues..."
+            className="ps-input w-full px-3 py-2.5 text-sm resize-none"
+            rows={3}
           />
         </div>
+
         <div>
           {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
           <label id="exercise-type-label" className="label-caps text-text-secondary block mb-1.5">
@@ -124,6 +192,7 @@ function CreateExerciseSheet({ open, onClose }: { open: boolean; onClose: () => 
             ))}
           </div>
         </div>
+
         <div>
           <label
             htmlFor="exercise-equipment"
@@ -145,23 +214,112 @@ function CreateExerciseSheet({ open, onClose }: { open: boolean; onClose: () => 
             ))}
           </select>
         </div>
+
         {type === 'resistance' && (
           <div className="ps-metric p-3 flex flex-col gap-3">
-            {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-            <label className="flex items-center justify-between" aria-label="Bodyweight base">
+            <div className="flex items-center justify-between" aria-label="Bodyweight base">
               <span className="text-sm">Bodyweight base</span>
               <Toggle checked={bodyweight} onChange={setBodyweight} label="Bodyweight base" />
-            </label>
-            {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-            <label className="flex items-center justify-between" aria-label="Allows added weight">
+            </div>
+            <div className="flex items-center justify-between" aria-label="Allows added weight">
               <span className="text-sm">Allows added weight</span>
               <Toggle checked={addedWeight} onChange={setAddedWeight} label="Allows added weight" />
-            </label>
-            {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-            <label className="flex items-center justify-between" aria-label="Bilateral">
+            </div>
+            <div className="flex items-center justify-between" aria-label="Bilateral">
               <span className="text-sm">Bilateral</span>
               <Toggle checked={bilateral} onChange={setBilateral} label="Bilateral" />
-            </label>
+            </div>
+          </div>
+        )}
+
+        {type === 'timed_hold' && (
+          <div className="ps-metric p-3 flex flex-col gap-3">
+            <div className="flex items-center justify-between">
+              <label htmlFor="target-duration" className="text-sm">
+                Target duration (seconds, optional)
+              </label>
+              <input
+                id="target-duration"
+                type="number"
+                value={targetDurationSeconds}
+                onChange={e => setTargetDurationSeconds(e.target.value)}
+                className="ps-input w-20 px-2 py-1.5 text-sm"
+                min="1"
+              />
+            </div>
+          </div>
+        )}
+
+        {type === 'distance' && (
+          <div className="ps-metric p-3 flex flex-col gap-3">
+            <div className="flex items-center justify-between">
+              <label htmlFor="distance-unit" className="text-sm">
+                Distance unit
+              </label>
+              <select
+                id="distance-unit"
+                value={distanceUnit}
+                onChange={e => setDistanceUnit(e.target.value)}
+                className="ps-input px-2 py-1.5 text-sm"
+              >
+                <option value="meters">Meters</option>
+                <option value="kilometers">Kilometers</option>
+                <option value="miles">Miles</option>
+                <option value="yards">Yards</option>
+              </select>
+            </div>
+            <div className="flex items-center justify-between" aria-label="Tracks elevation">
+              <span className="text-sm">Tracks elevation</span>
+              <Toggle
+                checked={tracksElevation}
+                onChange={setTracksElevation}
+                label="Tracks elevation"
+              />
+            </div>
+          </div>
+        )}
+
+        {type === 'interval' && (
+          <div className="ps-metric p-3 flex flex-col gap-3">
+            <div className="flex items-center justify-between">
+              <label htmlFor="default-work" className="text-sm">
+                Work seconds (optional)
+              </label>
+              <input
+                id="default-work"
+                type="number"
+                value={defaultWorkSeconds}
+                onChange={e => setDefaultWorkSeconds(e.target.value)}
+                className="ps-input w-20 px-2 py-1.5 text-sm"
+                min="1"
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <label htmlFor="default-rest" className="text-sm">
+                Rest seconds (optional)
+              </label>
+              <input
+                id="default-rest"
+                type="number"
+                value={defaultRestSeconds}
+                onChange={e => setDefaultRestSeconds(e.target.value)}
+                className="ps-input w-20 px-2 py-1.5 text-sm"
+                min="1"
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <label htmlFor="default-rounds" className="text-sm">
+                Rounds (optional)
+              </label>
+              <input
+                id="default-rounds"
+                type="number"
+                value={defaultRounds}
+                onChange={e => setDefaultRounds(e.target.value)}
+                className="ps-input w-20 px-2 py-1.5 text-sm"
+                min="1"
+              />
+            </div>
           </div>
         )}
       </div>
@@ -170,11 +328,35 @@ function CreateExerciseSheet({ open, onClose }: { open: boolean; onClose: () => 
 }
 
 export function ExercisesPage() {
-  const { data: exercises } = useExercises()
-  const { data: equipment } = useEquipment()
-  const { data: workouts } = useWorkouts()
-  const { deleteExercise, toast } = useApp()
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const { toast } = useApp()
+
+  const { data: exercises = [], isLoading } = useQuery({
+    queryKey: ['exercises'],
+    queryFn: listExercises,
+  })
+
+  const { data: equipment = [] } = useQuery({
+    queryKey: ['equipment'],
+    queryFn: listEquipment,
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteExerciseApi,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['exercises'] })
+      toast('Exercise deleted.')
+    },
+    onError: error => {
+      if (isAxiosError(error) && error.response?.status === 409) {
+        toast(error.response.data?.message ?? 'Exercise is in use.')
+      } else {
+        toast('Could not delete. Try again.')
+      }
+    },
+  })
+
   const [q, setQ] = useState('')
   const [type, setType] = useState('all')
   const [equip, setEquip] = useState('all')
@@ -187,6 +369,15 @@ export function ExercisesPage() {
       (equip === 'all' || e.equipmentTypeId === equip) &&
       e.name.toLowerCase().includes(q.toLowerCase())
   )
+
+  if (isLoading) {
+    return (
+      <>
+        <PageHeader title="Exercises" />
+        <p className="text-text-secondary text-sm">Loading...</p>
+      </>
+    )
+  }
 
   return (
     <>
@@ -247,8 +438,7 @@ export function ExercisesPage() {
       {filtered.length ? (
         <div className="flex flex-col gap-2.5">
           {filtered.map(ex => {
-            const usage = exerciseUsageCount(workouts, ex.id)
-            const inUse = usage > 0
+            const isSystem = ex.userId === null
             return (
               <Card
                 key={ex.id}
@@ -262,28 +452,19 @@ export function ExercisesPage() {
                   </div>
                 </div>
                 <TypeBadge type={ex.type} />
-                <button
-                  onClick={e => {
-                    e.stopPropagation()
-                    if (!inUse) setDeleting(ex)
-                  }}
-                  disabled={inUse}
-                  title={
-                    inUse
-                      ? `${ex.name} is in use by ${usage} workout${usage === 1 ? '' : 's'} and cannot be deleted.`
-                      : 'Delete exercise'
-                  }
-                  aria-label={
-                    inUse ? `${ex.name} in use by ${usage} workouts` : `Delete ${ex.name}`
-                  }
-                  className={`h-10 w-10 flex items-center justify-center rounded-lg shrink-0 ${
-                    inUse
-                      ? 'text-text-muted opacity-50 cursor-not-allowed'
-                      : 'text-text-muted hover:text-destructive hover:bg-surface-muted'
-                  }`}
-                >
-                  <Trash2 size={17} />
-                </button>
+                {!isSystem && (
+                  <button
+                    onClick={e => {
+                      e.stopPropagation()
+                      setDeleting(ex)
+                    }}
+                    title="Delete exercise"
+                    aria-label={`Delete ${ex.name}`}
+                    className="h-10 w-10 flex items-center justify-center rounded-lg shrink-0 text-text-muted hover:text-destructive hover:bg-surface-muted"
+                  >
+                    <Trash2 size={17} />
+                  </button>
+                )}
               </Card>
             )
           })}
@@ -309,7 +490,7 @@ export function ExercisesPage() {
         </EmptyState>
       )}
 
-      <CreateExerciseSheet open={showCreate} onClose={() => setShowCreate(false)} />
+      {showCreate && <CreateExerciseSheet onClose={() => setShowCreate(false)} />}
       <ConfirmDialog
         open={!!deleting}
         title="Delete exercise?"
@@ -317,9 +498,8 @@ export function ExercisesPage() {
         onCancel={() => setDeleting(null)}
         onConfirm={() => {
           if (deleting) {
-            deleteExercise(deleting.id)
+            deleteMutation.mutate(deleting.id)
             setDeleting(null)
-            toast('Exercise deleted.')
           }
         }}
       />


### PR DESCRIPTION
## Problem

The exercise catalog, create form, and detail pages were running on fixture data from the AppProvider store. They had no connection to the Exercise API built in the previous phase, and the create form only supported resistance-type fields.

## Solution

- Created `api/exercises.ts` with list, get, create, update, and delete functions that call the Exercise API and return transformed domain objects.
- Added `RawExercise` type and `toExercise` transformer in `api/transformers.ts` to flatten the API's nested `type_attributes` into the existing `Exercise` interface.
- Updated `Exercise.userId` to `string | null` so the UI can distinguish system exercises (read-only) from user-owned ones. Added `targetDurationSeconds` and `distanceUnit` fields that were missing from the type.
- Rewrote `exercises.tsx` to fetch data with TanStack Query, matching the pattern from the equipment page. Client-side search, type, and equipment filters remain. Delete uses a mutation with 409 error handling.
- Rewrote `CreateExerciseSheet` to post to the real API with 422 validation error display. Added type-specific form fields for all four exercise types: resistance toggles, timed hold duration input, distance unit selector with elevation toggle, and interval work/rest/rounds inputs.
- Rewrote `exercise-detail.tsx` to fetch a single exercise via TanStack Query, edit the name through an update mutation, and delete through a delete mutation. System exercises hide edit and delete controls. Distance unit now displays the value stored on the exercise instead of deriving it from the user's measurement preference.
