### PR TITLE
PS-66 - Wiring superset and circuit group actions in workout detail and template editor

### DIFF
--- a/app/Http/Controllers/Api/V1/TemplateEntryGroupController.php
+++ b/app/Http/Controllers/Api/V1/TemplateEntryGroupController.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\AssignTemplateGroupExercisesRequest;
+use App\Http\Requests\Api\V1\StoreTemplateEntryGroupRequest;
+use App\Http\Resources\Api\V1\WorkoutTemplateResource;
+use App\Models\Exercise;
+use App\Models\TemplateEntryGroup;
+use App\Models\WorkoutTemplate;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
+
+class TemplateEntryGroupController extends Controller
+{
+    use AuthorizesRequests;
+
+    private const TEMPLATE_EAGER_LOAD = ['exercises', 'groups'];
+
+    public function store(StoreTemplateEntryGroupRequest $request, WorkoutTemplate $template): JsonResponse
+    {
+        $this->authorize('update', $template);
+
+        $template->groups()->create($request->validated());
+
+        $template->load(self::TEMPLATE_EAGER_LOAD);
+
+        return (new WorkoutTemplateResource($template))
+            ->response()
+            ->setStatusCode(201);
+    }
+
+    public function destroy(WorkoutTemplate $template, TemplateEntryGroup $group): Response
+    {
+        $this->authorize('update', $template);
+
+        abort_if($group->template_id !== $template->id, 404);
+
+        $group->delete();
+
+        return response()->noContent();
+    }
+
+    public function assignExercises(
+        AssignTemplateGroupExercisesRequest $request,
+        WorkoutTemplate $template,
+        TemplateEntryGroup $group
+    ): WorkoutTemplateResource {
+        $this->authorize('update', $template);
+
+        abort_if($group->template_id !== $template->id, 404);
+
+        foreach ($request->validated('exercise_ids') as $exerciseId) {
+            $template->exercises()->updateExistingPivot($exerciseId, [
+                'template_entry_group_id' => $group->id,
+            ]);
+        }
+
+        $template->load(self::TEMPLATE_EAGER_LOAD);
+
+        return new WorkoutTemplateResource($template);
+    }
+
+    public function removeExercise(
+        WorkoutTemplate $template,
+        TemplateEntryGroup $group,
+        Exercise $exercise
+    ): WorkoutTemplateResource {
+        $this->authorize('update', $template);
+
+        abort_if($group->template_id !== $template->id, 404);
+
+        $template->exercises()->updateExistingPivot($exercise->id, [
+            'template_entry_group_id' => null,
+        ]);
+
+        $template->load(self::TEMPLATE_EAGER_LOAD);
+
+        return new WorkoutTemplateResource($template);
+    }
+}

--- a/app/Http/Requests/Api/V1/AssignTemplateGroupExercisesRequest.php
+++ b/app/Http/Requests/Api/V1/AssignTemplateGroupExercisesRequest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AssignTemplateGroupExercisesRequest extends FormRequest
+{
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        return [
+            'exercise_ids' => ['required', 'array', 'min:1'],
+            'exercise_ids.*' => ['required', 'integer'],
+        ];
+    }
+}

