### PR TITLE
PS-52 - Adding copy workout feature

### DIFF
--- a/app/Http/Controllers/Api/V1/WorkoutCopyController.php
+++ b/app/Http/Controllers/Api/V1/WorkoutCopyController.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\CopyWorkoutRequest;
+use App\Http\Resources\Api\V1\WorkoutResource;
+use App\Models\Workout;
+use App\Models\WorkoutEntry;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+
+class WorkoutCopyController extends Controller
+{
+    use AuthorizesRequests;
+
+    private const WORKOUT_EAGER_LOAD = [
+        'exercises',
+        'groups',
+        'entries.exercise',
+        'entries.loadMetric',
+        'entries.repMetric',
+        'entries.durationMetric',
+        'entries.distanceMetric',
+        'entries.cardioSetting',
+        'entries.intervalHeader.rounds',
+        'entries.intensityMetric',
+    ];
+
+    public function __invoke(CopyWorkoutRequest $request, Workout $workout): JsonResponse
+    {
+        $this->authorize('view', $workout);
+
+        $workout->load([
+            'exercises',
+            'groups',
+            'entries.loadMetric',
+            'entries.repMetric',
+            'entries.durationMetric',
+            'entries.distanceMetric',
+            'entries.cardioSetting',
+            'entries.intervalHeader',
+        ]);
+
+        $newWorkout = DB::transaction(function () use ($request, $workout) {
+            $newWorkout = Workout::create([
+                'name' => $request->validated('name', $workout->name),
+                'user_id' => $request->user()->id,
+                'date' => $request->validated('date'),
+            ]);
+
+            $groupMapping = [];
+            foreach ($workout->groups as $group) {
+                $newGroup = $newWorkout->groups()->create([
+                    'name' => $group->name,
+                    'planned_rounds' => $group->planned_rounds,
+                    'rest_between_exercises_seconds' => $group->rest_between_exercises_seconds,
+                    'rest_between_rounds_seconds' => $group->rest_between_rounds_seconds,
+                ]);
+                $groupMapping[$group->id] = $newGroup->id;
+            }
+
+            foreach ($workout->exercises as $exercise) {
+                $newWorkout->exercises()->attach($exercise->id, [
+                    'exercise_order' => $exercise->pivot->exercise_order,
+                ]);
+            }
+
+            foreach ($workout->entries as $entry) {
+                $newEntry = $newWorkout->entries()->create([
+                    'exercise_id' => $entry->exercise_id,
+                    'set_order' => $entry->set_order,
+                    'entry_group_id' => $entry->entry_group_id
+                        ? ($groupMapping[$entry->entry_group_id] ?? null)
+                        : null,
+                    'group_round' => $entry->group_round,
+                    'notes' => $entry->notes,
+                ]);
+
+                $this->cloneMetrics($entry, $newEntry);
+            }
+
+            return $newWorkout;
+        });
+
+        $newWorkout->load(self::WORKOUT_EAGER_LOAD);
+
+        return (new WorkoutResource($newWorkout))
+            ->response()
+            ->setStatusCode(201);
+    }
+
+    private function cloneMetrics(WorkoutEntry $source, WorkoutEntry $target): void
+    {
+        if ($source->loadMetric) {
+            $target->loadMetric()->create([
+                'target_weight' => $source->loadMetric->target_weight,
+                'bodyweight_only' => $source->loadMetric->bodyweight_only,
+            ]);
+        }
+
+        if ($source->repMetric) {
+            $target->repMetric()->create([
+                'target_reps' => $source->repMetric->target_reps,
+                'to_failure' => $source->repMetric->to_failure,
+            ]);
+        }
+
+        if ($source->durationMetric) {
+            $target->durationMetric()->create([
+                'target_duration_seconds' => $source->durationMetric->target_duration_seconds,
+            ]);
+        }
+
+        if ($source->distanceMetric) {
+            $target->distanceMetric()->create([
+                'target_distance' => $source->distanceMetric->target_distance,
+                'distance_unit' => $source->distanceMetric->distance_unit,
+            ]);
+        }
+
+        if ($source->cardioSetting) {
+            $target->cardioSetting()->create([
+                'resistance_level' => $source->cardioSetting->resistance_level,
+                'incline' => $source->cardioSetting->incline,
+                'speed' => $source->cardioSetting->speed,
+                'cadence' => $source->cardioSetting->cadence,
+            ]);
+        }
+
+        if ($source->intervalHeader) {
+            $target->intervalHeader()->create([
+                'programmed_rounds' => $source->intervalHeader->programmed_rounds,
+                'target_work_seconds' => $source->intervalHeader->target_work_seconds,
+                'target_rest_seconds' => $source->intervalHeader->target_rest_seconds,
+            ]);
+        }
+    }
+}

