### PR TITLE
PS-79 - Adding templates index page and replacing emoji with icon components

### DIFF
--- a/resources/js/app-root.tsx
+++ b/resources/js/app-root.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/pages/auth'
 import { WorkoutsPage } from '@/pages/workouts'
 import { WorkoutDetailPage } from '@/pages/workout-detail'
+import { TemplatesPage } from '@/pages/templates'
 import { TemplateEditorPage } from '@/pages/template-editor'
 import { ExercisesPage } from '@/pages/exercises'
 import { ExerciseDetailPage } from '@/pages/exercise-detail'
@@ -75,6 +76,7 @@ export function AppRoot() {
               >
                 <Route path="workouts" element={<WorkoutsPage />} />
                 <Route path="workouts/:id" element={<WorkoutDetailPage />} />
+                <Route path="templates" element={<TemplatesPage />} />
                 <Route path="templates/:id" element={<TemplateEditorPage />} />
                 <Route path="exercises" element={<ExercisesPage />} />
                 <Route path="exercises/:id" element={<ExerciseDetailPage />} />

--- a/resources/js/pages/template-editor.tsx
+++ b/resources/js/pages/template-editor.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { Trash2, Plus } from 'lucide-react'
+import { Trash2, Plus, Route, Check } from 'lucide-react'
 import type { WorkoutTemplate, TemplateExercise, TemplateEntryGroup } from '@/api/types'
 import {
   getTemplate,
@@ -256,7 +256,7 @@ export function TemplateEditorPage() {
           <Button
             size="sm"
             variant="secondary"
-            icon={<span>⊕</span>}
+            icon={<Route size={16} />}
             onClick={() => setSelectMode(true)}
           >
             Make a Superset
@@ -280,12 +280,14 @@ export function TemplateEditorPage() {
                 color: 'var(--color-primary)',
               }}
             >
-              ✓
+              <Check size={18} />
             </span>
             <div className="flex-1 min-w-0">
               <div className="font-semibold text-sm">Build a superset or circuit</div>
               <div className="text-[13px] text-text-secondary mt-0.5">
-                Tap 2 or more exercises to group them.
+                {
+                  "Tap 2 or more exercises below to combine them. You'll set rounds and rest in the next step."
+                }
               </div>
             </div>
           </div>
@@ -352,7 +354,7 @@ export function TemplateEditorPage() {
                       </div>
                       <button
                         onClick={() => ungroup(block)}
-                        className="text-[12px] font-semibold text-text-secondary hover:text-destructive px-2 h-8 rounded-lg hover:bg-surface-muted"
+                        className="text-[12px] font-semibold text-text-secondary hover:text-destructive px-2 h-9 rounded-lg hover:bg-surface-muted"
                       >
                         Ungroup
                       </button>
@@ -410,7 +412,7 @@ export function TemplateEditorPage() {
                           : { borderColor: 'var(--color-border-strong)' }
                       }
                     >
-                      {isSelected && '✓'}
+                      {isSelected && <Check size={16} />}
                     </span>
                     <div className="min-w-0 flex-1">
                       <div className="font-semibold text-sm truncate">{te.name}</div>

--- a/resources/js/pages/templates.tsx
+++ b/resources/js/pages/templates.tsx
@@ -1,0 +1,173 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { Plus, Trash2, Layers } from 'lucide-react'
+import type { WorkoutTemplateListItem } from '@/api/types'
+import { listTemplates, createTemplate, deleteTemplate } from '@/api/templates'
+import { useApp } from '@/lib/use-app'
+import { PageHeader, EmptyState, Button, Card, Sheet, ConfirmDialog } from '@/components/ui'
+
+export function TemplatesPage() {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const { toast } = useApp()
+
+  const [createOpen, setCreateOpen] = useState(false)
+  const [name, setName] = useState('')
+  const [deleting, setDeleting] = useState<WorkoutTemplateListItem | null>(null)
+
+  const { data: templates = [], isLoading } = useQuery({
+    queryKey: ['templates'],
+    queryFn: listTemplates,
+  })
+
+  const createMutation = useMutation({
+    mutationFn: (n: string) => createTemplate({ name: n }),
+    onSuccess: tpl => {
+      queryClient.invalidateQueries({ queryKey: ['templates'] })
+      setCreateOpen(false)
+      setName('')
+      toast('Template created.')
+      navigate(`/templates/${tpl.id}`)
+    },
+    onError: () => toast('Could not create template. Try again.'),
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteTemplate,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['templates'] })
+      toast('Template deleted.')
+    },
+    onError: () => toast('Could not delete template. Try again.'),
+  })
+
+  if (isLoading) {
+    return (
+      <>
+        <PageHeader title="Templates" back onBack={() => navigate('/workouts')} />
+        <p className="text-text-secondary text-sm">Loading...</p>
+      </>
+    )
+  }
+
+  return (
+    <div dusk="templates-page">
+      <PageHeader
+        title="Templates"
+        subtitle={`${templates.length} saved`}
+        back
+        onBack={() => navigate('/workouts')}
+        actions={
+          <Button
+            size="sm"
+            icon={<Plus size={16} />}
+            onClick={() => setCreateOpen(true)}
+            dusk="create-template-btn"
+          >
+            Create
+          </Button>
+        }
+      />
+
+      {templates.length ? (
+        <div className="flex flex-col gap-2.5" dusk="template-list">
+          {templates.map(tpl => (
+            <Card
+              key={tpl.id}
+              className="p-4 flex items-center gap-3 cursor-pointer"
+              onClick={() => navigate(`/templates/${tpl.id}`)}
+            >
+              <span
+                className="h-9 w-9 rounded-lg flex items-center justify-center shrink-0"
+                style={{
+                  background: 'color-mix(in srgb, var(--color-primary) 12%, transparent)',
+                  color: 'var(--color-primary)',
+                }}
+              >
+                <Layers size={18} />
+              </span>
+              <div className="min-w-0 flex-1">
+                <div className="font-semibold text-sm truncate">{tpl.name}</div>
+                <div className="text-[12px] text-text-secondary">
+                  {tpl.exercises.length} exercise{tpl.exercises.length !== 1 ? 's' : ''}
+                </div>
+              </div>
+              <button
+                onClick={e => {
+                  e.stopPropagation()
+                  setDeleting(tpl)
+                }}
+                aria-label={`Delete ${tpl.name}`}
+                title="Delete template"
+                dusk="delete-template-btn"
+                className="h-10 w-10 flex items-center justify-center rounded-lg shrink-0 text-text-muted hover:text-destructive hover:bg-surface-muted"
+              >
+                <Trash2 size={17} />
+              </button>
+            </Card>
+          ))}
+        </div>
+      ) : (
+        <EmptyState
+          title="No templates yet"
+          action={
+            <Button onClick={() => setCreateOpen(true)} icon={<Plus size={18} />}>
+              Create Template
+            </Button>
+          }
+        >
+          Save a routine once and start future workouts from it.
+        </EmptyState>
+      )}
+
+      <Sheet
+        open={createOpen}
+        onClose={() => {
+          setCreateOpen(false)
+          setName('')
+        }}
+        title="Create Template"
+        footer={
+          <Button
+            full
+            disabled={!name.trim() || createMutation.isPending}
+            onClick={() => createMutation.mutate(name.trim())}
+            dusk="submit-template-btn"
+          >
+            {createMutation.isPending ? 'Creating...' : 'Create'}
+          </Button>
+        }
+      >
+        <div>
+          <label
+            htmlFor="template-name-input"
+            className="label-caps text-text-secondary block mb-1.5"
+          >
+            Template name
+          </label>
+          <input
+            id="template-name-input"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            placeholder="e.g. Push Day"
+            className="ps-input w-full px-3 py-2.5 text-sm"
+          />
+        </div>
+      </Sheet>
+
+      <ConfirmDialog
+        open={!!deleting}
+        title="Delete template?"
+        message={deleting ? `"${deleting.name}" will be removed from your templates.` : ''}
+        onCancel={() => setDeleting(null)}
+        onConfirm={() => {
+          if (deleting) {
+            deleteMutation.mutate(deleting.id)
+            setDeleting(null)
+          }
+        }}
+      />
+    </div>
+  )
+}

