### PR TITLE
PS-65 - Adding entry groups for supersets and circuits

### DIFF
--- a/app/Http/Controllers/Api/V1/EntryGroupController.php
+++ b/app/Http/Controllers/Api/V1/EntryGroupController.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\AssignGroupEntriesRequest;
+use App\Http\Requests\Api\V1\StoreEntryGroupRequest;
+use App\Http\Requests\Api\V1\UpdateEntryGroupRequest;
+use App\Http\Resources\Api\V1\WorkoutResource;
+use App\Models\EntryGroup;
+use App\Models\Workout;
+use App\Models\WorkoutEntry;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\DB;
+
+class EntryGroupController extends Controller
+{
+    use AuthorizesRequests;
+
+    private const WORKOUT_EAGER_LOAD = [
+        'exercises',
+        'groups',
+        'entries.exercise',
+        'entries.loadMetric',
+        'entries.repMetric',
+        'entries.durationMetric',
+        'entries.distanceMetric',
+        'entries.cardioSetting',
+        'entries.intervalHeader.rounds',
+        'entries.intensityMetric',
+    ];
+
+    public function store(StoreEntryGroupRequest $request, Workout $workout): JsonResponse
+    {
+        $this->authorize('update', $workout);
+
+        $workout->groups()->create($request->validated());
+
+        $workout->load(self::WORKOUT_EAGER_LOAD);
+
+        return (new WorkoutResource($workout))
+            ->response()
+            ->setStatusCode(201);
+    }
+
+    public function update(UpdateEntryGroupRequest $request, Workout $workout, EntryGroup $group): WorkoutResource
+    {
+        $this->authorize('update', $workout);
+
+        abort_if($group->workout_id !== $workout->id, 404);
+
+        $group->update($request->validated());
+
+        $workout->load(self::WORKOUT_EAGER_LOAD);
+
+        return new WorkoutResource($workout);
+    }
+
+    public function destroy(Workout $workout, EntryGroup $group): Response
+    {
+        $this->authorize('update', $workout);
+
+        abort_if($group->workout_id !== $workout->id, 404);
+
+        // Clear group_round before delete; FK ON DELETE SET NULL handles entry_group_id
+        $group->entries()->update(['group_round' => null]);
+        $group->delete();
+
+        return response()->noContent();
+    }
+
+    public function assignEntries(AssignGroupEntriesRequest $request, Workout $workout, EntryGroup $group): WorkoutResource
+    {
+        $this->authorize('update', $workout);
+
+        abort_if($group->workout_id !== $workout->id, 404);
+
+        DB::transaction(function () use ($request, $workout, $group) {
+            foreach ($request->validated('entries') as $assignment) {
+                $workout->entries()
+                    ->where('id', $assignment['entry_id'])
+                    ->update([
+                        'entry_group_id' => $group->id,
+                        'group_round' => $assignment['group_round'],
+                    ]);
+            }
+        });
+
+        $workout->load(self::WORKOUT_EAGER_LOAD);
+
+        return new WorkoutResource($workout);
+    }
+
+    public function removeEntry(Workout $workout, EntryGroup $group, WorkoutEntry $entry): WorkoutResource
+    {
+        $this->authorize('update', $workout);
+
+        abort_if($group->workout_id !== $workout->id, 404);
+        abort_if($entry->workout_id !== $workout->id, 404);
+
+        $entry->update([
+            'entry_group_id' => null,
+            'group_round' => null,
+        ]);
+
+        $workout->load(self::WORKOUT_EAGER_LOAD);
+
+        return new WorkoutResource($workout);
+    }
+}

--- a/app/Http/Controllers/Api/V1/TemplateCloneController.php
+++ b/app/Http/Controllers/Api/V1/TemplateCloneController.php
@@ -7,10 +7,12 @@ namespace App\Http\Controllers\Api\V1;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\V1\CloneTemplateRequest;
 use App\Http\Resources\Api\V1\WorkoutResource;
+use App\Models\Exercise;
 use App\Models\Workout;
 use App\Models\WorkoutTemplate;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 
 class TemplateCloneController extends Controller
