### PR TITLE
PS-63 - Adding workout templates and clone-and-detach API

### DIFF
--- a/app/Http/Controllers/Api/V1/ExerciseController.php
+++ b/app/Http/Controllers/Api/V1/ExerciseController.php
@@ -120,11 +120,12 @@ class ExerciseController extends Controller
         $this->authorize('delete', $exercise);
 
         $inUse = DB::table('exercise_workout')->where('exercise_id', $exercise->id)->exists()
-            || DB::table('workout_entries')->where('exercise_id', $exercise->id)->exists();
+            || DB::table('workout_entries')->where('exercise_id', $exercise->id)->exists()
+            || DB::table('template_exercises')->where('exercise_id', $exercise->id)->exists();
 
         if ($inUse) {
             return response()->json([
-                'message' => 'Exercise is in use by workouts.',
+                'message' => 'Exercise is in use by workouts or templates.',
             ], 409);
         }
 

--- a/app/Http/Controllers/Api/V1/TemplateCloneController.php
+++ b/app/Http/Controllers/Api/V1/TemplateCloneController.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\CloneTemplateRequest;
+use App\Http\Resources\Api\V1\WorkoutResource;
+use App\Models\Workout;
+use App\Models\WorkoutTemplate;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+
+class TemplateCloneController extends Controller
+{
+    use AuthorizesRequests;
+
+    private const WORKOUT_EAGER_LOAD = [
+        'exercises',
+        'entries.exercise',
+        'entries.loadMetric',
+        'entries.repMetric',
+        'entries.durationMetric',
+        'entries.distanceMetric',
+        'entries.cardioSetting',
+        'entries.intervalHeader.rounds',
+        'entries.intensityMetric',
+    ];
+
+    public function __invoke(CloneTemplateRequest $request, WorkoutTemplate $template): JsonResponse
+    {
+        $this->authorize('view', $template);
+
+        $workout = DB::transaction(function () use ($request, $template) {
+            $workout = Workout::create([
+                'name' => $request->validated('name', $template->name),
+                'user_id' => $request->user()->id,
+                'date' => $request->validated('date'),
+            ]);
+
+            foreach ($template->exercises as $exercise) {
+                $workout->exercises()->attach($exercise->id, [
+                    'exercise_order' => $exercise->pivot->exercise_order,
+                ]);
+
+                $workout->entries()->create([
+                    'exercise_id' => $exercise->id,
+                    'set_order' => $exercise->pivot->exercise_order,
+                ]);
+            }
+
+            return $workout;
+        });
+
+        $workout->load(self::WORKOUT_EAGER_LOAD);
+
+        return (new WorkoutResource($workout))
+            ->response()
+            ->setStatusCode(201);
+    }
+}

--- a/app/Http/Controllers/Api/V1/TemplateExerciseController.php
+++ b/app/Http/Controllers/Api/V1/TemplateExerciseController.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\AttachExerciseRequest;
+use App\Http\Requests\Api\V1\ReorderRequest;
+use App\Http\Resources\Api\V1\WorkoutTemplateResource;
+use App\Models\Exercise;
+use App\Models\WorkoutTemplate;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\DB;
+
+class TemplateExerciseController extends Controller
+{
+    use AuthorizesRequests;
+
+    private const SHOW_EAGER_LOAD = ['exercises', 'groups'];
+
+    public function attach(AttachExerciseRequest $request, WorkoutTemplate $template): JsonResponse
+    {
+        $this->authorize('update', $template);
+
+        $exerciseId = $request->validated('exercise_id');
+
+        if ($template->exercises()->where('exercises.id', $exerciseId)->exists()) {
+            return response()->json([
+                'message' => 'Exercise is already attached to this template.',
+            ], 409);
+        }
+
+        $nextOrder = (int) ($template->exercises()->max('exercise_order') ?? -1);
+        $nextOrder++;
+
+        $template->exercises()->attach($exerciseId, ['exercise_order' => $nextOrder]);
+        $template->load(self::SHOW_EAGER_LOAD);
+
+        return (new WorkoutTemplateResource($template))
+            ->response()
+            ->setStatusCode(201);
+    }
+
+    public function detach(WorkoutTemplate $template, Exercise $exercise): Response
+    {
+        $this->authorize('update', $template);
+
+        $template->exercises()->detach($exercise->id);
+
+        return response()->noContent();
+    }
+
+    public function reorder(ReorderRequest $request, WorkoutTemplate $template): WorkoutTemplateResource
+    {
+        $this->authorize('update', $template);
+
+        DB::transaction(function () use ($request, $template) {
+            /** @var array<int, int> $ids */
+            $ids = $request->validated('ids');
+            foreach ($ids as $index => $id) {
+                $template->exercises()->updateExistingPivot($id, ['exercise_order' => $index]);
+            }
+        });
+
+        $template->load(self::SHOW_EAGER_LOAD);
+
+        return new WorkoutTemplateResource($template);
+    }
+}

--- a/app/Http/Controllers/Api/V1/WorkoutTemplateController.php
+++ b/app/Http/Controllers/Api/V1/WorkoutTemplateController.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\StoreWorkoutTemplateRequest;
+use App\Http\Requests\Api\V1\UpdateWorkoutTemplateRequest;
+use App\Http\Resources\Api\V1\WorkoutTemplateListResource;
+use App\Http\Resources\Api\V1\WorkoutTemplateResource;
+use App\Models\WorkoutTemplate;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\Response;
+
+class WorkoutTemplateController extends Controller
+{
+    use AuthorizesRequests;
+
+    private const SHOW_EAGER_LOAD = ['exercises', 'groups'];
+
+    public function index(Request $request): AnonymousResourceCollection
+    {
+        $user = $request->user();
+        $templates = WorkoutTemplate::where('user_id', $user->id)
+            ->with('exercises')
+            ->latest()
+            ->get();
+
+        return WorkoutTemplateListResource::collection($templates);
+    }
+
+    public function store(StoreWorkoutTemplateRequest $request): JsonResponse
+    {
+        $user = $request->user();
+        $template = WorkoutTemplate::create([
+            'name' => $request->validated('name'),
+            'user_id' => $user->id,
+            'notes' => $request->validated('notes'),
+        ]);
+
+        $template->load(self::SHOW_EAGER_LOAD);
+
+        return (new WorkoutTemplateResource($template))
+            ->response()
+            ->setStatusCode(201);
+    }
+
+    public function show(WorkoutTemplate $template): WorkoutTemplateResource
+    {
+        $this->authorize('view', $template);
+
+        $template->load(self::SHOW_EAGER_LOAD);
+
+        return new WorkoutTemplateResource($template);
+    }
+
+    public function update(UpdateWorkoutTemplateRequest $request, WorkoutTemplate $template): WorkoutTemplateResource
+    {
+        $this->authorize('update', $template);
+
+        $template->update($request->validated());
+        $template->load(self::SHOW_EAGER_LOAD);
+
+        return new WorkoutTemplateResource($template);
+    }
+
+    public function destroy(WorkoutTemplate $template): Response
+    {
+        $this->authorize('delete', $template);
+
+        $template->delete();
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Requests/Api/V1/CloneTemplateRequest.php
+++ b/app/Http/Requests/Api/V1/CloneTemplateRequest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CloneTemplateRequest extends FormRequest
+{
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        return [
+            'date' => ['required', 'date'],
+            'name' => ['sometimes', 'string', 'max:255'],
+        ];
+    }
+}

--- a/app/Http/Requests/Api/V1/StoreWorkoutTemplateRequest.php
+++ b/app/Http/Requests/Api/V1/StoreWorkoutTemplateRequest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreWorkoutTemplateRequest extends FormRequest
+{
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'notes' => ['sometimes', 'nullable', 'string'],
+        ];
+    }
+}