--- a/resources/js/pages/workout-detail.tsx
+++ b/resources/js/pages/workout-detail.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient, useQueries } from '@tanstack/react-query'
-import { Trash2, Flame, Target, Plus } from 'lucide-react'
+import { Trash2, Flame, Target, Plus, Calendar, Route, Check } from 'lucide-react'
 import type { WorkoutEntry, EntryGroup, Exercise, EquipmentType, Workout } from '@/api/types'
 import { listExercises } from '@/api/exercises'
 import { listEquipment } from '@/api/equipment'
@@ -584,7 +584,7 @@ export function WorkoutDetailPage() {
       <div className="ps-card p-4 mb-5">
         <div className="flex items-center justify-between mb-3">
           <label className="flex items-center gap-2 text-sm text-text-secondary">
-            <span>📅</span>
+            <Calendar size={16} />
             <input
               type="date"
               value={workout.date}
@@ -618,7 +618,7 @@ export function WorkoutDetailPage() {
           <Button
             size="sm"
             variant="secondary"
-            icon={<span>⊕</span>}
+            icon={<Route size={16} />}
             onClick={() => setSelectMode(true)}
           >
             Make a Superset
@@ -642,13 +642,14 @@ export function WorkoutDetailPage() {
                 color: 'var(--color-primary)',
               }}
             >
-              ✓
+              <Check size={18} />
             </span>
             <div className="flex-1 min-w-0">
               <div className="font-semibold text-sm">Build a superset or circuit</div>
               <div className="text-[13px] text-text-secondary mt-0.5">
-                Tap 2 or more exercises below to combine them. You will set rounds and rest in the
-                next step.
+                {
+                  "Tap 2 or more exercises below to combine them. You'll set rounds and rest in the next step."
+                }
               </div>
             </div>
           </div>
@@ -730,7 +731,7 @@ export function WorkoutDetailPage() {
                       {block.gid && (
                         <button
                           onClick={() => ungroupMutation.mutate(block.gid as string)}
-                          className="text-[12px] font-semibold text-text-secondary hover:text-destructive px-2 h-8 rounded-lg hover:bg-surface-muted"
+                          className="text-[12px] font-semibold text-text-secondary hover:text-destructive px-2 h-9 rounded-lg hover:bg-surface-muted"
                         >
                           Ungroup
                         </button>
@@ -747,7 +748,7 @@ export function WorkoutDetailPage() {
                               style={{ background: 'var(--color-border)' }}
                             />
                             {completed.includes(r) && (
-                              <span style={{ color: 'var(--color-success)' }}>✓</span>
+                              <Check size={14} style={{ color: 'var(--color-success)' }} />
                             )}
                           </div>
                           <div className="flex flex-col gap-3">
@@ -813,7 +814,7 @@ export function WorkoutDetailPage() {
                           : { borderColor: 'var(--color-border-strong)' }
                       }
                     >
-                      {isSelected && '✓'}
+                      {isSelected && <Check size={16} />}
                     </span>
                     <div className="min-w-0 flex-1">
                       <div className="font-semibold text-base truncate">{ex.name}</div>

--- a/resources/js/pages/workouts.tsx
+++ b/resources/js/pages/workouts.tsx
@@ -1,10 +1,9 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { Plus, BarChart3, Layers } from 'lucide-react'
+import { useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { Plus, BarChart3, Layers, Check } from 'lucide-react'
 import type { WorkoutListItem } from '@/api/types'
 import { listWorkouts, createWorkout } from '@/api/workouts'
-import { listTemplates, createTemplate } from '@/api/templates'
 import { useApp } from '@/lib/use-app'
 import { formatDate } from '@/lib/formatters'
 import {
@@ -14,7 +13,6 @@ import {
   CompletionBar,
   Button,
   Card,
-  Sheet,
 } from '@/components/ui'
 import { NewWorkoutWizard } from '@/components/app/pickers'
 
@@ -40,7 +38,7 @@ function WorkoutCard({ workout }: { workout: WorkoutListItem }) {
               className="inline-flex items-center gap-1 text-[11px] font-semibold"
               style={{ color: 'var(--color-success)' }}
             >
-              ✓ Complete
+              <Check size={13} /> Complete
             </span>
           ) : (
             <span className="text-[11px] font-semibold text-text-muted">
@@ -65,19 +63,12 @@ export function WorkoutsPage() {
   const { toast } = useApp()
 
   const [wizardOpen, setWizardOpen] = useState(false)
-  const [templateSheetOpen, setTemplateSheetOpen] = useState(false)
-  const [templateName, setTemplateName] = useState('')
 
   const { data, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } = useInfiniteQuery({
     queryKey: ['workouts'],
     queryFn: ({ pageParam }) => listWorkouts(pageParam),
     getNextPageParam: last => last.nextPage,
     initialPageParam: 1,
-  })
-
-  const { data: templates = [] } = useQuery({
-    queryKey: ['templates'],
-    queryFn: listTemplates,
   })
 
   const workouts = data?.pages?.flatMap(p => p.items) ?? []
@@ -91,18 +82,6 @@ export function WorkoutsPage() {
       navigate(`/workouts/${workout.id}`)
     },
     onError: () => toast('Could not create workout. Try again.'),
-  })
-
-  const createTemplateMutation = useMutation({
-    mutationFn: (name: string) => createTemplate({ name }),
-    onSuccess: tpl => {
-      queryClient.invalidateQueries({ queryKey: ['templates'] })
-      setTemplateSheetOpen(false)
-      setTemplateName('')
-      toast('Template created.')
-      navigate(`/templates/${tpl.id}`)
-    },
-    onError: () => toast('Could not create template. Try again.'),
   })
 
   const startEmpty = ({ name, date }: { name: string; date: string }) => {
@@ -144,33 +123,12 @@ export function WorkoutsPage() {
           full
           variant="secondary"
           icon={<Layers size={18} />}
-          onClick={() => setTemplateSheetOpen(true)}
+          onClick={() => navigate('/templates')}
+          dusk="templates-link"
         >
-          Create Template
+          Templates
         </Button>
       </div>
-
-      {templates.length > 0 && (
-        <section className="mb-7" dusk="template-section">
-          <SectionHeading>Templates</SectionHeading>
-          <div className="flex gap-3 overflow-x-auto pb-2 no-scrollbar">
-            {templates.map(tpl => (
-              <Card
-                key={tpl.id}
-                onClick={() => navigate(`/templates/${tpl.id}`)}
-                className="flex-shrink-0 w-40 cursor-pointer"
-              >
-                <div className="p-3">
-                  <div className="font-semibold text-sm truncate">{tpl.name}</div>
-                  <div className="text-[12px] text-text-secondary">
-                    {tpl.exercises.length} exercise{tpl.exercises.length !== 1 ? 's' : ''}
-                  </div>
-                </div>
-              </Card>
-            ))}
-          </div>
-        </section>
-      )}
 
       <section>
         <SectionHeading>History</SectionHeading>
@@ -225,40 +183,6 @@ export function WorkoutsPage() {
           navigate(`/workouts/${workoutId}`)
         }}
       />
-
-      <Sheet
-        open={templateSheetOpen}
-        onClose={() => {
-          setTemplateSheetOpen(false)
-          setTemplateName('')
-        }}
-        title="Create Template"
-        footer={
-          <Button
-            full
-            disabled={!templateName.trim() || createTemplateMutation.isPending}
-            onClick={() => createTemplateMutation.mutate(templateName.trim())}
-          >
-            {createTemplateMutation.isPending ? 'Creating...' : 'Create'}
-          </Button>
-        }
-      >
-        <div>
-          <label
-            htmlFor="template-name-input"
-            className="label-caps text-text-secondary block mb-1.5"
-          >
-            Template name
-          </label>
-          <input
-            id="template-name-input"
-            value={templateName}
-            onChange={e => setTemplateName(e.target.value)}
-            placeholder="e.g. Push Day"
-            className="ps-input w-full px-3 py-2.5 text-sm"
-          />
-        </div>
-      </Sheet>
     </div>
   )
 }

--- a/tests/Browser/TemplatesPageTest.php
+++ b/tests/Browser/TemplatesPageTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Models\WorkoutTemplate;
+use Laravel\Dusk\Browser;
+
+it('shows the empty state when the user has no templates', function () {
+    $user = User::factory()->create();
+
+    $this->browse(function (Browser $browser) use ($user) {
+        $this->loginAs($browser, $user);
+        $browser->visit('/templates')
+            ->waitFor('@templates-page')
+            ->assertSee('No templates yet')
+            ->screenshot('templates-empty');
+    });
+});
+
+it('lists the user templates', function () {
+    $user = User::factory()->create();
+    WorkoutTemplate::factory()->create(['user_id' => $user->id, 'name' => 'Push Day']);
+    WorkoutTemplate::factory()->create(['user_id' => $user->id, 'name' => 'Pull Day']);
+
+    $this->browse(function (Browser $browser) use ($user) {
+        $this->loginAs($browser, $user);
+        $browser->visit('/templates')
+            ->waitFor('@template-list')
+            ->assertSee('Push Day')
+            ->assertSee('Pull Day')
+            ->screenshot('templates-list');
+    });
+});
+
+it('navigates to the editor when a template is tapped', function () {
+    $user = User::factory()->create();
+    $template = WorkoutTemplate::factory()->create(['user_id' => $user->id, 'name' => 'Leg Day']);
+
+    $this->browse(function (Browser $browser) use ($user, $template) {
+        $this->loginAs($browser, $user);
+        $browser->visit('/templates')
+            ->waitFor('@template-list')
+            ->click('@template-list .cursor-pointer:first-child')
+            ->waitForLocation("/templates/{$template->id}")
+            ->assertPathIs("/templates/{$template->id}");
+    });
+});
+
+it('creates a template and opens the editor', function () {
+    $user = User::factory()->create();
+
+    $this->browse(function (Browser $browser) use ($user) {
+        $this->loginAs($browser, $user);
+        $browser->visit('/templates')
+            ->waitFor('@templates-page')
+            ->click('@create-template-btn')
+            ->waitFor('#template-name-input')
+            ->type('#template-name-input', 'Conditioning')
+            ->click('@submit-template-btn')
+            ->waitFor('@template-editor-page')
+            ->assertPathBeginsWith('/templates/');
+    });
+
+    $this->assertDatabaseHas('workout_templates', [
+        'user_id' => $user->id,
+        'name' => 'Conditioning',
+    ]);
+});
+
+it('deletes a template after confirmation', function () {
+    $user = User::factory()->create();
+    $template = WorkoutTemplate::factory()->create(['user_id' => $user->id, 'name' => 'Retired Day']);
+
+    $this->browse(function (Browser $browser) use ($user) {
+        $this->loginAs($browser, $user);
+        $browser->visit('/templates')
+            ->waitFor('@template-list')
+            ->click('@delete-template-btn')
+            ->waitForText('Delete template?')
+            ->press('Delete')
+            ->waitUntilMissing('@template-list')
+            ->assertSee('No templates yet');
+    });
+
+    $this->assertDatabaseMissing('workout_templates', [
+        'id' => $template->id,
+    ]);
+});
+
+it('returns to the workouts page via the back button', function () {
+    $user = User::factory()->create();
+
+    $this->browse(function (Browser $browser) use ($user) {
+        $this->loginAs($browser, $user);
+        $browser->visit('/templates')
+            ->waitFor('@templates-page')
+            ->click('@back')
+            ->waitForLocation('/workouts')
+            ->assertPathIs('/workouts');
+    });
+});

--- a/tests/Browser/WorkoutsPageTest.php
+++ b/tests/Browser/WorkoutsPageTest.php
@@ -140,19 +140,32 @@ it('has view progress button', function () {
     });
 });
 
-it('has create template button', function () {
+it('has a templates button', function () {
     $user = User::factory()->create();
 
     $this->browse(function (Browser $browser) use ($user) {
         $this->loginAs($browser, $user);
         $browser->visit('/workouts')
             ->waitFor('@workouts-page')
-            ->assertSee('Create Template')
-            ->screenshot('workouts-create-template-btn');
+            ->assertSee('Templates')
+            ->screenshot('workouts-templates-btn');
     });
 });
 
-it('shows templates section when templates exist', function () {
+it('navigates to the templates page from the templates button', function () {
+    $user = User::factory()->create();
+
+    $this->browse(function (Browser $browser) use ($user) {
+        $this->loginAs($browser, $user);
+        $browser->visit('/workouts')
+            ->waitFor('@workouts-page')
+            ->click('@templates-link')
+            ->waitForLocation('/templates')
+            ->assertPathIs('/templates');
+    });
+});
+
+it('does not list templates on the workouts page', function () {
     $user = User::factory()->create();
     WorkoutTemplate::factory()->create([
         'user_id' => $user->id,
@@ -162,43 +175,10 @@ it('shows templates section when templates exist', function () {
     $this->browse(function (Browser $browser) use ($user) {
         $this->loginAs($browser, $user);
         $browser->visit('/workouts')
-            ->waitFor('@template-section')
-            ->assertSee('Templates')
-            ->assertSee('Upper Body')
-            ->screenshot('workouts-templates-section');
-    });
-});
-
-it('hides templates section when no templates exist', function () {
-    $user = User::factory()->create();
-
-    $this->browse(function (Browser $browser) use ($user) {
-        $this->loginAs($browser, $user);
-        $browser->visit('/workouts')
             ->waitFor('@workouts-page')
             ->assertMissing('@template-section')
-            ->screenshot('workouts-no-templates');
-    });
-});
-
-it('displays multiple templates in carousel', function () {
-    $user = User::factory()->create();
-    WorkoutTemplate::factory()->create([
-        'user_id' => $user->id,
-        'name' => 'Push Day',
-    ]);
-    WorkoutTemplate::factory()->create([
-        'user_id' => $user->id,
-        'name' => 'Pull Day',
-    ]);
-
-    $this->browse(function (Browser $browser) use ($user) {
-        $this->loginAs($browser, $user);
-        $browser->visit('/workouts')
-            ->waitFor('@template-section')
-            ->assertSee('Push Day')
-            ->assertSee('Pull Day')
-            ->screenshot('workouts-multiple-templates');
+            ->assertDontSee('Upper Body')
+            ->screenshot('workouts-no-template-list');
     });
 });
 
@@ -224,99 +204,6 @@ it('navigates to workout detail when clicking a workout card', function () {
             ->click('@workout-history .cursor-pointer:first-child')
             ->waitForLocation("/workouts/{$workout->id}")
             ->assertPathIs("/workouts/{$workout->id}");
-    });
-});
-
-it('navigates to template detail when clicking a template', function () {
-    $user = User::factory()->create();
-    $template = WorkoutTemplate::factory()->create([
-        'user_id' => $user->id,
-        'name' => 'Test Template',
-    ]);
-
-    $this->browse(function (Browser $browser) use ($user, $template) {
-        $this->loginAs($browser, $user);
-        $browser->visit('/workouts')
-            ->waitFor('@template-section')
-            ->click('@template-section .cursor-pointer:first-child')
-            ->waitForLocation("/templates/{$template->id}")
-            ->assertPathIs("/templates/{$template->id}");
-    });
-});
-
-it('opens create template sheet when clicking create template button', function () {
-    $user = User::factory()->create();
-
-    $this->browse(function (Browser $browser) use ($user) {
-        $this->loginAs($browser, $user);
-        $browser->visit('/workouts')
-            ->waitFor('@workouts-page')
-            ->press('Create Template')
-            ->waitForText('Create Template')
-            ->assertSeeIn('h3', 'Create Template')
-            ->screenshot('workouts-template-sheet-open');
-    });
-});
-
-it('closes template sheet when clicking outside', function () {
-    $user = User::factory()->create();
-
-    $this->browse(function (Browser $browser) use ($user) {
-        $this->loginAs($browser, $user);
-        $browser->visit('/workouts')
-            ->waitFor('@workouts-page')
-            ->press('Create Template')
-            ->waitForText('Create Template');
-
-        $browser->script("document.querySelector('.ps-backdrop').click()");
-
-        $browser->pause(300)
-            ->assertMissing('.ps-sheet')
-            ->screenshot('workouts-template-sheet-closed');
-    });
-});
-
-it('creates a template with name', function () {
-    $user = User::factory()->create();
-
-    $this->browse(function (Browser $browser) use ($user) {
-        $this->loginAs($browser, $user);
-        $browser->visit('/workouts')
-            ->waitFor('@workouts-page')
-            ->press('Create Template')
-            ->waitForText('Create Template')
-            ->type('#template-name-input', 'New Template')
-            ->pause(500)
-            ->press('Create')
-            ->pause(1000);
-
-        $path = $browser->driver->getCurrentURL();
-        expect(str_contains($path, '/templates/'))->toBeTrue();
-
-        $browser->screenshot('workouts-template-created');
-    });
-
-    $this->assertDatabaseHas('workout_templates', [
-        'user_id' => $user->id,
-        'name' => 'New Template',
-    ]);
-});
-
-it('disables create template button when name is empty', function () {
-    $user = User::factory()->create();
-
-    $this->browse(function (Browser $browser) use ($user) {
-        $this->loginAs($browser, $user);
-        $browser->visit('/workouts')
-            ->waitFor('@workouts-page')
-            ->press('Create Template')
-            ->waitForText('Create Template')
-            ->waitFor('#template-name-input')
-            ->assertPresent('button:disabled')
-            ->type('#template-name-input', 'Test')
-            ->pause(300)
-            ->assertMissing('button:disabled')
-            ->screenshot('workouts-template-button-states');
     });
 });
 


### PR DESCRIPTION
## Problem

The workouts page listed saved templates inline and owned the create-template action, so templates had no page of their own and the workouts page was doing two jobs at once. Separately, a handful of spots on the workout and template pages drew check marks, a calendar, and a circled plus as raw Unicode characters instead of icons, which looked out of place next to the rest of the UI. Two smaller details had also drifted from the design: the ungroup button height and the select-mode helper text.

## Solution

Added a dedicated templates page at `/templates` (`resources/js/pages/templates.tsx`) for browsing, creating, editing, and deleting templates, laid out like the exercises and equipment pages. The workouts page (`resources/js/pages/workouts.tsx`) no longer lists templates and no longer owns the create-template sheet. Its third button now reads Templates and navigates to the new page. The New Workout flow and its in-sheet template picker are unchanged.

Replaced the Unicode glyphs with lucide-react icons (`Check`, `Calendar`, `Route`) in `workout-detail.tsx`, `template-editor.tsx`, and `workouts.tsx`. Bumped the ungroup button height and rewrote the select-mode helper text to match the design.

Moved the template list browser tests off `WorkoutsPageTest.php` into a new `TemplatesPageTest.php`, and updated the workouts page tests to assert it no longer lists templates.