@@ -19,6 +21,7 @@ class TemplateCloneController extends Controller
 
     private const WORKOUT_EAGER_LOAD = [
         'exercises',
+        'groups',
         'entries.exercise',
         'entries.loadMetric',
         'entries.repMetric',
@@ -33,6 +36,8 @@ class TemplateCloneController extends Controller
     {
         $this->authorize('view', $template);
 
+        $template->load(['exercises', 'groups']);
+
         $workout = DB::transaction(function () use ($request, $template) {
             $workout = Workout::create([
                 'name' => $request->validated('name', $template->name),
@@ -40,15 +45,57 @@ class TemplateCloneController extends Controller
                 'date' => $request->validated('date'),
             ]);
 
-            foreach ($template->exercises as $exercise) {
+            $groupMapping = [];
+            foreach ($template->groups as $templateGroup) {
+                $workoutGroup = $workout->groups()->create([
+                    'name' => $templateGroup->name,
+                    'planned_rounds' => $templateGroup->planned_rounds,
+                    'rest_between_exercises_seconds' => $templateGroup->rest_between_exercises_seconds,
+                    'rest_between_rounds_seconds' => $templateGroup->rest_between_rounds_seconds,
+                ]);
+                $groupMapping[$templateGroup->id] = $workoutGroup->id;
+            }
+
+            /** @var Collection<int, Exercise> $exercises */
+            $exercises = $template->exercises;
+
+            foreach ($exercises as $exercise) {
                 $workout->exercises()->attach($exercise->id, [
                     'exercise_order' => $exercise->pivot->exercise_order,
                 ]);
+            }
 
-                $workout->entries()->create([
-                    'exercise_id' => $exercise->id,
-                    'set_order' => $exercise->pivot->exercise_order,
-                ]);
+            $processedGroups = [];
+            $setOrder = 0;
+
+            foreach ($exercises as $exercise) {
+                $templateGroupId = $exercise->pivot->template_entry_group_id;
+
+                if ($templateGroupId === null) {
+                    $workout->entries()->create([
+                        'exercise_id' => $exercise->id,
+                        'set_order' => $setOrder++,
+                    ]);
+                } elseif (! in_array($templateGroupId, $processedGroups, true)) {
+                    $processedGroups[] = $templateGroupId;
+                    $templateGroup = $template->groups->firstWhere('id', $templateGroupId);
+                    $workoutGroupId = $groupMapping[$templateGroupId];
+
+                    $groupExercises = $exercises
+                        ->filter(fn (Exercise $e) => $e->pivot->template_entry_group_id === $templateGroupId)
+                        ->sortBy(fn (Exercise $e) => $e->pivot->exercise_order);
+
+                    for ($round = 1; $round <= $templateGroup->planned_rounds; $round++) {
+                        foreach ($groupExercises as $groupExercise) {
+                            $workout->entries()->create([
+                                'exercise_id' => $groupExercise->id,
+                                'set_order' => $setOrder++,
+                                'entry_group_id' => $workoutGroupId,
+                                'group_round' => $round,
+                            ]);
+                        }
+                    }
+                }
             }
 
             return $workout;

--- a/app/Http/Controllers/Api/V1/WorkoutController.php
+++ b/app/Http/Controllers/Api/V1/WorkoutController.php
@@ -22,6 +22,7 @@ class WorkoutController extends Controller
 
     private const SHOW_EAGER_LOAD = [
         'exercises',
+        'groups',
         'entries.exercise',
         'entries.loadMetric',
         'entries.repMetric',

--- a/app/Http/Controllers/Api/V1/WorkoutEntryController.php
+++ b/app/Http/Controllers/Api/V1/WorkoutEntryController.php
@@ -53,6 +53,8 @@ class WorkoutEntryController extends Controller
                 'exercise_id' => $request->validated('exercise_id'),
                 'set_order' => $request->validated('set_order'),
                 'notes' => $request->validated('notes'),
+                'entry_group_id' => $request->validated('entry_group_id'),
+                'group_round' => $request->validated('group_round'),
             ]);
 
             $metrics = $request->validated('metrics') ?? [];
@@ -84,7 +86,7 @@ class WorkoutEntryController extends Controller
         $this->authorize('update', $workout);
 
         DB::transaction(function () use ($request, $entry) {
-            $entry->update($request->safe()->only(['set_order', 'notes']));
+            $entry->update($request->safe()->only(['set_order', 'notes', 'entry_group_id', 'group_round']));
 
             $metrics = $request->validated('metrics') ?? [];
             if ($metrics) {

--- a/app/Http/Controllers/Api/V1/WorkoutExerciseController.php
+++ b/app/Http/Controllers/Api/V1/WorkoutExerciseController.php
@@ -21,6 +21,7 @@ class WorkoutExerciseController extends Controller
 
     private const SHOW_EAGER_LOAD = [
         'exercises',
+        'groups',
         'entries.exercise',
         'entries.loadMetric',
         'entries.repMetric',

--- a/app/Http/Requests/Api/V1/AssignGroupEntriesRequest.php
+++ b/app/Http/Requests/Api/V1/AssignGroupEntriesRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AssignGroupEntriesRequest extends FormRequest
+{
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        return [
+            'entries' => ['required', 'array', 'min:1'],
+            'entries.*.entry_id' => ['required', 'integer'],
+            'entries.*.group_round' => ['required', 'integer', 'min:1'],
+        ];
+    }
+}

--- a/app/Http/Requests/Api/V1/StoreEntryGroupRequest.php
+++ b/app/Http/Requests/Api/V1/StoreEntryGroupRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreEntryGroupRequest extends FormRequest
+{
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        return [
+            'name' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'planned_rounds' => ['sometimes', 'integer', 'min:1'],
+            'rest_between_exercises_seconds' => ['sometimes', 'integer', 'min:0'],
+            'rest_between_rounds_seconds' => ['sometimes', 'nullable', 'integer', 'min:0'],
+        ];
+    }
+}

--- a/app/Http/Requests/Api/V1/StoreWorkoutEntryRequest.php
+++ b/app/Http/Requests/Api/V1/StoreWorkoutEntryRequest.php
@@ -23,6 +23,12 @@ class StoreWorkoutEntryRequest extends FormRequest
             ],
             'set_order' => ['required', 'integer', 'min:0'],
             'notes' => ['sometimes', 'nullable', 'string'],
+            'entry_group_id' => [
+                'sometimes',
+                'nullable',
+                Rule::exists('entry_groups', 'id')->where('workout_id', $this->route('workout')->id),
+            ],
+            'group_round' => ['sometimes', 'nullable', 'integer', 'min:1'],
             'metrics' => ['sometimes', 'array'],
         ], $this->metricRules());
     }

--- a/app/Http/Requests/Api/V1/UpdateEntryGroupRequest.php
+++ b/app/Http/Requests/Api/V1/UpdateEntryGroupRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateEntryGroupRequest extends FormRequest
+{
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        return [
+            'name' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'planned_rounds' => ['sometimes', 'integer', 'min:1'],
+            'rest_between_exercises_seconds' => ['sometimes', 'integer', 'min:0'],
+            'rest_between_rounds_seconds' => ['sometimes', 'nullable', 'integer', 'min:0'],
+        ];
+    }
+}

--- a/app/Http/Requests/Api/V1/UpdateWorkoutEntryRequest.php
+++ b/app/Http/Requests/Api/V1/UpdateWorkoutEntryRequest.php
@@ -16,6 +16,12 @@ class UpdateWorkoutEntryRequest extends FormRequest
         return array_merge([
             'set_order' => ['sometimes', 'integer', 'min:0'],
             'notes' => ['sometimes', 'nullable', 'string'],
+            'entry_group_id' => [
+                'sometimes',
+                'nullable',
+                Rule::exists('entry_groups', 'id')->where('workout_id', $this->route('workout')->id),
+            ],
+            'group_round' => ['sometimes', 'nullable', 'integer', 'min:1'],
             'metrics' => ['sometimes', 'array'],
         ], $this->metricRules());
     }