--- a/app/Http/Requests/Api/V1/StoreTemplateEntryGroupRequest.php
+++ b/app/Http/Requests/Api/V1/StoreTemplateEntryGroupRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreTemplateEntryGroupRequest extends FormRequest
+{
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        return [
+            'name' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'planned_rounds' => ['sometimes', 'integer', 'min:1'],
+            'rest_between_exercises_seconds' => ['sometimes', 'integer', 'min:0'],
+            'rest_between_rounds_seconds' => ['sometimes', 'nullable', 'integer', 'min:0'],
+        ];
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "html",
+  "name": "physistrong",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/resources/js/api/templates.ts
+++ b/resources/js/api/templates.ts
@@ -82,3 +82,33 @@ export async function cloneTemplate(
   const { data } = await api.post(`/templates/${templateId}/clone`, payload)
   return toWorkout(data.data as RawWorkout)
 }
+
+export interface CreateTemplateGroupPayload {
+  name?: string | null
+  planned_rounds: number
+  rest_between_exercises_seconds: number
+  rest_between_rounds_seconds: number
+}
+
+export async function createTemplateGroup(
+  templateId: string,
+  payload: CreateTemplateGroupPayload
+): Promise<WorkoutTemplate> {
+  const { data } = await api.post(`/templates/${templateId}/groups`, payload)
+  return toWorkoutTemplate(data.data as RawWorkoutTemplate)
+}
+
+export async function deleteTemplateGroup(templateId: string, groupId: string): Promise<void> {
+  await api.delete(`/templates/${templateId}/groups/${groupId}`)
+}
+
+export async function assignExercisesToGroup(
+  templateId: string,
+  groupId: string,
+  exerciseIds: string[]
+): Promise<WorkoutTemplate> {
+  const { data } = await api.post(`/templates/${templateId}/groups/${groupId}/exercises`, {
+    exercise_ids: exerciseIds.map(Number),
+  })
+  return toWorkoutTemplate(data.data as RawWorkoutTemplate)
+}

--- a/resources/js/api/transformers.ts
+++ b/resources/js/api/transformers.ts
@@ -120,11 +120,21 @@ export interface RawWorkoutEntry {
   workout_id: number
   exercise_id: number
   set_order: number
+  entry_group_id: number | null
+  group_round: number | null
   notes: string | null
   exercise?: { id: number; name: string; type: string }
   metrics: Record<string, Record<string, unknown>>
   created_at: string
   updated_at: string
+}
+
+export interface RawEntryGroup {
+  id: number
+  name: string | null
+  planned_rounds: number
+  rest_between_exercises_seconds: number
+  rest_between_rounds_seconds: number | null
 }
 
 export interface RawWorkout {
@@ -135,6 +145,7 @@ export interface RawWorkout {
   soreness: number | null
   exercises: RawWorkoutExercise[]
   entries: RawWorkoutEntry[]
+  groups: RawEntryGroup[]
   created_at: string
   updated_at: string
 }
@@ -165,7 +176,14 @@ export function toWorkout(raw: RawWorkout): Workout {
     exhaustion: raw.exhaustion,
     soreness: raw.soreness,
     entries: raw.entries.map(toWorkoutEntry),
-    entryGroups: [],
+    entryGroups: (raw.groups ?? []).map(g => ({
+      id: String(g.id),
+      workoutId: String(raw.id),
+      name: g.name,
+      plannedRounds: g.planned_rounds,
+      restBetweenExercisesSeconds: g.rest_between_exercises_seconds,
+      restBetweenRoundsSeconds: g.rest_between_rounds_seconds,
+    })),
   }
 }
 
@@ -175,8 +193,8 @@ export function toWorkoutEntry(raw: RawWorkoutEntry): WorkoutEntry {
     workoutId: String(raw.workout_id),
     exerciseId: String(raw.exercise_id),
     setOrder: raw.set_order,
-    entryGroupId: null,
-    groupRound: null,
+    entryGroupId: raw.entry_group_id !== null ? String(raw.entry_group_id) : null,
+    groupRound: raw.group_round,
     notes: raw.notes,
   }
 

--- a/resources/js/api/workouts.ts
+++ b/resources/js/api/workouts.ts
@@ -36,6 +36,18 @@ export interface UpdateEntryPayload {
   metrics?: Record<string, unknown>
 }
 
+export interface CreateGroupPayload {
+  name?: string | null
+  planned_rounds: number
+  rest_between_exercises_seconds: number
+  rest_between_rounds_seconds: number | null
+}
+
+export interface AssignEntryPayload {
+  entry_id: number
+  group_round: number
+}
+
 interface PaginatedResponse {
   items: WorkoutListItem[]
   nextPage: number | null
@@ -114,4 +126,25 @@ export async function reorderEntries(workoutId: string, ids: string[]): Promise<
     ids: ids.map(Number),
   })
   return (data.data as RawWorkoutEntry[]).map(toWorkoutEntry)
+}
+
+export async function createGroup(
+  workoutId: string,
+  payload: CreateGroupPayload
+): Promise<Workout> {
+  const { data } = await api.post(`/workouts/${workoutId}/groups`, payload)
+  return toWorkout(data.data as RawWorkout)
+}
+
+export async function deleteGroup(workoutId: string, groupId: string): Promise<void> {
+  await api.delete(`/workouts/${workoutId}/groups/${groupId}`)
+}
+
+export async function assignEntries(
+  workoutId: string,
+  groupId: string,
+  entries: AssignEntryPayload[]
+): Promise<Workout> {
+  const { data } = await api.post(`/workouts/${workoutId}/groups/${groupId}/entries`, { entries })
+  return toWorkout(data.data as RawWorkout)
 }