--- a/app/Http/Requests/Api/V1/CopyWorkoutRequest.php
+++ b/app/Http/Requests/Api/V1/CopyWorkoutRequest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CopyWorkoutRequest extends FormRequest
+{
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        return [
+            'date' => ['required', 'date'],
+            'name' => ['sometimes', 'string', 'max:255'],
+        ];
+    }
+}

--- a/resources/js/api/workouts.ts
+++ b/resources/js/api/workouts.ts
@@ -48,6 +48,11 @@ export interface AssignEntryPayload {
   group_round: number
 }
 
+export interface CopyWorkoutPayload {
+  date: string
+  name?: string
+}
+
 interface PaginatedResponse {
   items: WorkoutListItem[]
   nextPage: number | null
@@ -146,5 +151,13 @@ export async function assignEntries(
   entries: AssignEntryPayload[]
 ): Promise<Workout> {
   const { data } = await api.post(`/workouts/${workoutId}/groups/${groupId}/entries`, { entries })
+  return toWorkout(data.data as RawWorkout)
+}
+
+export async function copyWorkout(
+  workoutId: string,
+  payload: CopyWorkoutPayload
+): Promise<Workout> {
+  const { data } = await api.post(`/workouts/${workoutId}/copy`, payload)
   return toWorkout(data.data as RawWorkout)
 }

--- a/resources/js/components/app/pickers.tsx
+++ b/resources/js/components/app/pickers.tsx
@@ -1,16 +1,17 @@
 import { useState, useEffect } from 'react'
 import { useQuery, useMutation } from '@tanstack/react-query'
-import { Search, Plus, ChevronRight, ChevronLeft, Grid } from 'lucide-react'
-import type { Exercise, EquipmentType } from '@/api/types'
+import { Search, Plus, ChevronRight, ChevronLeft, Grid, Copy } from 'lucide-react'
+import type { Exercise, EquipmentType, WorkoutListItem } from '@/api/types'
 import { listExercises } from '@/api/exercises'
 import { listEquipment } from '@/api/equipment'
 import { listTemplates, cloneTemplate } from '@/api/templates'
+import { listWorkouts, copyWorkout } from '@/api/workouts'
 import { Sheet } from '@/components/ui/sheet'
 import { Button } from '@/components/ui/button'
 import { TypeBadge } from '@/components/ui/type-badge'
 import { SegmentedControl } from '@/components/ui/segmented-control'
 import { cn } from '@/lib/utils'
-import { todayISO } from '@/lib/formatters'
+import { todayISO, formatDate } from '@/lib/formatters'
 
 function equipmentLabel(equipment: EquipmentType[], equipmentTypeId: string | null): string {
   if (!equipmentTypeId) return 'No equipment'
@@ -99,6 +100,7 @@ interface NewWorkoutWizardProps {
   onClose: () => void
   onCreateEmpty: (config: { name: string; date: string }) => void
   onCloneSuccess?: (workoutId: string) => void
+  onCopySuccess?: (workoutId: string) => void
 }
 
 export function NewWorkoutWizard({
@@ -106,17 +108,25 @@ export function NewWorkoutWizard({
   onClose,
   onCreateEmpty,
   onCloneSuccess,
+  onCopySuccess,
 }: NewWorkoutWizardProps) {
-  const [step, setStep] = useState<'method' | 'details' | 'template-picker' | 'template-date'>(
-    'method'
-  )
+  const [step, setStep] = useState<
+    'method' | 'details' | 'template-picker' | 'template-date' | 'workout-picker' | 'workout-date'
+  >('method')
   const [name, setName] = useState('')
   const [date, setDate] = useState(todayISO())
   const [selectedTemplate, setSelectedTemplate] = useState<string | null>(null)
+  const [selectedWorkout, setSelectedWorkout] = useState<WorkoutListItem | null>(null)
 
   const { data: templates = [] } = useQuery({
     queryKey: ['templates'],
     queryFn: listTemplates,
+  })
+
+  const { data: recentWorkouts } = useQuery({
+    queryKey: ['workouts', 'picker'],
+    queryFn: () => listWorkouts(1),
+    enabled: step === 'workout-picker',
   })
 
   const cloneMutation = useMutation({
@@ -128,12 +138,22 @@ export function NewWorkoutWizard({
     },
   })
 
+  const copyMutation = useMutation({
+    mutationFn: (payload: { workoutId: string; date: string; name?: string }) =>
+      copyWorkout(payload.workoutId, { date: payload.date, name: payload.name }),
+    onSuccess: workout => {
+      onClose()
+      onCopySuccess?.(workout.id)
+    },
+  })
+
   useEffect(() => {
     if (open) {
       setStep('method')
       setName('')
       setDate(todayISO())
       setSelectedTemplate(null)
+      setSelectedWorkout(null)
     }
   }, [open])
 
@@ -142,7 +162,9 @@ export function NewWorkoutWizard({
       ? 'New Workout'
       : step === 'template-picker'
         ? 'Choose Template'
-        : 'Workout Details'
+        : step === 'workout-picker'
+          ? 'Copy Previous Workout'
+          : 'Workout Details'
 
   const back =
     step === 'details'
@@ -151,7 +173,11 @@ export function NewWorkoutWizard({
         ? () => setStep('method')
         : step === 'template-date'
           ? () => setStep('template-picker')
-          : null
+          : step === 'workout-picker'
+            ? () => setStep('method')
+            : step === 'workout-date'
+              ? () => setStep('workout-picker')
+              : null
 
   const chooseScratch = () => {
     setName('')
@@ -183,6 +209,22 @@ export function NewWorkoutWizard({
         }}
       >
         {cloneMutation.isPending ? 'Creating...' : 'Start Workout'}
+      </Button>
+    ) : step === 'workout-date' ? (
+      <Button
+        full
+        disabled={copyMutation.isPending}
+        onClick={() => {
+          if (selectedWorkout) {
+            copyMutation.mutate({
+              workoutId: selectedWorkout.id,
+              date,
+              name: name.trim() || undefined,
+            })
+          }
+        }}
+      >
+        {copyMutation.isPending ? 'Copying...' : 'Start Workout'}
       </Button>
     ) : null
 
@@ -257,11 +299,10 @@ export function NewWorkoutWizard({
             disabled={templates.length === 0}
           />
           <MethodButton
-            icon={<Grid size={20} />}
+            icon={<Copy size={20} />}
             label="Copy a previous workout"
             sub="Repeat a past session"
-            disabled
-            badge="Coming Soon"
+            onClick={() => setStep('workout-picker')}
           />
         </div>
       )}
@@ -317,6 +358,67 @@ export function NewWorkoutWizard({
             </label>
             <input
               id="clone-date"
+              type="date"
+              value={date}
+              onChange={e => setDate(e.target.value)}
+              className="ps-input w-full px-3 py-2.5 text-sm"
+            />
+          </div>
+        </div>
+      )}
+
+      {step === 'workout-picker' && (
+        <div className="flex flex-col gap-2">
+          {(recentWorkouts?.items ?? []).map(w => (
+            <button
+              key={w.id}
+              onClick={() => {
+                setSelectedWorkout(w)
+                setName('')
+                setDate(todayISO())
+                setStep('workout-date')
+              }}
+              className="ps-card w-full p-4 flex items-center gap-3 text-left min-h-[68px] hover:bg-surface-muted"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="font-semibold text-sm truncate">{w.name}</div>
+                <div className="text-[12px] text-text-secondary">
+                  {formatDate(w.date)} &middot; {w.exercises.length} exercise
+                  {w.exercises.length !== 1 ? 's' : ''}
+                </div>
+              </div>
+              <ChevronRight size={18} className="text-text-muted shrink-0" />
+            </button>
+          ))}
+          {!(recentWorkouts?.items ?? []).length && (
+            <p className="text-text-muted text-sm text-center py-6">No workouts yet.</p>
+          )}
+        </div>
+      )}
+
+      {step === 'workout-date' && (
+        <div className="flex flex-col gap-4">
+          <div>
+            <label htmlFor="copy-name" className="label-caps text-text-secondary block mb-1.5">
+              Workout name{' '}
+              <span className="normal-case tracking-normal text-text-muted">
+                (optional override)
+              </span>
+            </label>
+            <input
+              id="copy-name"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              placeholder="Use workout name"
+              className="ps-input w-full px-3 py-2.5 text-sm"
+            />
+          </div>
+          <div>
+            <label htmlFor="copy-date" className="label-caps text-text-secondary block mb-1.5">
+              Date
+            </label>
+            <input
+              id="copy-date"
               type="date"
               value={date}
               onChange={e => setDate(e.target.value)}

--- a/resources/js/pages/workouts.tsx
+++ b/resources/js/pages/workouts.tsx
@@ -210,6 +210,12 @@ export function WorkoutsPage() {
           toast('Workout started from template.')
           navigate(`/workouts/${workoutId}`)
         }}
+        onCopySuccess={workoutId => {
+          setWizardOpen(false)
+          queryClient.invalidateQueries({ queryKey: ['workouts'] })
+          toast('Workout copied.')
+          navigate(`/workouts/${workoutId}`)
+        }}
       />
 
       <Sheet

--- a/routes/api.php
+++ b/routes/api.php
@@ -14,6 +14,7 @@ use App\Http\Controllers\Api\V1\TemplateEntryGroupController;
 use App\Http\Controllers\Api\V1\TemplateExerciseController;
 use App\Http\Controllers\Api\V1\UserController;
 use App\Http\Controllers\Api\V1\WorkoutController;
+use App\Http\Controllers\Api\V1\WorkoutCopyController;
 use App\Http\Controllers\Api\V1\WorkoutEntryController;
 use App\Http\Controllers\Api\V1\WorkoutExerciseController;
 use App\Http\Controllers\Api\V1\WorkoutTemplateController;
@@ -45,6 +46,7 @@ Route::middleware('auth:api')->group(function () {
     Route::delete('templates/{template}/exercises/{exercise}', [TemplateExerciseController::class, 'detach']);
     Route::put('templates/{template}/exercises/reorder', [TemplateExerciseController::class, 'reorder']);
     Route::post('templates/{template}/clone', TemplateCloneController::class);
+    Route::post('workouts/{workout}/copy', WorkoutCopyController::class);
     Route::post('templates/{template}/groups', [TemplateEntryGroupController::class, 'store']);
     Route::delete('templates/{template}/groups/{group}', [TemplateEntryGroupController::class, 'destroy']);
     Route::post('templates/{template}/groups/{group}/exercises', [TemplateEntryGroupController::class, 'assignExercises']);

--- a/tests/Feature/Api/V1/WorkoutCopyTest.php
+++ b/tests/Feature/Api/V1/WorkoutCopyTest.php
@@ -1,0 +1,492 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Models\Exercise;
+use App\Models\User;
+use App\Models\Workout;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
+use Tests\TestCase;
+use App\Models\EntryGroup;
+use App\Models\LogIntervalHeader;
+
+class WorkoutCopyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createExercise(
+        ?User $user,
+        string $type = 'resistance',
+        array $overrides = [],
+    ): Exercise {
+        $exercise = Exercise::create(array_merge([
+            'name' => 'Test Exercise',
+            'type' => $type,
+            'user_id' => $user?->id,
+        ], $overrides));
+
+        $defaults = match ($type) {
+            'resistance' => [],
+            'timed_hold' => [],
+            'distance' => ['distance_unit' => 'meters'],
+            'interval' => [],
+            default => [],
+        };
+
+        $childRelation = match ($type) {
+            'resistance' => 'resistance',
+            'timed_hold' => 'timedHold',
+            'distance' => 'distance',
+            'interval' => 'interval',
+            default => 'resistance',
+        };
+
+        $exercise->$childRelation()->create($defaults);
+
+        return $exercise;
+    }
+
+    private function createWorkoutWithExercises(User $user, array $exercises): Workout
+    {
+        $workout = Workout::create([
+            'name' => 'Source Workout',
+            'user_id' => $user->id,
+            'date' => '2026-06-01',
+        ]);
+
+        foreach ($exercises as $i => $exercise) {
+            $workout->exercises()->attach($exercise->id, ['exercise_order' => $i]);
+            $workout->entries()->create([
+                'exercise_id' => $exercise->id,
+                'set_order' => $i,
+            ]);
+        }
+
+        return $workout;
+    }
+
+    public function test_copies_workout_with_new_date(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance', ['name' => 'Bench Press']);
+        $workout = $this->createWorkoutWithExercises($user, [$exercise]);
+
+        Passport::actingAs($user);
+
+        $response = $this->postJson("/api/v1/workouts/{$workout->id}/copy", [
+            'date' => '2026-07-01',
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.name', 'Source Workout')
+            ->assertJsonPath('data.date', '2026-07-01');
+
+        $this->assertDatabaseCount('workouts', 2);
+    }
+
+    public function test_copy_allows_name_override(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance');
+        $workout = $this->createWorkoutWithExercises($user, [$exercise]);
+
+        Passport::actingAs($user);
+
+        $response = $this->postJson("/api/v1/workouts/{$workout->id}/copy", [
+            'date' => '2026-07-01',
+            'name' => 'My Custom Name',
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.name', 'My Custom Name');
+    }
+
+    public function test_copy_preserves_exercise_order(): void
+    {
+        $user = User::factory()->create();
+        $ex1 = $this->createExercise($user, 'resistance', ['name' => 'Squat']);
+        $ex2 = $this->createExercise($user, 'timed_hold', ['name' => 'Plank']);
+        $workout = $this->createWorkoutWithExercises($user, [$ex1, $ex2]);
+
+        Passport::actingAs($user);
+
+        $response = $this->postJson("/api/v1/workouts/{$workout->id}/copy", [
+            'date' => '2026-07-01',
+        ]);
+
+        $copyId = $response->json('data.id');
+
+        $this->assertDatabaseHas('exercise_workout', [
+            'workout_id' => $copyId,
+            'exercise_id' => $ex1->id,
+            'exercise_order' => 0,
+        ]);
+        $this->assertDatabaseHas('exercise_workout', [
+            'workout_id' => $copyId,
+            'exercise_id' => $ex2->id,
+            'exercise_order' => 1,
+        ]);
+    }
+
+    public function test_copy_clones_entry_groups(): void
+    {
+        $user = User::factory()->create();
+        $ex1 = $this->createExercise($user, 'resistance', ['name' => 'Bench']);
+        $ex2 = $this->createExercise($user, 'resistance', ['name' => 'Row']);
+
+        $workout = Workout::create([
+            'name' => 'Superset Day',
+            'user_id' => $user->id,
+            'date' => '2026-06-01',
+        ]);
+
+        $group = $workout->groups()->create([
+            'name' => 'Push/Pull',
+            'planned_rounds' => 3,
+            'rest_between_exercises_seconds' => 30,
+            'rest_between_rounds_seconds' => 90,
+        ]);
+
+        $workout->exercises()->attach($ex1->id, ['exercise_order' => 0]);
+        $workout->exercises()->attach($ex2->id, ['exercise_order' => 1]);
+
+        $setOrder = 0;
+        for ($round = 1; $round <= 3; $round++) {
+            $workout->entries()->create([
+                'exercise_id' => $ex1->id,
+                'set_order' => $setOrder++,
+                'entry_group_id' => $group->id,
+                'group_round' => $round,
+            ]);
+            $workout->entries()->create([
+                'exercise_id' => $ex2->id,
+                'set_order' => $setOrder++,
+                'entry_group_id' => $group->id,
+                'group_round' => $round,
+            ]);
+        }
+
+        Passport::actingAs($user);
+
+        $response = $this->postJson("/api/v1/workouts/{$workout->id}/copy", [
+            'date' => '2026-07-01',
+        ]);
+
+        $response->assertStatus(201);
+        $copyId = $response->json('data.id');
+
+        $this->assertDatabaseHas('entry_groups', [
+            'workout_id' => $copyId,
+            'name' => 'Push/Pull',
+            'planned_rounds' => 3,
+            'rest_between_exercises_seconds' => 30,
+            'rest_between_rounds_seconds' => 90,
+        ]);
+
+        $copyGroupId = EntryGroup::where('workout_id', $copyId)->first()->id;
+
+        $this->assertDatabaseCount('workout_entries', 12);
+        $this->assertDatabaseHas('workout_entries', [
+            'workout_id' => $copyId,
+            'exercise_id' => $ex1->id,
+            'entry_group_id' => $copyGroupId,
+            'group_round' => 1,
+        ]);
+    }
+
+    public function test_copy_clones_metric_targets_and_nulls_actuals(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance', ['name' => 'Squat']);
+
+        $workout = Workout::create([
+            'name' => 'Leg Day',
+            'user_id' => $user->id,
+            'date' => '2026-06-01',
+        ]);
+
+        $workout->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+        $entry = $workout->entries()->create([
+            'exercise_id' => $exercise->id,
+            'set_order' => 0,
+        ]);
+
+        $entry->loadMetric()->create([
+            'target_weight' => 225.00,
+            'actual_weight' => 225.00,
+            'bodyweight_only' => false,
+        ]);
+        $entry->repMetric()->create([
+            'target_reps' => 5,
+            'actual_reps' => 4,
+            'to_failure' => false,
+            'failure_rep' => 4,
+        ]);
+
+        Passport::actingAs($user);
+
+        $response = $this->postJson("/api/v1/workouts/{$workout->id}/copy", [
+            'date' => '2026-07-01',
+        ]);
+
+        $response->assertStatus(201);
+
+        $copyEntryId = $response->json('data.entries.0.id');
+
+        $this->assertDatabaseHas('log_load_metrics', [
+            'entry_id' => $copyEntryId,
+            'target_weight' => 225.00,
+            'actual_weight' => null,
+            'bodyweight_only' => false,
+        ]);
+        $this->assertDatabaseHas('log_rep_metrics', [
+            'entry_id' => $copyEntryId,
+            'target_reps' => 5,
+            'actual_reps' => null,
+            'to_failure' => false,
+            'failure_rep' => null,
+        ]);
+    }
+
+    public function test_copy_clones_cardio_settings(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'distance', ['name' => 'Treadmill Run']);
+
+        $workout = Workout::create([
+            'name' => 'Cardio Day',
+            'user_id' => $user->id,
+            'date' => '2026-06-01',
+        ]);
+
+        $workout->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+        $entry = $workout->entries()->create([
+            'exercise_id' => $exercise->id,
+            'set_order' => 0,
+        ]);
+
+        $entry->cardioSetting()->create([
+            'resistance_level' => 5,
+            'incline' => 2.5,
+            'speed' => 6.0,
+            'cadence' => 170,
+        ]);
+
+        Passport::actingAs($user);
+
+        $response = $this->postJson("/api/v1/workouts/{$workout->id}/copy", [
+            'date' => '2026-07-01',
+        ]);
+
+        $copyEntryId = $response->json('data.entries.0.id');
+
+        $this->assertDatabaseHas('log_cardio_settings', [
+            'entry_id' => $copyEntryId,
+            'resistance_level' => 5,
+            'incline' => 2.5,
+            'speed' => 6.0,
+            'cadence' => 170,
+        ]);
+    }
+
+    public function test_copy_clones_interval_header_without_rounds(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'interval', ['name' => 'HIIT Sprint']);
+
+        $workout = Workout::create([
+            'name' => 'Interval Day',
+            'user_id' => $user->id,
+            'date' => '2026-06-01',
+        ]);
+
+        $workout->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+        $entry = $workout->entries()->create([
+            'exercise_id' => $exercise->id,
+            'set_order' => 0,
+        ]);
+
+        $header = $entry->intervalHeader()->create([
+            'programmed_rounds' => 8,
+            'completed_rounds' => 8,
+            'target_work_seconds' => 30,
+            'target_rest_seconds' => 60,
+        ]);
+        $header->rounds()->create([
+            'round_number' => 1,
+            'actual_work_seconds' => 32,
+            'actual_rest_seconds' => 58,
+        ]);
+
+        Passport::actingAs($user);
+
+        $response = $this->postJson("/api/v1/workouts/{$workout->id}/copy", [
+            'date' => '2026-07-01',
+        ]);
+
+        $copyEntryId = $response->json('data.entries.0.id');
+
+        $this->assertDatabaseHas('log_interval_headers', [
+            'entry_id' => $copyEntryId,
+            'programmed_rounds' => 8,
+            'completed_rounds' => null,
+            'target_work_seconds' => 30,
+            'target_rest_seconds' => 60,
+        ]);
+
+        $copyHeaderId = LogIntervalHeader::where('entry_id', $copyEntryId)->first()->id;
+        $this->assertDatabaseMissing('log_interval_rounds', [
+            'interval_header_id' => $copyHeaderId,
+        ]);
+    }
+
+    public function test_copy_skips_intensity_metrics(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance', ['name' => 'Deadlift']);
+
+        $workout = Workout::create([
+            'name' => 'Heavy Day',
+            'user_id' => $user->id,
+            'date' => '2026-06-01',
+        ]);
+
+        $workout->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+        $entry = $workout->entries()->create([
+            'exercise_id' => $exercise->id,
+            'set_order' => 0,
+        ]);
+
+        $entry->intensityMetric()->create([
+            'rpe' => 9,
+            'avg_hr' => 155,
+            'max_hr' => 178,
+        ]);
+
+        Passport::actingAs($user);
+
+        $response = $this->postJson("/api/v1/workouts/{$workout->id}/copy", [
+            'date' => '2026-07-01',
+        ]);
+
+        $copyEntryId = $response->json('data.entries.0.id');
+
+        $this->assertDatabaseMissing('log_intensity_metrics', [
+            'entry_id' => $copyEntryId,
+        ]);
+    }
+
+    public function test_copy_preserves_entry_notes(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance', ['name' => 'Bench']);
+
+        $workout = Workout::create([
+            'name' => 'Push Day',
+            'user_id' => $user->id,
+            'date' => '2026-06-01',
+        ]);
+
+        $workout->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+        $workout->entries()->create([
+            'exercise_id' => $exercise->id,
+            'set_order' => 0,
+            'notes' => 'Use fat grip attachment',
+        ]);
+
+        Passport::actingAs($user);
+
+        $response = $this->postJson("/api/v1/workouts/{$workout->id}/copy", [
+            'date' => '2026-07-01',
+        ]);
+
+        $copyId = $response->json('data.id');
+
+        $this->assertDatabaseHas('workout_entries', [
+            'workout_id' => $copyId,
+            'notes' => 'Use fat grip attachment',
+        ]);
+    }
+
+    public function test_copy_does_not_carry_exhaustion_or_soreness(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance');
+
+        $workout = Workout::create([
+            'name' => 'Hard Session',
+            'user_id' => $user->id,
+            'date' => '2026-06-01',
+            'exhaustion' => 8,
+            'soreness' => 6,
+        ]);
+
+        $workout->exercises()->attach($exercise->id, ['exercise_order' => 0]);
+        $workout->entries()->create([
+            'exercise_id' => $exercise->id,
+            'set_order' => 0,
+        ]);
+
+        Passport::actingAs($user);
+
+        $response = $this->postJson("/api/v1/workouts/{$workout->id}/copy", [
+            'date' => '2026-07-01',
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.exhaustion', null)
+            ->assertJsonPath('data.soreness', null);
+    }
+
+    public function test_copied_workout_is_independent_of_source(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance');
+        $workout = $this->createWorkoutWithExercises($user, [$exercise]);
+
+        Passport::actingAs($user);
+
+        $response = $this->postJson("/api/v1/workouts/{$workout->id}/copy", [
+            'date' => '2026-07-01',
+        ]);
+
+        $copyId = $response->json('data.id');
+
+        $this->deleteJson("/api/v1/workouts/{$workout->id}")
+            ->assertNoContent();
+
+        $this->assertDatabaseHas('workouts', ['id' => $copyId]);
+        $this->assertDatabaseHas('exercise_workout', ['workout_id' => $copyId]);
+        $this->assertDatabaseHas('workout_entries', ['workout_id' => $copyId]);
+    }
+
+    public function test_cannot_copy_another_users_workout(): void
+    {
+        $owner = User::factory()->create();
+        $other = User::factory()->create();
+        $exercise = $this->createExercise($owner, 'resistance');
+        $workout = $this->createWorkoutWithExercises($owner, [$exercise]);
+
+        Passport::actingAs($other);
+
+        $this->postJson("/api/v1/workouts/{$workout->id}/copy", [
+            'date' => '2026-07-01',
+        ])->assertStatus(403);
+    }
+
+    public function test_copy_validates_date_required(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance');
+        $workout = $this->createWorkoutWithExercises($user, [$exercise]);
+
+        Passport::actingAs($user);
+
+        $this->postJson("/api/v1/workouts/{$workout->id}/copy", [])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['date']);
+    }
+}


### PR DESCRIPTION
## Problem

The "Copy a previous workout" button in the New Workout wizard was disabled with a "Coming Soon" badge. Users had no way to repeat a past workout without manually recreating it or relying on a template.

## Solution

Added `POST /workouts/{workout}/copy` endpoint via `WorkoutCopyController`. The controller clones the workout structure in a transaction: entry groups (with rest/round settings), exercise pivot records (preserving order), entries (with group mapping and notes), and metric targets. Actuals are nulled so the user fills them in during the new session. Intensity metrics and interval rounds are skipped since they are purely actual data. Cardio settings are copied in full.

On the frontend, enabled the wizard button and added two new steps: a workout picker showing recent history, and a date/name form mirroring the existing template-date step. The `copyWorkout` API function and `onCopySuccess` callback wire through to the workouts page with cache invalidation and navigation.

13 feature tests cover the copy behavior: structure cloning, metric target/actual handling, group mapping, notes, auth, validation, and source independence.