--- a/app/Http/Resources/Api/V1/WorkoutEntryResource.php
+++ b/app/Http/Resources/Api/V1/WorkoutEntryResource.php
@@ -19,6 +19,8 @@ class WorkoutEntryResource extends JsonResource
             'workout_id' => $this->workout_id,
             'exercise_id' => $this->exercise_id,
             'set_order' => $this->set_order,
+            'entry_group_id' => $this->entry_group_id,
+            'group_round' => $this->group_round,
             'notes' => $this->notes,
             'exercise' => $this->whenLoaded('exercise', fn () => [
                 'id' => $this->exercise->id,

--- a/app/Http/Resources/Api/V1/WorkoutResource.php
+++ b/app/Http/Resources/Api/V1/WorkoutResource.php
@@ -27,6 +27,13 @@ class WorkoutResource extends JsonResource
                 'equipment_type_id' => $exercise->equipment_type_id,
                 'exercise_order' => $exercise->pivot->exercise_order,
             ])),
+            'groups' => $this->whenLoaded('groups', fn () => $this->groups->map(fn ($group) => [
+                'id' => $group->id,
+                'name' => $group->name,
+                'planned_rounds' => $group->planned_rounds,
+                'rest_between_exercises_seconds' => $group->rest_between_exercises_seconds,
+                'rest_between_rounds_seconds' => $group->rest_between_rounds_seconds,
+            ])),
             'entries' => $this->whenLoaded('entries', fn () => WorkoutEntryResource::collection($this->entries)),
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,

--- a/app/Models/EntryGroup.php
+++ b/app/Models/EntryGroup.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class EntryGroup extends Model
+{
+    /** @var list<string> */
+    protected $fillable = [
+        'workout_id',
+        'name',
+        'planned_rounds',
+        'rest_between_exercises_seconds',
+        'rest_between_rounds_seconds',
+    ];
+
+    /** @return BelongsTo<Workout, $this> */
+    public function workout(): BelongsTo
+    {
+        return $this->belongsTo(Workout::class);
+    }
+
+    /** @return HasMany<WorkoutEntry, $this> */
+    public function entries(): HasMany
+    {
+        return $this->hasMany(WorkoutEntry::class, 'entry_group_id');
+    }
+}

--- a/app/Models/Exercise.php
+++ b/app/Models/Exercise.php
@@ -8,11 +8,10 @@ use App\Enums\ExerciseType;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasOne;
-use App\Models\Pivots\ExerciseWorkoutPivot;
 
 /**
  * @property ExerciseType $type
- * @property ExerciseWorkoutPivot|null $pivot
+ * @property mixed $pivot
  */
 class Exercise extends Model
 {

--- a/app/Models/Workout.php
+++ b/app/Models/Workout.php
@@ -58,4 +58,10 @@ class Workout extends Model
     {
         return $this->hasMany(WorkoutEntry::class);
     }
+
+    /** @return HasMany<EntryGroup, $this> */
+    public function groups(): HasMany
+    {
+        return $this->hasMany(EntryGroup::class);
+    }
 }

--- a/app/Models/WorkoutEntry.php
+++ b/app/Models/WorkoutEntry.php
@@ -14,6 +14,8 @@ class WorkoutEntry extends Model
     protected $fillable = [
         'workout_id',
         'exercise_id',
+        'entry_group_id',
+        'group_round',
         'set_order',
         'notes',
     ];
@@ -28,6 +30,12 @@ class WorkoutEntry extends Model
     public function exercise(): BelongsTo
     {
         return $this->belongsTo(Exercise::class);
+    }
+
+    /** @return BelongsTo<EntryGroup, $this> */
+    public function entryGroup(): BelongsTo
+    {
+        return $this->belongsTo(EntryGroup::class, 'entry_group_id');
     }
 
     /** @return HasOne<LogLoadMetric, $this> */

--- a/database/migrations/2026_06_28_400001_create_entry_groups_table.php
+++ b/database/migrations/2026_06_28_400001_create_entry_groups_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('entry_groups', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('workout_id')->constrained()->cascadeOnDelete();
+            $table->string('name')->nullable();
+            $table->unsignedInteger('planned_rounds')->default(1);
+            $table->unsignedInteger('rest_between_exercises_seconds')->default(0);
+            $table->unsignedInteger('rest_between_rounds_seconds')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('entry_groups');
+    }
+};