--- a/resources/js/pages/template-editor.tsx
+++ b/resources/js/pages/template-editor.tsx
@@ -10,6 +10,9 @@ import {
   attachExercise as attachExerciseApi,
   detachExercise as detachExerciseApi,
   reorderExercises as reorderExercisesApi,
+  createTemplateGroup,
+  deleteTemplateGroup,
+  assignExercisesToGroup,
 } from '@/api/templates'
 import { listEquipment } from '@/api/equipment'
 import { useApp } from '@/lib/use-app'
@@ -18,7 +21,7 @@ import { formatDuration } from '@/lib/formatters'
 import type { Exercise } from '@/api/types'
 import { PageHeader, Button, Card, TypeBadge, InlineEdit, ConfirmDialog } from '@/components/ui'
 import { ReorderList } from '@/components/app/reorderable'
-import { ExercisePicker } from '@/components/app/pickers'
+import { ExercisePicker, GroupConfigSheet } from '@/components/app/pickers'
 
 interface TemplateBlock {
   kind: 'exercise' | 'group'
@@ -53,6 +56,9 @@ export function TemplateEditorPage() {
 
   const [exercisePickerOpen, setExercisePickerOpen] = useState(false)
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false)
+  const [selectMode, setSelectMode] = useState(false)
+  const [selected, setSelected] = useState<string[]>([])
+  const [groupSheetOpen, setGroupSheetOpen] = useState(false)
 
   const { data: tpl, isLoading } = useQuery({
     queryKey: ['templates', templateId],
@@ -104,6 +110,53 @@ export function TemplateEditorPage() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['templates', templateId] })
     },
