### PR TITLE
PS-78 - Pre-filling password reset email from URL and fixing PageHeader descender clipping

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -1,10 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Providers;
 
 use App\Notifications\WelcomeNotification;
 use DateInterval;
 use Illuminate\Auth\Events\Registered;
+use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Passport\Passport;
@@ -23,6 +26,10 @@ class AppServiceProvider extends ServiceProvider
 
         Event::listen(Registered::class, function (Registered $event): void {
             $event->user->notify(new WelcomeNotification());
+        });
+
+        ResetPassword::createUrlUsing(function (mixed $notifiable, string $token): string {
+            return config('app.url').'/password/reset/'.$token.'?email='.urlencode($notifiable->getEmailForPasswordReset());
         });
     }
 }

--- a/resources/js/components/ui/page-header.tsx
+++ b/resources/js/components/ui/page-header.tsx
@@ -26,7 +26,7 @@ export function PageHeader({ title, subtitle, back, onBack, actions, className }
           </button>
         )}
         <h1
-          className="truncate min-w-0 flex-1 leading-normal"
+          className="truncate min-w-0 flex-1 py-px"
           style={{ fontSize: 24, fontWeight: 700, letterSpacing: '-0.5px' }}
         >
           {title}

--- a/resources/js/pages/auth.tsx
+++ b/resources/js/pages/auth.tsx
@@ -1,5 +1,5 @@
 import { type FormEvent, type ReactNode, useState } from 'react'
-import { Link, useNavigate, useParams } from 'react-router-dom'
+import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import { isAxiosError } from 'axios'
 import { Button } from '@/components/ui/button'
 import { SegmentedControl } from '@/components/ui/segmented-control'
@@ -47,6 +47,7 @@ interface FieldProps {
   placeholder?: string
   name?: string
   error?: string
+  readOnly?: boolean
 }
 
 export function Field({
@@ -57,6 +58,7 @@ export function Field({
   placeholder,
   name,
   error,
+  readOnly,
 }: FieldProps) {
   return (
     <label className="block">
@@ -66,8 +68,9 @@ export function Field({
         name={name}
         value={value}
         placeholder={placeholder}
+        readOnly={readOnly}
         onChange={e => onChange(e.target.value)}
-        className={`ps-input w-full px-3 py-2.5 text-sm${error ? ' border-destructive' : ''}`}
+        className={`ps-input w-full px-3 py-2.5 text-sm${error ? ' border-destructive' : ''}${readOnly ? ' opacity-60 cursor-not-allowed' : ''}`}
       />
       {error && <p className="text-destructive text-xs mt-1">{error}</p>}
     </label>
@@ -397,7 +400,8 @@ export function PasswordResetRequestPage() {
 export function PasswordResetFormPage() {
   const navigate = useNavigate()
   const { token } = useParams<{ token: string }>()
-  const [email, setEmail] = useState('')
+  const [searchParams] = useSearchParams()
+  const [email, setEmail] = useState(searchParams.get('email') ?? '')
   const [password, setPassword] = useState('')
   const [passwordConfirm, setPasswordConfirm] = useState('')
   const [done, setDone] = useState(false)
@@ -460,6 +464,7 @@ export function PasswordResetFormPage() {
             onChange={setEmail}
             placeholder="you@example.com"
             error={errors.email}
+            readOnly={searchParams.has('email')}
           />
           <Field
             label="New password"

--- a/tests/Feature/Api/V1/Auth/PasswordResetTest.php
+++ b/tests/Feature/Api/V1/Auth/PasswordResetTest.php
@@ -90,4 +90,19 @@ class PasswordResetTest extends TestCase
         $this->postJson('/api/v1/password/forgot', ['email' => 'user@example.com'])
             ->assertStatus(429);
     }
+
+    public function test_reset_link_contains_email_and_spa_path(): void
+    {
+        Notification::fake();
+        $user = User::factory()->create(['email' => 'user@example.com']);
+
+        $this->postJson('/api/v1/password/forgot', ['email' => 'user@example.com']);
+
+        Notification::assertSentTo($user, ResetPassword::class, function (ResetPassword $notification) use ($user): bool {
+            $url = $notification->toMail($user)->actionUrl;
+
+            return str_contains($url, '/password/reset/')
+                && str_contains($url, 'email=user%40example.com');
+        });
+    }
 }


### PR DESCRIPTION
## Problem

The password reset form required users to manually re-type their email address, even though they just clicked a link from their inbox. The email field is required by Laravel's Password broker for token lookup, so it can't be removed, but it shouldn't need manual entry. Separately, the PageHeader component was clipping the bottom of descenders ("g", "p") and digit tails on detail pages.

## Solution

Customized the reset notification URL via `ResetPassword::createUrlUsing()` in `AppServiceProvider` to include the user's email as a query parameter. The frontend reads it with `useSearchParams` and pre-fills the email field as read-only. Added a `readOnly` prop to the `Field` component to support this.

For the PageHeader, replaced `leading-normal` with `py-px` on the h1 to add 1px vertical padding inside the `overflow: hidden` boundary, preventing descender clipping.