--- a/database/migrations/2026_06_28_400002_add_group_columns_to_workout_entries_table.php
+++ b/database/migrations/2026_06_28_400002_add_group_columns_to_workout_entries_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('workout_entries', function (Blueprint $table) {
+            $table->foreignId('entry_group_id')
+                ->nullable()
+                ->after('exercise_id')
+                ->constrained('entry_groups')
+                ->nullOnDelete();
+            $table->unsignedInteger('group_round')->nullable()->after('entry_group_id');
+            $table->index(['entry_group_id', 'group_round', 'set_order']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('workout_entries', function (Blueprint $table) {
+            $table->dropIndex(['entry_group_id', 'group_round', 'set_order']);
+            $table->dropConstrainedForeignId('entry_group_id');
+            $table->dropColumn('group_round');
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\Api\V1\Auth\LoginController;
 use App\Http\Controllers\Api\V1\Auth\LogoutController;
 use App\Http\Controllers\Api\V1\Auth\RegisterController;
 use App\Http\Controllers\Api\V1\Auth\ResetPasswordController;
+use App\Http\Controllers\Api\V1\EntryGroupController;
 use App\Http\Controllers\Api\V1\EquipmentTypeController;
 use App\Http\Controllers\Api\V1\ExerciseController;
 use App\Http\Controllers\Api\V1\TemplateCloneController;
@@ -40,4 +41,9 @@ Route::middleware('auth:api')->group(function () {
     Route::delete('templates/{template}/exercises/{exercise}', [TemplateExerciseController::class, 'detach']);
     Route::put('templates/{template}/exercises/reorder', [TemplateExerciseController::class, 'reorder']);
     Route::post('templates/{template}/clone', TemplateCloneController::class);
+    Route::post('workouts/{workout}/groups', [EntryGroupController::class, 'store']);
+    Route::put('workouts/{workout}/groups/{group}', [EntryGroupController::class, 'update']);
+    Route::delete('workouts/{workout}/groups/{group}', [EntryGroupController::class, 'destroy']);
+    Route::post('workouts/{workout}/groups/{group}/entries', [EntryGroupController::class, 'assignEntries']);
+    Route::delete('workouts/{workout}/groups/{group}/entries/{entry}', [EntryGroupController::class, 'removeEntry']);
 });

--- a/tests/Feature/Api/V1/EntryGroupTest.php
+++ b/tests/Feature/Api/V1/EntryGroupTest.php
@@ -1,0 +1,449 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Models\EntryGroup;
+use App\Models\Exercise;
+use App\Models\User;
+use App\Models\Workout;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
+use Tests\TestCase;
+
+class EntryGroupTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createExercise(
+        ?User $user,
+        string $type = 'resistance',
+        array $overrides = [],
+    ): Exercise {
+        $exercise = Exercise::create(array_merge([
+            'name' => 'Test Exercise',
+            'type' => $type,
+            'user_id' => $user?->id,
+        ], $overrides));
+
+        $defaults = match ($type) {
+            'resistance' => [],
+            'timed_hold' => [],
+            'distance' => ['distance_unit' => 'meters'],
+            'interval' => [],
+            default => [],
+        };
+
+        $childRelation = match ($type) {
+            'resistance' => 'resistance',
+            'timed_hold' => 'timedHold',
+            'distance' => 'distance',
+            'interval' => 'interval',
+            default => 'resistance',
+        };
+
+        $exercise->$childRelation()->create($defaults);
+
+        return $exercise;
+    }
+
+    // -- Store --
+
+    public function test_creates_entry_group(): void
+    {
+        $user = User::factory()->create();
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+
+        Passport::actingAs($user);
+
+        $response = $this->postJson("/api/v1/workouts/{$workout->id}/groups", [
+            'name' => 'Chest/Back Superset',
+            'planned_rounds' => 3,
+            'rest_between_exercises_seconds' => 30,
+            'rest_between_rounds_seconds' => 60,
+        ]);
+
+        $response->assertStatus(201);
+
+        $this->assertDatabaseHas('entry_groups', [
+            'workout_id' => $workout->id,
+            'name' => 'Chest/Back Superset',
+            'planned_rounds' => 3,
+            'rest_between_exercises_seconds' => 30,
+            'rest_between_rounds_seconds' => 60,
+        ]);
+    }
+
+    public function test_creates_entry_group_with_defaults(): void
+    {
+        $user = User::factory()->create();
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+
+        Passport::actingAs($user);
+
+        $response = $this->postJson("/api/v1/workouts/{$workout->id}/groups", []);
+
+        $response->assertStatus(201);
+
+        $this->assertDatabaseHas('entry_groups', [
+            'workout_id' => $workout->id,
+            'name' => null,
+            'planned_rounds' => 1,
+            'rest_between_exercises_seconds' => 0,
+            'rest_between_rounds_seconds' => null,
+        ]);
+    }
+
+    public function test_store_returns_workout_with_groups(): void
+    {
+        $user = User::factory()->create();
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+
+        Passport::actingAs($user);
+
+        $response = $this->postJson("/api/v1/workouts/{$workout->id}/groups", [
+            'name' => 'Push Circuit',
+            'planned_rounds' => 2,
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.groups.0.name', 'Push Circuit')
+            ->assertJsonPath('data.groups.0.planned_rounds', 2);
+    }
+
+    public function test_cannot_create_group_on_other_users_workout(): void
+    {
+        $owner = User::factory()->create();
+        $other = User::factory()->create();
+        $workout = Workout::factory()->create(['user_id' => $owner->id]);
+
+        Passport::actingAs($other);
+
+        $this->postJson("/api/v1/workouts/{$workout->id}/groups", [
+            'planned_rounds' => 2,
+        ])->assertStatus(403);
+    }
+
+    public function test_validates_planned_rounds_minimum(): void
+    {
+        $user = User::factory()->create();
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+
+        Passport::actingAs($user);
+
+        $this->postJson("/api/v1/workouts/{$workout->id}/groups", [
+            'planned_rounds' => 0,
+        ])->assertStatus(422)
+            ->assertJsonValidationErrors('planned_rounds');
+    }
+
+    // -- Update --
+
+    public function test_updates_entry_group(): void
+    {
+        $user = User::factory()->create();
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+        $group = EntryGroup::create([
+            'workout_id' => $workout->id,
+            'name' => 'Old Name',
+            'planned_rounds' => 2,
+            'rest_between_exercises_seconds' => 0,
+        ]);
+
+        Passport::actingAs($user);
+
+        $response = $this->putJson("/api/v1/workouts/{$workout->id}/groups/{$group->id}", [
+            'name' => 'New Name',
+            'planned_rounds' => 4,
+            'rest_between_exercises_seconds' => 45,
+            'rest_between_rounds_seconds' => 90,
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.groups.0.name', 'New Name')
+            ->assertJsonPath('data.groups.0.planned_rounds', 4)
+            ->assertJsonPath('data.groups.0.rest_between_exercises_seconds', 45)
+            ->assertJsonPath('data.groups.0.rest_between_rounds_seconds', 90);
+    }
+
+    public function test_cannot_update_group_on_other_users_workout(): void
+    {
+        $owner = User::factory()->create();
+        $other = User::factory()->create();
+        $workout = Workout::factory()->create(['user_id' => $owner->id]);
+        $group = EntryGroup::create([
+            'workout_id' => $workout->id,
+            'planned_rounds' => 2,
+            'rest_between_exercises_seconds' => 0,
+        ]);
+
+        Passport::actingAs($other);
+
+        $this->putJson("/api/v1/workouts/{$workout->id}/groups/{$group->id}", [
+            'name' => 'Hacked',
+        ])->assertStatus(403);
+    }
+
+    public function test_update_returns_404_for_group_from_other_workout(): void
+    {
+        $user = User::factory()->create();
+        $workout1 = Workout::factory()->create(['user_id' => $user->id]);
+        $workout2 = Workout::factory()->create(['user_id' => $user->id]);
+        $group = EntryGroup::create([
+            'workout_id' => $workout1->id,
+            'planned_rounds' => 2,
+            'rest_between_exercises_seconds' => 0,
+        ]);
+
+        Passport::actingAs($user);
+
+        $this->putJson("/api/v1/workouts/{$workout2->id}/groups/{$group->id}", [
+            'name' => 'Cross-workout',
+        ])->assertStatus(404);
+    }
+
+    // -- Destroy --
+
+    public function test_deletes_entry_group(): void
+    {
+        $user = User::factory()->create();
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+        $group = EntryGroup::create([
+            'workout_id' => $workout->id,
+            'planned_rounds' => 2,
+            'rest_between_exercises_seconds' => 0,
+        ]);
+
+        Passport::actingAs($user);
+
+        $this->deleteJson("/api/v1/workouts/{$workout->id}/groups/{$group->id}")
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('entry_groups', ['id' => $group->id]);
+    }
+
+    public function test_delete_group_preserves_entries_with_null_fk(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance', ['name' => 'Bench']);
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+        $workout->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+
+        $group = EntryGroup::create([
+            'workout_id' => $workout->id,
+            'planned_rounds' => 2,
+            'rest_between_exercises_seconds' => 0,
+        ]);
+
+        $entry = $workout->entries()->create([
+            'exercise_id' => $exercise->id,
+            'set_order' => 0,
+            'entry_group_id' => $group->id,
+            'group_round' => 1,
+        ]);
+
+        Passport::actingAs($user);
+
+        $this->deleteJson("/api/v1/workouts/{$workout->id}/groups/{$group->id}")
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('entry_groups', ['id' => $group->id]);
+        $this->assertDatabaseHas('workout_entries', [
+            'id' => $entry->id,
+            'entry_group_id' => null,
+            'group_round' => null,
+        ]);
+    }
+
+    public function test_workout_delete_cascades_groups(): void
+    {
+        $user = User::factory()->create();
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+        $group = EntryGroup::create([
+            'workout_id' => $workout->id,
+            'planned_rounds' => 2,
+            'rest_between_exercises_seconds' => 0,
+        ]);
+
+        Passport::actingAs($user);
+
+        $this->deleteJson("/api/v1/workouts/{$workout->id}")
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('entry_groups', ['id' => $group->id]);
+    }
+
+    // -- Assign Entries --
+
+    public function test_assigns_entries_to_group(): void
+    {
+        $user = User::factory()->create();
+        $exercise1 = $this->createExercise($user, 'resistance', ['name' => 'Bench']);
+        $exercise2 = $this->createExercise($user, 'resistance', ['name' => 'Row']);
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+        $workout->exercises()->attach($exercise1->id, ['exercise_order' => 0]);
+        $workout->exercises()->attach($exercise2->id, ['exercise_order' => 1]);
+
+        $entry1 = $workout->entries()->create(['exercise_id' => $exercise1->id, 'set_order' => 0]);
+        $entry2 = $workout->entries()->create(['exercise_id' => $exercise2->id, 'set_order' => 1]);
+
+        $group = EntryGroup::create([
+            'workout_id' => $workout->id,
+            'planned_rounds' => 2,
+            'rest_between_exercises_seconds' => 30,
+        ]);
+
+        Passport::actingAs($user);
+
+        $response = $this->postJson("/api/v1/workouts/{$workout->id}/groups/{$group->id}/entries", [
+            'entries' => [
+                ['entry_id' => $entry1->id, 'group_round' => 1],
+                ['entry_id' => $entry2->id, 'group_round' => 1],
+            ],
+        ]);
+
+        $response->assertOk();
+
+        $this->assertDatabaseHas('workout_entries', [
+            'id' => $entry1->id,
+            'entry_group_id' => $group->id,
+            'group_round' => 1,
+        ]);
+
+        $this->assertDatabaseHas('workout_entries', [
+            'id' => $entry2->id,
+            'entry_group_id' => $group->id,
+            'group_round' => 1,
+        ]);
+    }
+
+    public function test_assign_validates_entries_required(): void
+    {
+        $user = User::factory()->create();
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+        $group = EntryGroup::create([
+            'workout_id' => $workout->id,
+            'planned_rounds' => 2,
+            'rest_between_exercises_seconds' => 0,
+        ]);
+
+        Passport::actingAs($user);
+
+        $this->postJson("/api/v1/workouts/{$workout->id}/groups/{$group->id}/entries", [])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors('entries');
+    }
+
+    // -- Remove Entry --
+
+    public function test_removes_entry_from_group(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance', ['name' => 'Bench']);
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+        $workout->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+
+        $group = EntryGroup::create([
+            'workout_id' => $workout->id,
+            'planned_rounds' => 2,
+            'rest_between_exercises_seconds' => 0,
+        ]);
+
+        $entry = $workout->entries()->create([
+            'exercise_id' => $exercise->id,
+            'set_order' => 0,
+            'entry_group_id' => $group->id,
+            'group_round' => 1,
+        ]);
+
+        Passport::actingAs($user);
+
+        $response = $this->deleteJson(
+            "/api/v1/workouts/{$workout->id}/groups/{$group->id}/entries/{$entry->id}"
+        );
+
+        $response->assertOk();
+
+        $this->assertDatabaseHas('workout_entries', [
+            'id' => $entry->id,
+            'entry_group_id' => null,
+            'group_round' => null,
+        ]);
+    }
+
+    // -- Response Integration --
+
+    public function test_workout_show_includes_groups(): void
+    {
+        $user = User::factory()->create();
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+        EntryGroup::create([
+            'workout_id' => $workout->id,
+            'name' => 'Push/Pull',
+            'planned_rounds' => 3,
+            'rest_between_exercises_seconds' => 30,
+            'rest_between_rounds_seconds' => 60,
+        ]);
+
+        Passport::actingAs($user);
+
+        $response = $this->getJson("/api/v1/workouts/{$workout->id}");
+
+        $response->assertOk()
+            ->assertJsonPath('data.groups.0.name', 'Push/Pull')
+            ->assertJsonPath('data.groups.0.planned_rounds', 3)
+            ->assertJsonPath('data.groups.0.rest_between_exercises_seconds', 30)
+            ->assertJsonPath('data.groups.0.rest_between_rounds_seconds', 60);
+    }
+
+    public function test_entry_response_includes_group_fields(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance', ['name' => 'Bench']);
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+        $workout->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+
+        $group = EntryGroup::create([
+            'workout_id' => $workout->id,
+            'planned_rounds' => 2,
+            'rest_between_exercises_seconds' => 0,
+        ]);
+
+        $workout->entries()->create([
+            'exercise_id' => $exercise->id,
+            'set_order' => 0,
+            'entry_group_id' => $group->id,
+            'group_round' => 1,
+        ]);
+
+        Passport::actingAs($user);
+
+        $response = $this->getJson("/api/v1/workouts/{$workout->id}");
+
+        $response->assertOk()
+            ->assertJsonPath('data.entries.0.entry_group_id', $group->id)
+            ->assertJsonPath('data.entries.0.group_round', 1);
+    }
+
+    public function test_standalone_entry_has_null_group_fields(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance');
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+        $workout->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+
+        $workout->entries()->create([
+            'exercise_id' => $exercise->id,
+            'set_order' => 0,
+        ]);
+
+        Passport::actingAs($user);
+
+        $response = $this->getJson("/api/v1/workouts/{$workout->id}");
+
+        $response->assertOk()
+            ->assertJsonPath('data.entries.0.entry_group_id', null)
+            ->assertJsonPath('data.entries.0.group_round', null);
+    }
+}

--- a/tests/Feature/Api/V1/TemplateCloneTest.php
+++ b/tests/Feature/Api/V1/TemplateCloneTest.php
@@ -10,6 +10,7 @@ use App\Models\WorkoutTemplate;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Passport\Passport;
 use Tests\TestCase;
+use App\Models\EntryGroup;
 
 class TemplateCloneTest extends TestCase
 {
@@ -191,5 +192,234 @@ class TemplateCloneTest extends TestCase
         $this->postJson("/api/v1/templates/{$template->id}/clone", [
             'date' => '2026-07-01',
         ])->assertStatus(403);
+    }
+
+    public function test_clone_creates_entry_groups_from_template_groups(): void
+    {
+        $user = User::factory()->create();
+        $exercise1 = $this->createExercise($user, 'resistance', ['name' => 'Bench Press']);
+        $exercise2 = $this->createExercise($user, 'resistance', ['name' => 'Barbell Row']);
+
+        $template = WorkoutTemplate::factory()->create([
+            'user_id' => $user->id,
+            'name' => 'Push/Pull',
+        ]);
+
+        $templateGroup = $template->groups()->create([
+            'name' => 'Chest/Back Superset',
+            'planned_rounds' => 3,
+            'rest_between_exercises_seconds' => 30,
+            'rest_between_rounds_seconds' => 60,
+        ]);
+
+        $template->exercises()->attach($exercise1->id, [
+            'exercise_order' => 0,
+            'template_entry_group_id' => $templateGroup->id,
+        ]);
+        $template->exercises()->attach($exercise2->id, [
+            'exercise_order' => 1,
+            'template_entry_group_id' => $templateGroup->id,
+        ]);
+
+        Passport::actingAs($user);
+
+        $response = $this->postJson("/api/v1/templates/{$template->id}/clone", [
+            'date' => '2026-07-01',
+        ]);
+
+        $response->assertStatus(201);
+
+        $workoutId = $response->json('data.id');
+
+        $this->assertDatabaseHas('entry_groups', [
+            'workout_id' => $workoutId,
+            'name' => 'Chest/Back Superset',
+            'planned_rounds' => 3,
+            'rest_between_exercises_seconds' => 30,
+            'rest_between_rounds_seconds' => 60,
+        ]);
+    }
+
+    public function test_clone_expands_grouped_exercises_into_round_entries(): void
+    {
+        $user = User::factory()->create();
+        $exercise1 = $this->createExercise($user, 'resistance', ['name' => 'Bench Press']);
+        $exercise2 = $this->createExercise($user, 'resistance', ['name' => 'Barbell Row']);
+
+        $template = WorkoutTemplate::factory()->create([
+            'user_id' => $user->id,
+        ]);
+
+        $templateGroup = $template->groups()->create([
+            'planned_rounds' => 2,
+            'rest_between_exercises_seconds' => 0,
+        ]);
+
+        $template->exercises()->attach($exercise1->id, [
+            'exercise_order' => 0,
+            'template_entry_group_id' => $templateGroup->id,
+        ]);
+        $template->exercises()->attach($exercise2->id, [
+            'exercise_order' => 1,
+            'template_entry_group_id' => $templateGroup->id,
+        ]);
+
+        Passport::actingAs($user);
+
+        $response = $this->postJson("/api/v1/templates/{$template->id}/clone", [
+            'date' => '2026-07-01',
+        ]);
+
+        $workoutId = $response->json('data.id');
+        $workoutGroupId = EntryGroup::where('workout_id', $workoutId)->first()->id;
+
+        // 2 exercises x 2 rounds = 4 entries
+        $this->assertDatabaseCount('workout_entries', 4);
+
+        // Round 1
+        $this->assertDatabaseHas('workout_entries', [
+            'workout_id' => $workoutId,
+            'exercise_id' => $exercise1->id,
+            'set_order' => 0,
+            'entry_group_id' => $workoutGroupId,
+            'group_round' => 1,
+        ]);
+        $this->assertDatabaseHas('workout_entries', [
+            'workout_id' => $workoutId,
+            'exercise_id' => $exercise2->id,
+            'set_order' => 1,
+            'entry_group_id' => $workoutGroupId,
+            'group_round' => 1,
+        ]);
+
+        // Round 2
+        $this->assertDatabaseHas('workout_entries', [
+            'workout_id' => $workoutId,
+            'exercise_id' => $exercise1->id,
+            'set_order' => 2,
+            'entry_group_id' => $workoutGroupId,
+            'group_round' => 2,
+        ]);
+        $this->assertDatabaseHas('workout_entries', [
+            'workout_id' => $workoutId,
+            'exercise_id' => $exercise2->id,
+            'set_order' => 3,
+            'entry_group_id' => $workoutGroupId,
+            'group_round' => 2,
+        ]);
+    }
+
+    public function test_clone_interleaves_standalone_and_grouped_entries(): void
+    {
+        $user = User::factory()->create();
+        $squat = $this->createExercise($user, 'resistance', ['name' => 'Squat']);
+        $bench = $this->createExercise($user, 'resistance', ['name' => 'Bench']);
+        $row = $this->createExercise($user, 'resistance', ['name' => 'Row']);
+        $plank = $this->createExercise($user, 'timed_hold', ['name' => 'Plank']);
+
+        $template = WorkoutTemplate::factory()->create(['user_id' => $user->id]);
+
+        $templateGroup = $template->groups()->create([
+            'planned_rounds' => 2,
+            'rest_between_exercises_seconds' => 0,
+        ]);
+
+        // Squat standalone, then Bench/Row superset, then Plank standalone
+        $template->exercises()->attach($squat->id, ['exercise_order' => 0]);
+        $template->exercises()->attach($bench->id, [
+            'exercise_order' => 1,
+            'template_entry_group_id' => $templateGroup->id,
+        ]);
+        $template->exercises()->attach($row->id, [
+            'exercise_order' => 2,
+            'template_entry_group_id' => $templateGroup->id,
+        ]);
+        $template->exercises()->attach($plank->id, ['exercise_order' => 3]);
+
+        Passport::actingAs($user);
+
+        $response = $this->postJson("/api/v1/templates/{$template->id}/clone", [
+            'date' => '2026-07-01',
+        ]);
+
+        $workoutId = $response->json('data.id');
+        $workoutGroupId = EntryGroup::where('workout_id', $workoutId)->first()->id;
+
+        // 2 standalone + (2 exercises x 2 rounds) = 6 entries
+        $this->assertDatabaseCount('workout_entries', 6);
+
+        // set_order 0: Squat (standalone)
+        $this->assertDatabaseHas('workout_entries', [
+            'workout_id' => $workoutId,
+            'exercise_id' => $squat->id,
+            'set_order' => 0,
+            'entry_group_id' => null,
+        ]);
+
+        // set_order 1-4: Bench/Row superset rounds 1-2
+        $this->assertDatabaseHas('workout_entries', [
+            'workout_id' => $workoutId,
+            'exercise_id' => $bench->id,
+            'set_order' => 1,
+            'entry_group_id' => $workoutGroupId,
+            'group_round' => 1,
+        ]);
+        $this->assertDatabaseHas('workout_entries', [
+            'workout_id' => $workoutId,
+            'exercise_id' => $row->id,
+            'set_order' => 2,
+            'entry_group_id' => $workoutGroupId,
+            'group_round' => 1,
+        ]);
+        $this->assertDatabaseHas('workout_entries', [
+            'workout_id' => $workoutId,
+            'exercise_id' => $bench->id,
+            'set_order' => 3,
+            'entry_group_id' => $workoutGroupId,
+            'group_round' => 2,
+        ]);
+        $this->assertDatabaseHas('workout_entries', [
+            'workout_id' => $workoutId,
+            'exercise_id' => $row->id,
+            'set_order' => 4,
+            'entry_group_id' => $workoutGroupId,
+            'group_round' => 2,
+        ]);
+
+        // set_order 5: Plank (standalone)
+        $this->assertDatabaseHas('workout_entries', [
+            'workout_id' => $workoutId,
+            'exercise_id' => $plank->id,
+            'set_order' => 5,
+            'entry_group_id' => null,
+        ]);
+    }
+
+    public function test_clone_response_includes_groups(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance', ['name' => 'Bench']);
+
+        $template = WorkoutTemplate::factory()->create(['user_id' => $user->id]);
+        $templateGroup = $template->groups()->create([
+            'name' => 'Test Group',
+            'planned_rounds' => 2,
+            'rest_between_exercises_seconds' => 30,
+        ]);
+        $template->exercises()->attach($exercise->id, [
+            'exercise_order' => 0,
+            'template_entry_group_id' => $templateGroup->id,
+        ]);
+
+        Passport::actingAs($user);
+
+        $response = $this->postJson("/api/v1/templates/{$template->id}/clone", [
+            'date' => '2026-07-01',
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.groups.0.name', 'Test Group')
+            ->assertJsonPath('data.groups.0.planned_rounds', 2)
+            ->assertJsonPath('data.groups.0.rest_between_exercises_seconds', 30);
     }
 }

--- a/tests/Feature/Api/V1/WorkoutEntryTest.php
+++ b/tests/Feature/Api/V1/WorkoutEntryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Api\V1;
 
+use App\Models\EntryGroup;
 use App\Models\Exercise;
 use App\Models\User;
 use App\Models\Workout;
@@ -500,5 +501,98 @@ class WorkoutEntryTest extends TestCase
             'exercise_id' => $exercise->id,
             'set_order' => 0,
         ])->assertStatus(403);
+    }
+
+    // -- Group Fields --
+
+    public function test_creates_entry_with_group_assignment(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance', ['name' => 'Bench']);
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+        $workout->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+
+        $group = EntryGroup::create([
+            'workout_id' => $workout->id,
+            'planned_rounds' => 3,
+            'rest_between_exercises_seconds' => 30,
+        ]);
+
+        Passport::actingAs($user);
+
+        $response = $this->postJson("/api/v1/workouts/{$workout->id}/entries", [
+            'exercise_id' => $exercise->id,
+            'set_order' => 0,
+            'entry_group_id' => $group->id,
+            'group_round' => 1,
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.entry_group_id', $group->id)
+            ->assertJsonPath('data.group_round', 1);
+
+        $this->assertDatabaseHas('workout_entries', [
+            'workout_id' => $workout->id,
+            'entry_group_id' => $group->id,
+            'group_round' => 1,
+        ]);
+    }
+
+    public function test_updates_entry_group_assignment(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance');
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+        $workout->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+
+        $entry = $workout->entries()->create([
+            'exercise_id' => $exercise->id,
+            'set_order' => 0,
+        ]);
+
+        $group = EntryGroup::create([
+            'workout_id' => $workout->id,
+            'planned_rounds' => 2,
+            'rest_between_exercises_seconds' => 0,
+        ]);
+
+        Passport::actingAs($user);
+
+        $this->putJson("/api/v1/workouts/{$workout->id}/entries/{$entry->id}", [
+            'entry_group_id' => $group->id,
+            'group_round' => 2,
+        ])->assertOk()
+            ->assertJsonPath('data.entry_group_id', $group->id)
+            ->assertJsonPath('data.group_round', 2);
+    }
+
+    public function test_removes_entry_from_group_via_update(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance');
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+        $workout->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+
+        $group = EntryGroup::create([
+            'workout_id' => $workout->id,
+            'planned_rounds' => 2,
+            'rest_between_exercises_seconds' => 0,
+        ]);
+
+        $entry = $workout->entries()->create([
+            'exercise_id' => $exercise->id,
+            'set_order' => 0,
+            'entry_group_id' => $group->id,
+            'group_round' => 1,
+        ]);
+
+        Passport::actingAs($user);
+
+        $this->putJson("/api/v1/workouts/{$workout->id}/entries/{$entry->id}", [
+            'entry_group_id' => null,
+            'group_round' => null,
+        ])->assertOk()
+            ->assertJsonPath('data.entry_group_id', null)
+            ->assertJsonPath('data.group_round', null);
     }
 }


### PR DESCRIPTION
## Problem

Workouts had no way to represent supersets, tri-sets, circuits, or giant sets. Exercises were always standalone, with no mechanism to group them into rounds or attach rest timing between exercises or rounds.

## Solution

Added a first-class `entry_groups` table that workouts own. Each group has a name, planned rounds, and rest timing. Entries reference their group via a nullable FK (`entry_group_id`) with `ON DELETE SET NULL`, so deleting a group preserves the entries as standalone.

- `EntryGroupController` provides CRUD (store/update/destroy), batch entry assignment, and single entry removal, all nested under `workouts/{workout}/groups`
- `WorkoutEntryController` store and update now accept `entry_group_id` and `group_round`, validated against the parent workout's groups
- `TemplateCloneController` clones template groups into workout groups and expands grouped exercises into round-interleaved entries (e.g., 2 exercises with 3 planned rounds becomes 6 entries with correct `set_order` and `group_round`)
- `WorkoutResource` includes groups in the response; `WorkoutEntryResource` includes `entry_group_id` and `group_round`
- 24 new feature tests covering group CRUD, entry assignment, delete-preserves-entries behavior, clone with groups, and response integration