+  })
+
+  const createGroupMutation = useMutation({
+    mutationFn: async (config: {
+      name: string | null
+      plannedRounds: number
+      restBetweenExercisesSeconds: number
+      restBetweenRoundsSeconds: number
+    }) => {
+      if (!tpl) throw new Error('Template not loaded')
+      const afterCreate = await createTemplateGroup(templateId ?? '', {
+        name: config.name,
+        planned_rounds: config.plannedRounds,
+        rest_between_exercises_seconds: config.restBetweenExercisesSeconds,
+        rest_between_rounds_seconds: config.restBetweenRoundsSeconds,
+      })
+
+      const existingIds = new Set(tpl.groups.map(g => g.id))
+      const newGroup = afterCreate.groups.find(g => !existingIds.has(g.id))
+      if (!newGroup) throw new Error('Group not created')
+
+      const currentBlocks = buildBlocks(tpl)
+      const exerciseIds = currentBlocks
+        .filter(
+          (b): b is TemplateBlock & { te: TemplateExercise } =>
+            selected.includes(b.id) && b.kind === 'exercise' && !!b.te
+        )
+        .map(b => b.te.exerciseId)
+
+      return assignExercisesToGroup(templateId ?? '', newGroup.id, exerciseIds)
+    },
+    onSuccess: data => {
+      queryClient.setQueryData(['templates', templateId], data)
+      setSelectMode(false)
+      setSelected([])
+      toast('Group created.')
+    },
+    onError: () => toast('Could not create group. Try again.'),
+  })
+
+  const ungroupMutation = useMutation({
+    mutationFn: (groupId: string) => deleteTemplateGroup(templateId ?? '', groupId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['templates', templateId] })
+      toast('Group removed.')
+    },
+    onError: () => toast('Could not ungroup. Try again.'),
   })
 
   if (!templateId) {
@@ -160,7 +213,7 @@ export function TemplateEditorPage() {
 
   const ungroup = (block: TemplateBlock) => {
     if (!block.group) return
-    toast('Coming in a future update')
+    ungroupMutation.mutate(block.group.id)
   }
 
   const exerciseBlockCount = blocks.filter(b => b.kind === 'exercise').length
@@ -193,24 +246,71 @@ export function TemplateEditorPage() {
         <Button size="sm" icon={<Plus size={16} />} onClick={() => setExercisePickerOpen(true)}>
           Add Exercise
         </Button>
-        {exerciseBlockCount >= 2 && (
+        {!selectMode && exerciseBlockCount >= 2 && (
           <Button
             size="sm"
             variant="secondary"
             icon={<span>⊕</span>}
-            onClick={() => toast('Coming in a future update')}
+            onClick={() => setSelectMode(true)}
           >
             Make a Superset
           </Button>
         )}
       </div>
 
+      {selectMode && (
+        <div
+          className="ps-card p-4 mb-4"
+          style={{
+            border: '1px solid var(--color-primary)',
+            background: 'color-mix(in srgb, var(--color-primary) 6%, var(--color-surface-card))',
+          }}
+        >
+          <div className="flex items-start gap-3">
+            <span
+              className="h-9 w-9 rounded-lg flex items-center justify-center shrink-0"
+              style={{
+                background: 'color-mix(in srgb, var(--color-primary) 14%, transparent)',
+                color: 'var(--color-primary)',
+              }}
+            >
+              ✓
+            </span>
+            <div className="flex-1 min-w-0">
+              <div className="font-semibold text-sm">Build a superset or circuit</div>
+              <div className="text-[13px] text-text-secondary mt-0.5">
+                Tap 2 or more exercises to group them.
+              </div>
+            </div>
+          </div>
+          <div className="flex items-center gap-2 mt-3">
+            <Button
+              size="sm"
+              disabled={selected.length < 2}
+              onClick={() => setGroupSheetOpen(true)}
+            >
+              Continue · {selected.length} selected
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => {
+                setSelectMode(false)
+                setSelected([])
+              }}
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+
       {blocks.length ? (
         <ReorderList
           items={blocks}
           getKey={b => b.id}
           onReorder={handleReorder}
-          disabled={false}
+          disabled={selectMode}
           className="flex flex-col gap-3"
           itemClassName="rounded-2xl"
           renderItem={(block, { handle, controls }) => {
@@ -274,6 +374,51 @@ export function TemplateEditorPage() {
             if (!block.te) return null
             const te = block.te
 
+            if (selectMode) {
+              const isSelected = selected.includes(block.id)
+              return (
+                <Card
+                  className="p-4"
+                  style={
+                    isSelected
+                      ? { outline: '2px solid var(--color-primary)', outlineOffset: '-1px' }
+                      : undefined
+                  }
+                >
+                  <button
+                    onClick={() =>
+                      setSelected(s =>
+                        s.includes(block.id) ? s.filter(x => x !== block.id) : [...s, block.id]
+                      )
+                    }
+                    className="flex items-center gap-3 w-full text-left cursor-pointer"
+                  >
+                    <span
+                      className="h-6 w-6 rounded-md border-2 flex items-center justify-center shrink-0"
+                      style={
+                        isSelected
+                          ? {
+                              background: 'var(--color-primary)',
+                              borderColor: 'var(--color-primary)',
+                              color: '#fff',
+                            }
+                          : { borderColor: 'var(--color-border-strong)' }
+                      }
+                    >
+                      {isSelected && '✓'}
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <div className="font-semibold text-sm truncate">{te.name}</div>
+                      <div className="text-[12px] text-text-secondary">
+                        {equipmentName(equipment, te.equipmentTypeId || null)}
+                      </div>
+                    </div>
+                    <TypeBadge type={te.type} />
+                  </button>
+                </Card>
+              )
+            }
+
             return (
               <Card className="p-4">
                 <div className="flex items-center gap-2">
@@ -319,6 +464,15 @@ export function TemplateEditorPage() {
         message={`"${tpl.name}" will be removed.`}
         onCancel={() => setConfirmDeleteOpen(false)}
         onConfirm={() => deleteMutation.mutate()}
+      />
+      <GroupConfigSheet
+        open={groupSheetOpen}
+        onClose={() => setGroupSheetOpen(false)}
+        count={selected.length}
+        onConfirm={config => {
+          createGroupMutation.mutate(config)
+          setGroupSheetOpen(false)
+        }}
       />
     </>
   )

--- a/resources/js/pages/workout-detail.tsx
+++ b/resources/js/pages/workout-detail.tsx
@@ -15,9 +15,12 @@ import {
   updateEntry,
   deleteEntry,
   reorderEntries,
+  createGroup,
+  deleteGroup,
+  assignEntries,
 } from '@/api/workouts'
 import { toMetricsPayload } from '@/api/transformers'
-import type { CreateEntryPayload } from '@/api/workouts'
+import type { CreateEntryPayload, AssignEntryPayload } from '@/api/workouts'
 import { useApp } from '@/lib/use-app'
 import { formatDuration } from '@/lib/formatters'
 import { workoutCompletion, exerciseById, equipmentName, entryHasActual } from '@/lib/domain'
@@ -334,6 +337,52 @@ export function WorkoutDetailPage() {
     onSuccess: invalidateWorkout,
   })
 
+  const createGroupMutation = useMutation({
+    mutationFn: async (config: {
+      name: string | null
+      plannedRounds: number
+      restBetweenExercisesSeconds: number
+      restBetweenRoundsSeconds: number
+    }) => {
+      if (!workout) throw new Error('Workout not loaded')
+
+      const afterCreate = await createGroup(workoutId, {
+        name: config.name,
+        planned_rounds: config.plannedRounds,
+        rest_between_exercises_seconds: config.restBetweenExercisesSeconds,
+        rest_between_rounds_seconds: config.restBetweenRoundsSeconds,
+      })
+
+      const existingIds = new Set((workout?.entryGroups ?? []).map(g => g.id))
+      const newGroup = afterCreate.entryGroups.find(g => !existingIds.has(g.id))
+      if (!newGroup) throw new Error('Group not created')
+
+      const currentBlocks = buildBlocks(workout?.entries ?? [], workout?.entryGroups ?? [])
+      const selectedBlocks = currentBlocks.filter(b => selected.includes(b.id))
+      const assignments: AssignEntryPayload[] = selectedBlocks.flatMap(b =>
+        b.entries.map(e => ({ entry_id: Number(e.id), group_round: 1 }))
+      )
+
+      return assignEntries(workoutId, newGroup.id, assignments)
+    },
+    onSuccess: data => {
+      queryClient.setQueryData(['workouts', workoutId], data)
+      setSelectMode(false)
+      setSelected([])
+      toast('Group created.')
+    },
+    onError: () => toast('Could not create group. Try again.'),
+  })
+
+  const ungroupMutation = useMutation({
+    mutationFn: (groupId: string) => deleteGroup(workoutId, groupId),
+    onSuccess: () => {
+      invalidateWorkout()
+      toast('Group removed.')
+    },
+    onError: () => toast('Could not ungroup. Try again.'),
+  })
+
   const debouncedEntryUpdate = useCallback(
     (entryId: string, entry: WorkoutEntry) => {
       const pending = pendingUpdates.current
@@ -628,6 +677,14 @@ export function WorkoutDetailPage() {
                             : 'no round rest'}
                         </div>
                       </div>
+                      {block.gid && (
+                        <button
+                          onClick={() => ungroupMutation.mutate(block.gid as string)}
+                          className="text-[12px] font-semibold text-text-secondary hover:text-destructive px-2 h-8 rounded-lg hover:bg-surface-muted"
+                        >
+                          Ungroup
+                        </button>
+                      )}
                       {controls}
                     </div>
                     <div className="flex flex-col gap-4">
@@ -767,7 +824,7 @@ export function WorkoutDetailPage() {
       <div className="ps-card p-4 mt-6">
         <h3 className="font-semibold text-base mb-1">How was the session?</h3>
         <p className="text-[13px] text-text-secondary mb-4">
-          Rate after you finish — helps track recovery.
+          Rate after you finish. Helps track recovery.
         </p>
         <div className="flex flex-col gap-4">
           <div>
@@ -804,11 +861,9 @@ export function WorkoutDetailPage() {
         open={groupSheetOpen}
         onClose={() => setGroupSheetOpen(false)}
         count={selected.length}
-        onConfirm={() => {
-          toast('Supersets require the grouping API (Phase 8a).')
+        onConfirm={config => {
+          createGroupMutation.mutate(config)
           setGroupSheetOpen(false)
-          setSelectMode(false)
-          setSelected([])
         }}
       />
       <ConfirmDialog

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Api\V1\EntryGroupController;
 use App\Http\Controllers\Api\V1\EquipmentTypeController;
 use App\Http\Controllers\Api\V1\ExerciseController;
 use App\Http\Controllers\Api\V1\TemplateCloneController;
+use App\Http\Controllers\Api\V1\TemplateEntryGroupController;
 use App\Http\Controllers\Api\V1\TemplateExerciseController;
 use App\Http\Controllers\Api\V1\UserController;
 use App\Http\Controllers\Api\V1\WorkoutController;
@@ -41,6 +42,10 @@ Route::middleware('auth:api')->group(function () {
     Route::delete('templates/{template}/exercises/{exercise}', [TemplateExerciseController::class, 'detach']);
     Route::put('templates/{template}/exercises/reorder', [TemplateExerciseController::class, 'reorder']);
     Route::post('templates/{template}/clone', TemplateCloneController::class);
+    Route::post('templates/{template}/groups', [TemplateEntryGroupController::class, 'store']);
+    Route::delete('templates/{template}/groups/{group}', [TemplateEntryGroupController::class, 'destroy']);
+    Route::post('templates/{template}/groups/{group}/exercises', [TemplateEntryGroupController::class, 'assignExercises']);
+    Route::delete('templates/{template}/groups/{group}/exercises/{exercise}', [TemplateEntryGroupController::class, 'removeExercise']);
     Route::post('workouts/{workout}/groups', [EntryGroupController::class, 'store']);
     Route::put('workouts/{workout}/groups/{group}', [EntryGroupController::class, 'update']);
     Route::delete('workouts/{workout}/groups/{group}', [EntryGroupController::class, 'destroy']);

--- a/tests/Feature/Api/V1/TemplateEntryGroupTest.php
+++ b/tests/Feature/Api/V1/TemplateEntryGroupTest.php
@@ -1,0 +1,213 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Models\Exercise;
+use App\Models\TemplateEntryGroup;
+use App\Models\User;
+use App\Models\WorkoutTemplate;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
+use Tests\TestCase;
+
+class TemplateEntryGroupTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createExercise(User $user, string $name = 'Test Exercise'): Exercise
+    {
+        $exercise = Exercise::create([
+            'name' => $name,
+            'type' => 'resistance',
+            'user_id' => $user->id,
+        ]);
+
+        $exercise->resistance()->create([]);
+
+        return $exercise;
+    }
+
+    public function test_creates_template_group(): void
+    {
+        $user = User::factory()->create();
+        $template = WorkoutTemplate::factory()->create(['user_id' => $user->id]);
+
+        Passport::actingAs($user);
+
+        $response = $this->postJson("/api/v1/templates/{$template->id}/groups", [
+            'name' => 'Push Superset',
+            'planned_rounds' => 3,
+            'rest_between_exercises_seconds' => 30,
+            'rest_between_rounds_seconds' => 60,
+        ]);
+
+        $response->assertStatus(201);
+
+        $this->assertDatabaseHas('template_entry_groups', [
+            'template_id' => $template->id,
+            'name' => 'Push Superset',
+            'planned_rounds' => 3,
+        ]);
+    }
+
+    public function test_store_returns_template_with_groups(): void
+    {
+        $user = User::factory()->create();
+        $template = WorkoutTemplate::factory()->create(['user_id' => $user->id]);
+
+        Passport::actingAs($user);
+
+        $response = $this->postJson("/api/v1/templates/{$template->id}/groups", [
+            'name' => 'Circuit',
+            'planned_rounds' => 4,
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.groups.0.name', 'Circuit')
+            ->assertJsonPath('data.groups.0.planned_rounds', 4);
+    }
+
+    public function test_cannot_create_group_on_other_users_template(): void
+    {
+        $owner = User::factory()->create();
+        $other = User::factory()->create();
+        $template = WorkoutTemplate::factory()->create(['user_id' => $owner->id]);
+
+        Passport::actingAs($other);
+
+        $this->postJson("/api/v1/templates/{$template->id}/groups", [
+            'planned_rounds' => 2,
+        ])->assertStatus(403);
+    }
+
+    public function test_deletes_template_group(): void
+    {
+        $user = User::factory()->create();
+        $template = WorkoutTemplate::factory()->create(['user_id' => $user->id]);
+        $group = TemplateEntryGroup::create([
+            'template_id' => $template->id,
+            'planned_rounds' => 2,
+            'rest_between_exercises_seconds' => 0,
+        ]);
+
+        Passport::actingAs($user);
+
+        $this->deleteJson("/api/v1/templates/{$template->id}/groups/{$group->id}")
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('template_entry_groups', ['id' => $group->id]);
+    }
+
+    public function test_delete_group_nulls_exercise_pivot_fk(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'Bench Press');
+        $template = WorkoutTemplate::factory()->create(['user_id' => $user->id]);
+        $group = TemplateEntryGroup::create([
+            'template_id' => $template->id,
+            'planned_rounds' => 3,
+            'rest_between_exercises_seconds' => 0,
+        ]);
+        $template->exercises()->attach($exercise->id, [
+            'exercise_order' => 0,
+            'template_entry_group_id' => $group->id,
+        ]);
+
+        Passport::actingAs($user);
+
+        $this->deleteJson("/api/v1/templates/{$template->id}/groups/{$group->id}")
+            ->assertNoContent();
+
+        $this->assertDatabaseHas('template_exercises', [
+            'template_id' => $template->id,
+            'exercise_id' => $exercise->id,
+            'template_entry_group_id' => null,
+        ]);
+    }
+
+    public function test_destroy_returns_404_for_group_from_other_template(): void
+    {
+        $user = User::factory()->create();
+        $template1 = WorkoutTemplate::factory()->create(['user_id' => $user->id]);
+        $template2 = WorkoutTemplate::factory()->create(['user_id' => $user->id]);
+        $group = TemplateEntryGroup::create([
+            'template_id' => $template1->id,
+            'planned_rounds' => 2,
+            'rest_between_exercises_seconds' => 0,
+        ]);
+
+        Passport::actingAs($user);
+
+        $this->deleteJson("/api/v1/templates/{$template2->id}/groups/{$group->id}")
+            ->assertStatus(404);
+    }
+
+    public function test_assigns_exercises_to_group(): void
+    {
+        $user = User::factory()->create();
+        $ex1 = $this->createExercise($user, 'Bench');
+        $ex2 = $this->createExercise($user, 'Row');
+        $template = WorkoutTemplate::factory()->create(['user_id' => $user->id]);
+        $template->exercises()->attach($ex1->id, ['exercise_order' => 0]);
+        $template->exercises()->attach($ex2->id, ['exercise_order' => 1]);
+
+        $group = TemplateEntryGroup::create([
+            'template_id' => $template->id,
+            'planned_rounds' => 3,
+            'rest_between_exercises_seconds' => 30,
+        ]);
+
+        Passport::actingAs($user);
+
+        $response = $this->postJson(
+            "/api/v1/templates/{$template->id}/groups/{$group->id}/exercises",
+            ['exercise_ids' => [$ex1->id, $ex2->id]]
+        );
+
+        $response->assertOk();
+
+        $this->assertDatabaseHas('template_exercises', [
+            'template_id' => $template->id,
+            'exercise_id' => $ex1->id,
+            'template_entry_group_id' => $group->id,
+        ]);
+
+        $this->assertDatabaseHas('template_exercises', [
+            'template_id' => $template->id,
+            'exercise_id' => $ex2->id,
+            'template_entry_group_id' => $group->id,
+        ]);
+    }
+
+    public function test_removes_exercise_from_group(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'Bench');
+        $template = WorkoutTemplate::factory()->create(['user_id' => $user->id]);
+        $group = TemplateEntryGroup::create([
+            'template_id' => $template->id,
+            'planned_rounds' => 2,
+            'rest_between_exercises_seconds' => 0,
+        ]);
+        $template->exercises()->attach($exercise->id, [
+            'exercise_order' => 0,
+            'template_entry_group_id' => $group->id,
+        ]);
+
+        Passport::actingAs($user);
+
+        $response = $this->deleteJson(
+            "/api/v1/templates/{$template->id}/groups/{$group->id}/exercises/{$exercise->id}"
+        );
+
+        $response->assertOk();
+
+        $this->assertDatabaseHas('template_exercises', [
+            'template_id' => $template->id,
+            'exercise_id' => $exercise->id,
+            'template_entry_group_id' => null,
+        ]);
+    }
+}


### PR DESCRIPTION
## Problem

The workout detail and template editor pages had group rendering code (accent borders, round counters, rest timing) but it was inert. The frontend transformer layer hardcoded `entryGroups` to an empty array and `entryGroupId`/`groupRound` to null on every entry, so groups from the API never reached the UI. The action handlers for "Make a Superset" and "Ungroup" showed placeholder toasts. Templates also had no backend API for managing groups.

## Solution

Fixed `toWorkout` and `toWorkoutEntry` in `transformers.ts` to parse group data from API responses. Added `createGroup`, `deleteGroup`, and `assignEntries` API functions in `workouts.ts`.

On the workout detail page, the GroupConfigSheet `onConfirm` now creates a real entry group via the API and assigns selected entries as round 1. An "Ungroup" button on group blocks deletes the group (entries become standalone via SET NULL).

Added a `TemplateEntryGroupController` with store, destroy, assign-exercises, and remove-exercise actions, plus 4 routes and 8 feature tests. Added matching frontend API functions and wired the template editor with the same select mode and GroupConfigSheet flow as the workout detail page.