--- a/app/Http/Requests/Api/V1/UpdateWorkoutTemplateRequest.php
+++ b/app/Http/Requests/Api/V1/UpdateWorkoutTemplateRequest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateWorkoutTemplateRequest extends FormRequest
+{
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        return [
+            'name' => ['sometimes', 'string', 'max:255'],
+            'notes' => ['sometimes', 'nullable', 'string'],
+        ];
+    }
+}

--- a/app/Http/Resources/Api/V1/WorkoutTemplateListResource.php
+++ b/app/Http/Resources/Api/V1/WorkoutTemplateListResource.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Models\WorkoutTemplate;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin WorkoutTemplate */
+class WorkoutTemplateListResource extends JsonResource
+{
+    /** @return array<string, mixed> */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'notes' => $this->notes,
+            'exercises' => $this->whenLoaded('exercises', function (): array {
+                return $this->exercises->map(fn ($exercise) => [
+                    'id' => $exercise->id,
+                    'name' => $exercise->name,
+                    'type' => $exercise->type,
+                ])->all();
+            }),
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/app/Http/Resources/Api/V1/WorkoutTemplateResource.php
+++ b/app/Http/Resources/Api/V1/WorkoutTemplateResource.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Models\WorkoutTemplate;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin WorkoutTemplate */
+class WorkoutTemplateResource extends JsonResource
+{
+    /** @return array<string, mixed> */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'notes' => $this->notes,
+            'exercises' => $this->whenLoaded('exercises', function (): array {
+                return $this->exercises->map(fn ($exercise) => [
+                    'id' => $exercise->id,
+                    'name' => $exercise->name,
+                    'type' => $exercise->type,
+                    'equipment_type_id' => $exercise->equipment_type_id,
+                    'exercise_order' => $exercise->pivot->exercise_order,
+                    'template_entry_group_id' => $exercise->pivot->template_entry_group_id,
+                ])->all();
+            }),
+            'groups' => $this->whenLoaded('groups', function (): array {
+                return $this->groups->map(fn ($group) => [
+                    'id' => $group->id,
+                    'name' => $group->name,
+                    'planned_rounds' => $group->planned_rounds,
+                    'rest_between_exercises_seconds' => $group->rest_between_exercises_seconds,
+                    'rest_between_rounds_seconds' => $group->rest_between_rounds_seconds,
+                ])->all();
+            }),
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/app/Models/Pivots/TemplateExercisePivot.php
+++ b/app/Models/Pivots/TemplateExercisePivot.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Pivots;
+
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+/**
+ * @property int $exercise_order
+ * @property int|null $template_entry_group_id
+ */
+class TemplateExercisePivot extends Pivot
+{
+    public $timestamps = false;
+
+    protected $table = 'template_exercises';
+}

--- a/app/Models/TemplateEntryGroup.php
+++ b/app/Models/TemplateEntryGroup.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TemplateEntryGroup extends Model
+{
+    /** @var list<string> */
+    protected $fillable = [
+        'template_id',
+        'name',
+        'planned_rounds',
+        'rest_between_exercises_seconds',
+        'rest_between_rounds_seconds',
+    ];
+
+    /** @return BelongsTo<WorkoutTemplate, $this> */
+    public function template(): BelongsTo
+    {
+        return $this->belongsTo(WorkoutTemplate::class, 'template_id');
+    }
+}

--- a/app/Models/WorkoutTemplate.php
+++ b/app/Models/WorkoutTemplate.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Models\Pivots\TemplateExercisePivot;
+use Database\Factories\WorkoutTemplateFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class WorkoutTemplate extends Model
+{
+    /** @use HasFactory<WorkoutTemplateFactory> */
+    use HasFactory;
+
+    /** @var list<string> */
+    protected $fillable = [
+        'name',
+        'user_id',
+        'notes',
+    ];
+
+    /** @return BelongsTo<User, $this> */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /** @return BelongsToMany<Exercise, $this, TemplateExercisePivot, 'pivot'> */
+    public function exercises(): BelongsToMany
+    {
+        return $this->belongsToMany(Exercise::class, 'template_exercises', 'template_id', 'exercise_id')
+            ->using(TemplateExercisePivot::class)
+            ->withPivot('exercise_order', 'template_entry_group_id')
+            ->orderByPivot('exercise_order');
+    }
+
+    /** @return HasMany<TemplateEntryGroup, $this> */
+    public function groups(): HasMany
+    {
+        return $this->hasMany(TemplateEntryGroup::class, 'template_id');
+    }
+}

--- a/app/Policies/WorkoutTemplatePolicy.php
+++ b/app/Policies/WorkoutTemplatePolicy.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\User;
+use App\Models\WorkoutTemplate;
+
+class WorkoutTemplatePolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    public function view(User $user, WorkoutTemplate $template): bool
+    {
+        return $template->user_id === $user->id;
+    }
+
+    public function create(User $user): bool
+    {
+        return true;
+    }
+
+    public function update(User $user, WorkoutTemplate $template): bool
+    {
+        return $template->user_id === $user->id;
+    }
+
+    public function delete(User $user, WorkoutTemplate $template): bool
+    {
+        return $template->user_id === $user->id;
+    }
+}

--- a/database/factories/WorkoutTemplateFactory.php
+++ b/database/factories/WorkoutTemplateFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use App\Models\WorkoutTemplate;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<WorkoutTemplate> */
+class WorkoutTemplateFactory extends Factory
+{
+    /** @return array<string, mixed> */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'name' => fake()->words(3, true),
+        ];
+    }
+}

--- a/database/migrations/2026_06_28_300001_create_workout_templates_table.php
+++ b/database/migrations/2026_06_28_300001_create_workout_templates_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('workout_templates', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->text('notes')->nullable();
+            $table->timestamps();
+            $table->index('user_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('workout_templates');
+    }
+};

--- a/database/migrations/2026_06_28_300002_create_template_entry_groups_table.php
+++ b/database/migrations/2026_06_28_300002_create_template_entry_groups_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('template_entry_groups', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('template_id')->constrained('workout_templates')->cascadeOnDelete();
+            $table->string('name')->nullable();
+            $table->unsignedInteger('planned_rounds')->default(1);
+            $table->unsignedInteger('rest_between_exercises_seconds')->default(0);
+            $table->unsignedInteger('rest_between_rounds_seconds')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('template_entry_groups');
+    }
+};

--- a/database/migrations/2026_06_28_300003_create_template_exercises_table.php
+++ b/database/migrations/2026_06_28_300003_create_template_exercises_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('template_exercises', function (Blueprint $table) {
+            $table->foreignId('template_id')->constrained('workout_templates')->cascadeOnDelete();
+            $table->foreignId('exercise_id')->constrained()->restrictOnDelete();
+            $table->unsignedInteger('exercise_order');
+            $table->foreignId('template_entry_group_id')->nullable()->constrained('template_entry_groups')->nullOnDelete();
+            $table->primary(['template_id', 'exercise_id']);
+            $table->index(['template_id', 'exercise_order']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('template_exercises');
+    }
+};

--- a/resources/js/api/transformers.ts
+++ b/resources/js/api/transformers.ts
@@ -1,4 +1,4 @@
-import type { User, EquipmentType, Exercise, ExerciseType } from '@/api/types'
+import type { User, EquipmentType, Exercise, ExerciseType, WorkoutListItem } from '@/api/types'
 import type { MeasurementSystem } from '@/lib/units'
 
 export interface RawUser {
@@ -81,4 +81,32 @@ export function toExercise(raw: RawExercise): Exercise {
   }
 
   return exercise
+}
+
+export interface RawWorkoutListItem {
+  id: number
+  name: string
+  date: string
+  exhaustion: number | null
+  soreness: number | null
+  entries_count: number
+  completed_entries_count: number
+  exercises: Array<{ id: number; name: string; type: string }>
+}
+
+export function toWorkoutListItem(raw: RawWorkoutListItem): WorkoutListItem {
+  return {
+    id: String(raw.id),
+    name: raw.name,
+    date: raw.date,
+    exhaustion: raw.exhaustion,
+    soreness: raw.soreness,
+    entriesCount: raw.entries_count,
+    completedEntriesCount: raw.completed_entries_count,
+    exercises: raw.exercises.map(e => ({
+      id: String(e.id),
+      name: e.name,
+      type: e.type as ExerciseType,
+    })),
+  }
 }

--- a/resources/js/api/types.ts
+++ b/resources/js/api/types.ts
@@ -120,6 +120,17 @@ export interface Workout {
   entryGroups: EntryGroup[]
 }
 
+export interface WorkoutListItem {
+  id: string
+  name: string
+  date: string
+  exhaustion: number | null
+  soreness: number | null
+  entriesCount: number
+  completedEntriesCount: number
+  exercises: Array<{ id: string; name: string; type: ExerciseType }>
+}
+
 export interface TemplateExercise {
   id: string
   exerciseId: string

--- a/resources/js/api/workouts.ts
+++ b/resources/js/api/workouts.ts
@@ -1,0 +1,40 @@
+import { api } from './client'
+import { toWorkoutListItem, type RawWorkoutListItem } from './transformers'
+import type { Workout, WorkoutListItem } from './types'
+
+interface WorkoutListResponse {
+  items: WorkoutListItem[]
+  nextPage: number | undefined
+  total: number
+}
+
+interface PaginationMeta {
+  current_page: number
+  last_page: number
+  total: number
+}
+
+export async function listWorkouts(page: number = 1): Promise<WorkoutListResponse> {
+  const { data } = await api.get('/workouts', { params: { page } })
+  const meta = data.meta as PaginationMeta
+  const items = (data.data as RawWorkoutListItem[]).map(toWorkoutListItem)
+  const nextPage = meta.current_page < meta.last_page ? meta.current_page + 1 : undefined
+
+  return {
+    items,
+    nextPage,
+    total: meta.total,
+  }
+}
+
+interface CreateWorkoutPayload {
+  name: string
+  date: string
+  exhaustion?: number
+  soreness?: number
+}
+
+export async function createWorkout(payload: CreateWorkoutPayload): Promise<Workout> {
+  const { data } = await api.post('/workouts', payload)
+  return data.data as Workout
+}

--- a/resources/js/components/app/pickers.tsx
+++ b/resources/js/components/app/pickers.tsx
@@ -1,10 +1,9 @@
 import { useState, useEffect } from 'react'
-import { useNavigate } from 'react-router-dom'
-import { Search, Plus, Edit, ChevronRight, ChevronLeft, Grid } from 'lucide-react'
-import type { Exercise, WorkoutTemplate, EquipmentType } from '@/api/types'
-import { useExercises } from '@/hooks/use-exercises'
-import { useTemplates } from '@/hooks/use-templates'
-import { useEquipment } from '@/hooks/use-equipment'
+import { useQuery } from '@tanstack/react-query'
+import { Search, Plus, ChevronRight, ChevronLeft, Grid } from 'lucide-react'
+import type { Exercise, EquipmentType } from '@/api/types'
+import { listExercises } from '@/api/exercises'
+import { listEquipment } from '@/api/equipment'
 import { Sheet } from '@/components/ui/sheet'
 import { Button } from '@/components/ui/button'
 import { TypeBadge } from '@/components/ui/type-badge'
@@ -25,8 +24,14 @@ interface ExercisePickerProps {
 }
 
 export function ExercisePicker({ open, onClose, onSelect }: ExercisePickerProps) {
-  const { data: exercises } = useExercises()
-  const { data: equipment } = useEquipment()
+  const { data: exercises = [] } = useQuery({
+    queryKey: ['exercises'],
+    queryFn: listExercises,
+  })
+  const { data: equipment = [] } = useQuery({
+    queryKey: ['equipment'],
+    queryFn: listEquipment,
+  })
   const [q, setQ] = useState('')
   const [type, setType] = useState('all')
 
@@ -92,70 +97,32 @@ interface NewWorkoutWizardProps {
   open: boolean
   onClose: () => void
   onCreateEmpty: (config: { name: string; date: string }) => void
-  onCreateFromTemplate: (template: WorkoutTemplate, config: { name: string; date: string }) => void
 }
 
-export function NewWorkoutWizard({
-  open,
-  onClose,
-  onCreateEmpty,
-  onCreateFromTemplate,
-}: NewWorkoutWizardProps) {
-  const { data: templates } = useTemplates()
-  const navigate = useNavigate()
-  const [step, setStep] = useState<'method' | 'template' | 'details'>('method')
-  const [method, setMethod] = useState<'scratch' | 'template' | null>(null)
-  const [selectedTemplate, setSelectedTemplate] = useState<WorkoutTemplate | null>(null)
+export function NewWorkoutWizard({ open, onClose, onCreateEmpty }: NewWorkoutWizardProps) {
+  const [step, setStep] = useState<'method' | 'details'>('method')
   const [name, setName] = useState('')
   const [date, setDate] = useState(todayISO())
 
   useEffect(() => {
     if (open) {
       setStep('method')
-      setMethod(null)
-      setSelectedTemplate(null)
       setName('')
       setDate(todayISO())
     }
   }, [open])
 
-  const title =
-    step === 'method'
-      ? 'New Workout'
-      : step === 'template'
-        ? 'Choose a Template'
-        : 'Workout Details'
+  const title = step === 'method' ? 'New Workout' : 'Workout Details'
 
-  const back =
-    step === 'details'
-      ? () => setStep(method === 'template' ? 'template' : 'method')
-      : step === 'template'
-        ? () => setStep('method')
-        : null
+  const back = step === 'details' ? () => setStep('method') : null
 
   const chooseScratch = () => {
-    setMethod('scratch')
     setName('')
     setStep('details')
   }
 
-  const chooseTemplateMethod = () => {
-    setMethod('template')
-    setStep('template')
-  }
-
-  const pickTemplate = (t: WorkoutTemplate) => {
-    setSelectedTemplate(t)
-    setName(t.name)
-    setStep('details')
-  }
-
   const finish = () => {
-    if (method === 'template' && selectedTemplate) {
-      onCreateFromTemplate(selectedTemplate, { name: name.trim(), date })
-    } else {
-      onCreateEmpty({ name: name.trim(), date })
-    }
+    onCreateEmpty({ name: name.trim(), date })
     onClose()
   }
 
@@ -232,9 +199,9 @@ export function NewWorkoutWizard({
           <MethodButton
             icon={<Grid size={20} />}
             label="Use a template"
-            sub={`${templates.length} saved routine${templates.length === 1 ? '' : 's'}`}
-            onClick={chooseTemplateMethod}
-            disabled={!templates.length}
+            sub="Start from a saved routine"
+            disabled
+            badge="Coming Soon"
           />
           <MethodButton
             icon={<Grid size={20} />}
@@ -246,57 +213,8 @@ export function NewWorkoutWizard({
         </div>
       )}
 
-      {step === 'template' && (
-        <div className="flex flex-col gap-2">
-          {templates.map(t => {
-            const count = t.exercises.length + t.groups.reduce((a, g) => a + g.exercises.length, 0)
-            return (
-              <div key={t.id} className="ps-card p-2.5 flex items-center gap-2 min-h-[60px]">
-                <button
-                  onClick={() => pickTemplate(t)}
-                  className="flex items-center gap-3 flex-1 min-w-0 text-left"
-                >
-                  <span
-                    className="h-9 w-9 rounded-lg flex items-center justify-center shrink-0"
-                    style={{
-                      background: 'color-mix(in srgb, var(--color-primary) 12%, transparent)',
-                      color: 'var(--color-primary)',
-                    }}
-                  >
-                    <Grid size={18} />
-                  </span>
-                  <span className="min-w-0 flex-1">
-                    <span className="block font-semibold text-sm truncate">{t.name}</span>
-                    <span className="block text-[12px] text-text-secondary">
-                      {count} exercise{count === 1 ? '' : 's'}
-                    </span>
-                  </span>
-                </button>
-                <button
-                  onClick={() => {
-                    onClose()
-                    navigate(`/templates/${t.id}`)
-                  }}
-                  title="Edit template"
-                  aria-label={`Edit ${t.name}`}
-                  className="h-10 w-10 flex items-center justify-center rounded-lg text-text-muted hover:text-text-primary hover:bg-surface-muted shrink-0"
-                >
-                  <Edit size={17} />
-                </button>
-              </div>
-            )
-          })}
-        </div>
-      )}
-
       {step === 'details' && (
         <div className="flex flex-col gap-4">
-          {method === 'template' && selectedTemplate && (
-            <div className="ps-metric p-3 flex items-center gap-2 text-sm">
-              <Grid size={16} className="text-primary" /> Based on{' '}
-              <span className="font-semibold">{selectedTemplate.name}</span>
-            </div>
-          )}
           <div>
             <label htmlFor="workout-name" className="label-caps text-text-secondary block mb-1.5">
               Workout name

--- a/resources/js/pages/workouts.tsx
+++ b/resources/js/pages/workouts.tsx
@@ -1,12 +1,11 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Plus, BarChart3 } from 'lucide-react'
-import type { useWorkout } from '@/hooks/use-workouts'
-import { useWorkouts } from '@/hooks/use-workouts'
-import { useExercises } from '@/hooks/use-exercises'
 import { useApp } from '@/lib/use-app'
 import { formatDate } from '@/lib/formatters'
-import { workoutCompletion, exerciseById } from '@/lib/domain'
+import { listWorkouts, createWorkout } from '@/api/workouts'
+import type { WorkoutListItem } from '@/api/types'
 import {
   PageHeader,
   SectionHeading,
@@ -18,26 +17,14 @@ import {
 import { NewWorkoutWizard } from '@/components/app/pickers'
 
 interface WorkoutCardProps {
-  workout: ReturnType<typeof useWorkout>['data']
-  exercises: ReturnType<typeof useExercises>['data']
+  workout: WorkoutListItem
 }
 
-function WorkoutCard({ workout, exercises }: WorkoutCardProps) {
+function WorkoutCard({ workout }: WorkoutCardProps) {
   const navigate = useNavigate()
-  if (!workout) return null
 
-  const ratio = workoutCompletion(workout)
-  const names: string[] = []
-  const seen = new Set<string>()
-
-  workout.entries.forEach(e => {
-    if (!seen.has(e.exerciseId)) {
-      seen.add(e.exerciseId)
-      const ex = exerciseById(exercises, e.exerciseId)
-      if (ex) names.push(ex.name)
-    }
-  })
-
+  const ratio = workout.entriesCount > 0 ? workout.completedEntriesCount / workout.entriesCount : 0
+  const names = workout.exercises.map(e => e.name)
   const shown = names.slice(0, 4)
   const extra = names.length - shown.length
   const complete = ratio >= 1
@@ -76,32 +63,46 @@ function WorkoutCard({ workout, exercises }: WorkoutCardProps) {
 
 export function WorkoutsPage() {
   const navigate = useNavigate()
-  const { data: workouts } = useWorkouts()
-  const { data: exercises } = useExercises()
-  const { addWorkout, createFromTemplate, toast } = useApp()
+  const queryClient = useQueryClient()
+  const { toast } = useApp()
 
   const [wizardOpen, setWizardOpen] = useState(false)
 
+  const { data, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } = useInfiniteQuery({
+    queryKey: ['workouts'],
+    queryFn: ({ pageParam = 1 }) => listWorkouts(pageParam),
+    getNextPageParam: last => last.nextPage,
+    initialPageParam: 1,
+  })
+
+  const workouts = data?.pages?.flatMap(p => p.items) ?? []
+
+  const createMutation = useMutation({
+    mutationFn: createWorkout,
+    onSuccess: workout => {
+      queryClient.invalidateQueries({ queryKey: ['workouts'] })
+      toast('Workout started.')
+      navigate(`/workouts/${workout.id}`)
+    },
+    onError: () => toast('Could not create workout. Try again.'),
+  })
+
   const startEmpty = ({ name, date }: { name: string; date: string }) => {
-    const w = addWorkout({ name, date, entries: [], entryGroups: [] })
-    toast('Workout started.')
-    navigate(`/workouts/${w.id}`)
+    createMutation.mutate({ name, date })
   }
 
-  const startFromTemplate = (
-    tpl: { id: string },
-    { name, date }: { name: string; date: string }
-  ) => {
-    const w = createFromTemplate(tpl.id, date, name || undefined)
-    if (w) {
-      toast('Workout started.')
-      navigate(`/workouts/${w.id}`)
-    }
+  if (isLoading) {
+    return (
+      <>
+        <PageHeader title="Workouts" />
+        <p className="text-text-secondary text-sm">Loading...</p>
+      </>
+    )
   }
 
   return (
     <>
-      <PageHeader title="Workouts" subtitle={`${workouts.length} logged`} />
+      <PageHeader title="Workouts" subtitle={`${data?.pages?.[0]?.total ?? 0} logged`} />
 
       <div className="flex flex-col gap-2.5 mb-7">
         <Button full size="lg" icon={<Plus size={18} />} onClick={() => setWizardOpen(true)}>
@@ -122,8 +123,19 @@ export function WorkoutsPage() {
         {workouts.length ? (
           <div className="flex flex-col gap-3">
             {workouts.map(w => (
-              <WorkoutCard key={w.id} workout={w} exercises={exercises} />
+              <WorkoutCard key={w.id} workout={w} />
             ))}
+            {hasNextPage && (
+              <Button
+                full
+                variant="secondary"
+                onClick={() => fetchNextPage()}
+                disabled={isFetchingNextPage}
+                className="mt-3"
+              >
+                {isFetchingNextPage ? 'Loading...' : 'Load More'}
+              </Button>
+            )}
           </div>
         ) : (
           <EmptyState
@@ -144,7 +156,6 @@ export function WorkoutsPage() {
         open={wizardOpen}
         onClose={() => setWizardOpen(false)}
         onCreateEmpty={startEmpty}
-        onCreateFromTemplate={startFromTemplate}
       />
     </>
   )

--- a/routes/api.php
+++ b/routes/api.php
@@ -7,10 +7,13 @@ use App\Http\Controllers\Api\V1\Auth\RegisterController;
 use App\Http\Controllers\Api\V1\Auth\ResetPasswordController;
 use App\Http\Controllers\Api\V1\EquipmentTypeController;
 use App\Http\Controllers\Api\V1\ExerciseController;
+use App\Http\Controllers\Api\V1\TemplateCloneController;
+use App\Http\Controllers\Api\V1\TemplateExerciseController;
 use App\Http\Controllers\Api\V1\UserController;
 use App\Http\Controllers\Api\V1\WorkoutController;
 use App\Http\Controllers\Api\V1\WorkoutEntryController;
 use App\Http\Controllers\Api\V1\WorkoutExerciseController;
+use App\Http\Controllers\Api\V1\WorkoutTemplateController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/health', fn () => response()->json(['status' => 'ok']));
@@ -32,4 +35,9 @@ Route::middleware('auth:api')->group(function () {
     Route::put('workouts/{workout}/exercises/reorder', [WorkoutExerciseController::class, 'reorder']);
     Route::put('workouts/{workout}/entries/reorder', [WorkoutEntryController::class, 'reorder']);
     Route::apiResource('workouts.entries', WorkoutEntryController::class)->scoped();
+    Route::apiResource('templates', WorkoutTemplateController::class);
+    Route::post('templates/{template}/exercises', [TemplateExerciseController::class, 'attach']);
+    Route::delete('templates/{template}/exercises/{exercise}', [TemplateExerciseController::class, 'detach']);
+    Route::put('templates/{template}/exercises/reorder', [TemplateExerciseController::class, 'reorder']);
+    Route::post('templates/{template}/clone', TemplateCloneController::class);
 });

--- a/tests/Feature/Api/V1/ExerciseTest.php
+++ b/tests/Feature/Api/V1/ExerciseTest.php
@@ -8,6 +8,7 @@ use App\Models\EquipmentType;
 use App\Models\Exercise;
 use App\Models\User;
 use App\Models\Workout;
+use App\Models\WorkoutTemplate;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Passport\Passport;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -413,6 +414,19 @@ class ExerciseTest extends TestCase
             ->assertStatus(409);
 
         $this->assertDatabaseHas('exercises', ['id' => $exercise->id]);
+    }
+
+    public function test_cannot_delete_exercise_referenced_by_template(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance');
+        $template = WorkoutTemplate::factory()->create(['user_id' => $user->id]);
+        $template->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+
+        Passport::actingAs($user);
+
+        $this->deleteJson("/api/v1/exercises/{$exercise->id}")
+            ->assertStatus(409);
     }
 
     // -- Auth --

--- a/tests/Feature/Api/V1/TemplateCloneTest.php
+++ b/tests/Feature/Api/V1/TemplateCloneTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Models\Exercise;
+use App\Models\User;
+use App\Models\WorkoutTemplate;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
+use Tests\TestCase;
+
+class TemplateCloneTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createExercise(
+        ?User $user,
+        string $type = 'resistance',
+        array $overrides = [],
+    ): Exercise {
+        $exercise = Exercise::create(array_merge([
+            'name' => 'Test Exercise',
+            'type' => $type,
+            'user_id' => $user?->id,
+        ], $overrides));
+
+        $defaults = match ($type) {
+            'resistance' => [],
+            'timed_hold' => [],
+            'distance' => ['distance_unit' => 'meters'],
+            'interval' => [],
+            default => [],
+        };
+
+        $childRelation = match ($type) {
+            'resistance' => 'resistance',
+            'timed_hold' => 'timedHold',
+            'distance' => 'distance',
+            'interval' => 'interval',
+            default => 'resistance',
+        };
+
+        $exercise->$childRelation()->create($defaults);
+
+        return $exercise;
+    }
+
+    // -- Clone --
+
+    public function test_clones_template_to_workout(): void
+    {
+        $user = User::factory()->create();
+        $exercise1 = $this->createExercise($user, 'resistance', ['name' => 'Bench Press']);
+        $exercise2 = $this->createExercise($user, 'timed_hold', ['name' => 'Plank']);
+
+        $template = WorkoutTemplate::factory()->create([
+            'user_id' => $user->id,
+            'name' => 'Push Day',
+        ]);
+
+        $template->exercises()->attach($exercise1->id, ['exercise_order' => 0]);
+        $template->exercises()->attach($exercise2->id, ['exercise_order' => 1]);
+
+        Passport::actingAs($user);
+
+        $response = $this->postJson("/api/v1/templates/{$template->id}/clone", [
+            'date' => '2026-07-01',
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.name', 'Push Day')
+            ->assertJsonPath('data.date', '2026-07-01');
+
+        $workoutId = $response->json('data.id');
+
+        $this->assertDatabaseHas('workouts', [
+            'id' => $workoutId,
+            'name' => 'Push Day',
+            'user_id' => $user->id,
+        ]);
+
+        $this->assertDatabaseHas('exercise_workout', [
+            'workout_id' => $workoutId,
+            'exercise_id' => $exercise1->id,
+            'exercise_order' => 0,
+        ]);
+
+        $this->assertDatabaseHas('exercise_workout', [
+            'workout_id' => $workoutId,
+            'exercise_id' => $exercise2->id,
+            'exercise_order' => 1,
+        ]);
+    }
+
+    public function test_clone_creates_one_entry_per_exercise(): void
+    {
+        $user = User::factory()->create();
+        $exercise1 = $this->createExercise($user, 'resistance', ['name' => 'Squat']);
+        $exercise2 = $this->createExercise($user, 'resistance', ['name' => 'Deadlift']);
+
+        $template = WorkoutTemplate::factory()->create(['user_id' => $user->id]);
+        $template->exercises()->attach($exercise1->id, ['exercise_order' => 0]);
+        $template->exercises()->attach($exercise2->id, ['exercise_order' => 1]);
+
+        Passport::actingAs($user);
+
+        $response = $this->postJson("/api/v1/templates/{$template->id}/clone", [
+            'date' => '2026-07-01',
+        ]);
+
+        $workoutId = $response->json('data.id');
+
+        $this->assertDatabaseHas('workout_entries', [
+            'workout_id' => $workoutId,
+            'exercise_id' => $exercise1->id,
+            'set_order' => 0,
+        ]);
+
+        $this->assertDatabaseHas('workout_entries', [
+            'workout_id' => $workoutId,
+            'exercise_id' => $exercise2->id,
+            'set_order' => 1,
+        ]);
+    }
+
+    public function test_clone_allows_name_override(): void
+    {
+        $user = User::factory()->create();
+        $template = WorkoutTemplate::factory()->create([
+            'user_id' => $user->id,
+            'name' => 'Template Name',
+        ]);
+
+        Passport::actingAs($user);
+
+        $response = $this->postJson("/api/v1/templates/{$template->id}/clone", [
+            'date' => '2026-07-01',
+            'name' => 'Custom Workout Name',
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.name', 'Custom Workout Name');
+    }
+
+    public function test_cloned_workout_is_independent_of_template(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance');
+
+        $template = WorkoutTemplate::factory()->create(['user_id' => $user->id]);
+        $template->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+
+        Passport::actingAs($user);
+
+        $response = $this->postJson("/api/v1/templates/{$template->id}/clone", [
+            'date' => '2026-07-01',
+        ]);
+
+        $workoutId = $response->json('data.id');
+
+        $this->deleteJson("/api/v1/templates/{$template->id}")
+            ->assertNoContent();
+
+        $this->assertDatabaseHas('workouts', ['id' => $workoutId]);
+        $this->assertDatabaseHas('exercise_workout', ['workout_id' => $workoutId]);
+        $this->assertDatabaseHas('workout_entries', ['workout_id' => $workoutId]);
+    }
+
+    public function test_clone_validates_date_required(): void
+    {
+        $user = User::factory()->create();
+        $template = WorkoutTemplate::factory()->create(['user_id' => $user->id]);
+
+        Passport::actingAs($user);
+
+        $this->postJson("/api/v1/templates/{$template->id}/clone", [])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['date']);
+    }
+
+    public function test_cannot_clone_other_users_template(): void
+    {
+        $owner = User::factory()->create();
+        $cloner = User::factory()->create();
+        $template = WorkoutTemplate::factory()->create(['user_id' => $owner->id]);
+
+        Passport::actingAs($cloner);
+
+        $this->postJson("/api/v1/templates/{$template->id}/clone", [
+            'date' => '2026-07-01',
+        ])->assertStatus(403);
+    }
+}

--- a/tests/Feature/Api/V1/TemplateExerciseTest.php
+++ b/tests/Feature/Api/V1/TemplateExerciseTest.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Models\Exercise;
+use App\Models\User;
+use App\Models\WorkoutTemplate;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
+use Tests\TestCase;
+
+class TemplateExerciseTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createExercise(
+        ?User $user,
+        string $type = 'resistance',
+        array $overrides = [],
+    ): Exercise {
+        $exercise = Exercise::create(array_merge([
+            'name' => 'Test Exercise',
+            'type' => $type,
+            'user_id' => $user?->id,
+        ], $overrides));
+
+        $defaults = match ($type) {
+            'resistance' => [],
+            'timed_hold' => [],
+            'distance' => ['distance_unit' => 'meters'],
+            'interval' => [],
+            default => [],
+        };
+
+        $childRelation = match ($type) {
+            'resistance' => 'resistance',
+            'timed_hold' => 'timedHold',
+            'distance' => 'distance',
+            'interval' => 'interval',
+            default => 'resistance',
+        };
+
+        $exercise->$childRelation()->create($defaults);
+
+        return $exercise;
+    }
+
+    // -- Attach --
+
+    public function test_attaches_exercise_to_template(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance', ['name' => 'Bench Press']);
+        $template = WorkoutTemplate::factory()->create(['user_id' => $user->id]);
+
+        Passport::actingAs($user);
+
+        $response = $this->postJson("/api/v1/templates/{$template->id}/exercises", [
+            'exercise_id' => $exercise->id,
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.exercises.0.id', $exercise->id)
+            ->assertJsonPath('data.exercises.0.name', 'Bench Press');
+
+        $this->assertDatabaseHas('template_exercises', [
+            'template_id' => $template->id,
+            'exercise_id' => $exercise->id,
+            'exercise_order' => 0,
+        ]);
+    }
+
+    public function test_rejects_duplicate_exercise_attachment(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance');
+        $template = WorkoutTemplate::factory()->create(['user_id' => $user->id]);
+        $template->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+
+        Passport::actingAs($user);
+
+        $this->postJson("/api/v1/templates/{$template->id}/exercises", [
+            'exercise_id' => $exercise->id,
+        ])->assertStatus(409);
+    }
+
+    public function test_auto_assigns_exercise_order(): void
+    {
+        $user = User::factory()->create();
+        $exercise1 = $this->createExercise($user, 'resistance', ['name' => 'Exercise 1']);
+        $exercise2 = $this->createExercise($user, 'resistance', ['name' => 'Exercise 2']);
+        $exercise3 = $this->createExercise($user, 'resistance', ['name' => 'Exercise 3']);
+        $template = WorkoutTemplate::factory()->create(['user_id' => $user->id]);
+
+        Passport::actingAs($user);
+
+        $this->postJson("/api/v1/templates/{$template->id}/exercises", [
+            'exercise_id' => $exercise1->id,
+        ])->assertStatus(201);
+
+        $this->postJson("/api/v1/templates/{$template->id}/exercises", [
+            'exercise_id' => $exercise2->id,
+        ])->assertStatus(201);
+
+        $this->postJson("/api/v1/templates/{$template->id}/exercises", [
+            'exercise_id' => $exercise3->id,
+        ])->assertStatus(201);
+
+        $this->assertDatabaseHas('template_exercises', [
+            'exercise_id' => $exercise1->id,
+            'exercise_order' => 0,
+        ]);
+
+        $this->assertDatabaseHas('template_exercises', [
+            'exercise_id' => $exercise2->id,
+            'exercise_order' => 1,
+        ]);
+
+        $this->assertDatabaseHas('template_exercises', [
+            'exercise_id' => $exercise3->id,
+            'exercise_order' => 2,
+        ]);
+    }
+
+    public function test_validates_exercise_belongs_to_user_or_system(): void
+    {
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $otherExercise = $this->createExercise($otherUser, 'resistance');
+        $template = WorkoutTemplate::factory()->create(['user_id' => $user->id]);
+
+        Passport::actingAs($user);
+
+        $this->postJson("/api/v1/templates/{$template->id}/exercises", [
+            'exercise_id' => $otherExercise->id,
+        ])->assertStatus(422)
+            ->assertJsonValidationErrors('exercise_id');
+
+        $systemExercise = $this->createExercise(null, 'resistance', ['name' => 'System Exercise']);
+
+        $this->postJson("/api/v1/templates/{$template->id}/exercises", [
+            'exercise_id' => $systemExercise->id,
+        ])->assertStatus(201);
+    }
+
+    // -- Detach --
+
+    public function test_detaches_exercise_from_template(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance');
+        $template = WorkoutTemplate::factory()->create(['user_id' => $user->id]);
+        $template->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+
+        Passport::actingAs($user);
+
+        $this->deleteJson("/api/v1/templates/{$template->id}/exercises/{$exercise->id}")
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('template_exercises', [
+            'template_id' => $template->id,
+            'exercise_id' => $exercise->id,
+        ]);
+    }
+
+    // -- Reorder --
+
+    public function test_reorders_exercises(): void
+    {
+        $user = User::factory()->create();
+        $exercise1 = $this->createExercise($user, 'resistance', ['name' => 'Exercise 1']);
+        $exercise2 = $this->createExercise($user, 'resistance', ['name' => 'Exercise 2']);
+        $exercise3 = $this->createExercise($user, 'resistance', ['name' => 'Exercise 3']);
+        $template = WorkoutTemplate::factory()->create(['user_id' => $user->id]);
+
+        $template->exercises()->attach($exercise1->id, ['exercise_order' => 0]);
+        $template->exercises()->attach($exercise2->id, ['exercise_order' => 1]);
+        $template->exercises()->attach($exercise3->id, ['exercise_order' => 2]);
+
+        Passport::actingAs($user);
+
+        $this->putJson("/api/v1/templates/{$template->id}/exercises/reorder", [
+            'ids' => [$exercise3->id, $exercise1->id, $exercise2->id],
+        ])->assertOk();
+
+        $this->assertDatabaseHas('template_exercises', [
+            'exercise_id' => $exercise3->id,
+            'exercise_order' => 0,
+        ]);
+
+        $this->assertDatabaseHas('template_exercises', [
+            'exercise_id' => $exercise1->id,
+            'exercise_order' => 1,
+        ]);
+
+        $this->assertDatabaseHas('template_exercises', [
+            'exercise_id' => $exercise2->id,
+            'exercise_order' => 2,
+        ]);
+    }
+
+    // -- Authorization --
+
+    public function test_cannot_attach_to_other_users_template(): void
+    {
+        $owner = User::factory()->create();
+        $attacher = User::factory()->create();
+        $exercise = $this->createExercise($attacher, 'resistance');
+        $template = WorkoutTemplate::factory()->create(['user_id' => $owner->id]);
+
+        Passport::actingAs($attacher);
+
+        $this->postJson("/api/v1/templates/{$template->id}/exercises", [
+            'exercise_id' => $exercise->id,
+        ])->assertStatus(403);
+    }
+
+    public function test_cannot_detach_from_other_users_template(): void
+    {
+        $owner = User::factory()->create();
+        $detacher = User::factory()->create();
+        $exercise = $this->createExercise($owner, 'resistance');
+        $template = WorkoutTemplate::factory()->create(['user_id' => $owner->id]);
+        $template->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+
+        Passport::actingAs($detacher);
+
+        $this->deleteJson("/api/v1/templates/{$template->id}/exercises/{$exercise->id}")
+            ->assertStatus(403);
+    }
+}

--- a/tests/Feature/Api/V1/WorkoutTemplateTest.php
+++ b/tests/Feature/Api/V1/WorkoutTemplateTest.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Models\Exercise;
+use App\Models\User;
+use App\Models\WorkoutTemplate;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
+use Tests\TestCase;
+
+class WorkoutTemplateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createExercise(
+        ?User $user,
+        string $type = 'resistance',
+        array $overrides = [],
+    ): Exercise {
+        $exercise = Exercise::create(array_merge([
+            'name' => 'Test Exercise',
+            'type' => $type,
+            'user_id' => $user?->id,
+        ], $overrides));
+
+        $defaults = match ($type) {
+            'resistance' => [],
+            'timed_hold' => [],
+            'distance' => ['distance_unit' => 'meters'],
+            'interval' => [],
+            default => [],
+        };
+
+        $childRelation = match ($type) {
+            'resistance' => 'resistance',
+            'timed_hold' => 'timedHold',
+            'distance' => 'distance',
+            'interval' => 'interval',
+            default => 'resistance',
+        };
+
+        $exercise->$childRelation()->create($defaults);
+
+        return $exercise;
+    }
+
+    // -- Store --
+
+    public function test_creates_template(): void
+    {
+        $user = User::factory()->create();
+        Passport::actingAs($user);
+
+        $response = $this->postJson('/api/v1/templates', [
+            'name' => 'Push Day',
+            'notes' => 'Chest and shoulders',
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.name', 'Push Day')
+            ->assertJsonPath('data.notes', 'Chest and shoulders');
+
+        $this->assertDatabaseHas('workout_templates', [
+            'name' => 'Push Day',
+            'user_id' => $user->id,
+        ]);
+    }
+
+    public function test_creates_template_without_notes(): void
+    {
+        $user = User::factory()->create();
+        Passport::actingAs($user);
+
+        $response = $this->postJson('/api/v1/templates', [
+            'name' => 'Leg Day',
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.name', 'Leg Day')
+            ->assertJsonPath('data.notes', null);
+    }
+
+    public function test_validates_required_fields_for_store(): void
+    {
+        $user = User::factory()->create();
+        Passport::actingAs($user);
+
+        $this->postJson('/api/v1/templates', [])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['name']);
+    }
+
+    // -- Index --
+
+    public function test_lists_own_templates(): void
+    {
+        $user = User::factory()->create();
+        $other = User::factory()->create();
+
+        WorkoutTemplate::factory(3)->create(['user_id' => $user->id]);
+        WorkoutTemplate::factory(1)->create(['user_id' => $other->id]);
+
+        Passport::actingAs($user);
+
+        $response = $this->getJson('/api/v1/templates');
+
+        $response->assertOk();
+        $this->assertCount(3, $response->json('data'));
+    }
+
+    // -- Show --
+
+    public function test_shows_template_with_exercises(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance', ['name' => 'Bench Press']);
+        $template = WorkoutTemplate::factory()->create(['user_id' => $user->id]);
+
+        $template->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+
+        Passport::actingAs($user);
+
+        $response = $this->getJson("/api/v1/templates/{$template->id}");
+
+        $response->assertOk()
+            ->assertJsonPath('data.id', $template->id)
+            ->assertJsonPath('data.exercises.0.id', $exercise->id)
+            ->assertJsonPath('data.exercises.0.name', 'Bench Press')
+            ->assertJsonPath('data.exercises.0.exercise_order', 0);
+    }
+
+    public function test_cannot_view_other_users_template(): void
+    {
+        $owner = User::factory()->create();
+        $viewer = User::factory()->create();
+        $template = WorkoutTemplate::factory()->create(['user_id' => $owner->id]);
+
+        Passport::actingAs($viewer);
+
+        $this->getJson("/api/v1/templates/{$template->id}")
+            ->assertStatus(403);
+    }
+
+    // -- Update --
+
+    public function test_updates_template(): void
+    {
+        $user = User::factory()->create();
+        $template = WorkoutTemplate::factory()->create(['user_id' => $user->id, 'name' => 'Old Name']);
+        Passport::actingAs($user);
+
+        $this->putJson("/api/v1/templates/{$template->id}", ['name' => 'New Name'])
+            ->assertOk()
+            ->assertJsonPath('data.name', 'New Name');
+    }
+
+    public function test_cannot_update_other_users_template(): void
+    {
+        $owner = User::factory()->create();
+        $updater = User::factory()->create();
+        $template = WorkoutTemplate::factory()->create(['user_id' => $owner->id]);
+
+        Passport::actingAs($updater);
+
+        $this->putJson("/api/v1/templates/{$template->id}", ['name' => 'Hacked'])
+            ->assertStatus(403);
+    }
+
+    // -- Destroy --
+
+    public function test_deletes_template(): void
+    {
+        $user = User::factory()->create();
+        $template = WorkoutTemplate::factory()->create(['user_id' => $user->id]);
+        Passport::actingAs($user);
+
+        $this->deleteJson("/api/v1/templates/{$template->id}")
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('workout_templates', ['id' => $template->id]);
+    }
+
+    public function test_delete_cascades_exercises_and_groups(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance');
+        $template = WorkoutTemplate::factory()->create(['user_id' => $user->id]);
+        $template->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+        $group = $template->groups()->create([
+            'name' => 'Superset',
+            'planned_rounds' => 3,
+        ]);
+
+        Passport::actingAs($user);
+
+        $this->deleteJson("/api/v1/templates/{$template->id}")
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('workout_templates', ['id' => $template->id]);
+        $this->assertDatabaseMissing('template_exercises', ['template_id' => $template->id]);
+        $this->assertDatabaseMissing('template_entry_groups', ['id' => $group->id]);
+    }
+
+    // -- Auth --
+
+    public function test_unauthenticated_cannot_access_templates(): void
+    {
+        $this->getJson('/api/v1/templates')
+            ->assertStatus(401);
+
+        $this->postJson('/api/v1/templates', ['name' => 'Nope'])
+            ->assertStatus(401);
+    }
+}


### PR DESCRIPTION
## Problem

Users had no way to save reusable workout routines. Every workout had to be built from scratch by manually adding exercises one at a time.

## Solution

Added workout templates as a separate entity with full CRUD, exercise management, and a clone-and-detach flow that creates an independent workout from a template.

- WorkoutTemplate model with user-scoped isolation, TemplateEntryGroup (for future superset/circuit support), and a TemplateExercisePivot with composite PK and exercise ordering
- WorkoutTemplateController for standard CRUD, TemplateExerciseController for attach/detach/reorder (reuses existing AttachExerciseRequest and ReorderRequest), and TemplateCloneController as a single-action controller
- Clone creates a workout in a transaction: copies the exercise structure into exercise_workout, creates one workout_entry per exercise, and returns a WorkoutResource. No FK back to the template
- ExerciseController::destroy now also checks template_exercises so referenced exercises return 409
- 25 new feature tests covering template CRUD, exercise management, clone behavior, independence after clone, and authorization
