### PR TITLE
PS-90 - Implementing ADR-001 token revocation via a Redis-backed JTI blacklist

### DIFF
--- a/app/Http/Controllers/Api/V1/Auth/LogoutController.php
+++ b/app/Http/Controllers/Api/V1/Auth/LogoutController.php
@@ -5,17 +5,27 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Api\V1\Auth;
 
 use App\Http\Controllers\Controller;
+use App\Services\TokenBlacklist;
+use DateTimeInterface;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-use Laravel\Passport\Token;
+use Laravel\Passport\AccessToken;
 
 class LogoutController extends Controller
 {
-    public function __invoke(Request $request): Response
+    public function __invoke(Request $request, TokenBlacklist $blacklist): Response
     {
         $token = $request->user()->currentAccessToken();
 
-        if ($token instanceof Token) {
+        if ($token instanceof AccessToken) {
+            // Read the raw attributes: the string @property type hides that actingAs tokens carry no id.
+            $jti = $token->toArray()['oauth_access_token_id'] ?? null;
+            $expiresAt = $token->expires_at;
+
+            if (is_string($jti) && $expiresAt instanceof DateTimeInterface) {
+                $blacklist->add($jti, $expiresAt);
+            }
+
             $token->revoke();
         }
 

--- a/app/Http/Middleware/RejectBlacklistedTokens.php
+++ b/app/Http/Middleware/RejectBlacklistedTokens.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Services\TokenBlacklist;
+use Closure;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Http\Request;
+use Laravel\Passport\AccessToken;
+use Symfony\Component\HttpFoundation\Response;
+
+class RejectBlacklistedTokens
+{
+    public function __construct(private TokenBlacklist $blacklist) {}
+
+    /**
+     * @throws AuthenticationException
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $token = $request->user()?->currentAccessToken();
+
+        $jti = $token instanceof AccessToken ? $token->oauth_access_token_id : null;
+
+        if (is_string($jti) && $this->blacklist->has($jti)) {
+            throw new AuthenticationException();
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Services/TokenBlacklist.php
+++ b/app/Services/TokenBlacklist.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use DateTimeInterface;
+use Illuminate\Contracts\Cache\Repository as Cache;
+
+class TokenBlacklist
+{
+    private const KEY_PREFIX = 'auth:revoked-jti:';
+
+    public function __construct(private Cache $cache) {}
+
+    public function add(string $jti, DateTimeInterface $expiresAt): void
+    {
+        // put() with a past expiry stores nothing, so expired tokens never create entries
+        $this->cache->put(self::KEY_PREFIX.$jti, true, $expiresAt);
+    }
+
+    public function has(string $jti): bool
+    {
+        return $this->cache->has(self::KEY_PREFIX.$jti);
+    }
+}

--- a/docs/decisions/adr-001-auth-passport-jwt.md
+++ b/docs/decisions/adr-001-auth-passport-jwt.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted
+Accepted (amended 2026-07-02 with PS-90 implementation notes)
 
 ## Date
 
@@ -36,7 +36,34 @@ We will use Laravel Passport with OAuth2 + JWT for authentication.
 - JWTs will include a JTI (JWT ID) claim for token identity
 - Web clients receive JWT in an HTTP-only cookie (standard browser security practice)
 - Mobile clients receive JWT in the response body for secure device storage, sent via Authorization header on subsequent requests
-- Logout invalidates tokens via a Redis-backed JTI blacklist where each entry's TTL equals the remaining lifetime of the invalidated token, ensuring auto-expiration without filling up Redis
+- Logout invalidates tokens via a Redis-backed JTI blacklist where each entry's TTL equals the remaining lifetime of the invalidated token, so entries auto-expire without filling up Redis
+
+---
+
+## Implementation Notes (2026-07-02, PS-90)
+
+The JTI blacklist is implemented behind Laravel's cache layer rather
+than raw Redis commands:
+
+- `App\Services\TokenBlacklist` writes `auth:revoked-jti:{jti}`
+  entries through the default cache store with the entry expiry set
+  to the token's `expires_at`. The deployed stack sets
+  `CACHE_STORE=redis` (cache connection, Redis database 1), so
+  entries land in Redis under the framework cache prefix and expire
+  with the token. The test suite swaps in the array store, keeping
+  the suite free of a Redis dependency.
+- `App\Http\Middleware\RejectBlacklistedTokens` runs after `auth:api`
+  on the protected route group and rejects blacklisted JTIs with 401.
+- Logout keeps Passport's database revocation (`revoked` flag) as a
+  second layer, so Passport's per-request database token lookup still
+  runs. The "token revocation without database lookups per request"
+  property above is a design goal, not yet the runtime behavior.
+  Removing the lookup is deferred until blacklist state can be
+  rebuilt from the database after a Redis flush (PS-124).
+- A Redis flush does not resurrect logged-out tokens today because
+  the database `revoked` flag still rejects them.
+
+Cookie-based delivery for web clients remains open under PS-91.
 
 ---
 
@@ -100,7 +127,7 @@ A lightweight JWT library without additional OAuth2 infrastructure.
 
 ### New Decisions Required
 
-- Implement secure Redis connection pooling and failover strategy to ensure blacklist availability
+- Implement secure Redis connection pooling and failover strategy to keep the blacklist available
 - Decide on HTTP-only cookie SameSite and Secure flags for web clients to prevent CSRF and XSS attacks
 - Define JWT expiration times (access token TTL and refresh token rotation policy)
 - Determine scope definitions and their mapping to application permissions

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "physistrong",
+  "name": "html",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/routes/api.php
+++ b/routes/api.php
@@ -18,6 +18,7 @@ use App\Http\Controllers\Api\V1\WorkoutCopyController;
 use App\Http\Controllers\Api\V1\WorkoutEntryController;
 use App\Http\Controllers\Api\V1\WorkoutExerciseController;
 use App\Http\Controllers\Api\V1\WorkoutTemplateController;
+use App\Http\Middleware\RejectBlacklistedTokens;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/health', fn () => response()->json(['status' => 'ok']));
@@ -27,7 +28,7 @@ Route::post('/login', LoginController::class);
 Route::post('/password/forgot', ForgotPasswordController::class);
 Route::post('/password/reset', ResetPasswordController::class);
 
-Route::middleware('auth:api')->group(function () {
+Route::middleware(['auth:api', RejectBlacklistedTokens::class])->group(function () {
     Route::post('/logout', LogoutController::class);
     Route::get('/user', [UserController::class, 'show']);
     Route::put('/user', [UserController::class, 'update']);

--- a/tests/Feature/Api/V1/Auth/TokenRevocationTest.php
+++ b/tests/Feature/Api/V1/Auth/TokenRevocationTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1\Auth;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Laravel\Passport\Token;
+use Tests\CreatesPassportToken;
+use Tests\TestCase;
+
+class TokenRevocationTest extends TestCase
+{
+    use CreatesPassportToken;
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setUpPassport();
+    }
+
+    public function test_logout_blacklists_the_token_for_its_remaining_lifetime(): void
+    {
+        $this->freezeTime();
+
+        $token = $this->login($this->createUser());
+
+        $dbToken = Token::query()->sole();
+        $expiresAt = $dbToken->expires_at;
+
+        $this->travelTo(now()->addDays(10));
+
+        $this->withToken($token)->postJson('/api/v1/logout')->assertNoContent();
+
+        $key = 'auth:revoked-jti:'.$dbToken->getKey();
+
+        $this->assertTrue(Cache::has($key));
+        $this->assertTrue($dbToken->fresh()->revoked);
+
+        $this->travelTo($expiresAt->copy()->subMinute());
+        $this->assertTrue(Cache::has($key));
+
+        $this->travelTo($expiresAt->copy()->addMinute());
+        $this->assertFalse(Cache::has($key));
+    }
+
+    public function test_rejects_a_blacklisted_token_even_when_its_database_row_is_not_revoked(): void
+    {
+        $token = $this->login($this->createUser());
+
+        $this->withToken($token)->getJson('/api/v1/user')->assertOk();
+
+        $this->withToken($token)->postJson('/api/v1/logout')->assertNoContent();
+
+        Token::query()->update(['revoked' => false]);
+
+        $this->withToken($token)->getJson('/api/v1/user')->assertStatus(401);
+    }
+
+    public function test_logout_leaves_other_tokens_for_the_same_user_valid(): void
+    {
+        $user = $this->createUser();
+
+        $firstToken = $this->login($user);
+        $secondToken = $this->login($user);
+
+        $this->withToken($firstToken)->postJson('/api/v1/logout')->assertNoContent();
+
+        // In-process test requests share one guard instance, which caches the resolved
+        // user and its access token; drop it when switching tokens the way a real
+        // per-request process would.
+        $this->app['auth']->forgetGuards();
+
+        $this->withToken($secondToken)->getJson('/api/v1/user')->assertOk();
+
+        $this->app['auth']->forgetGuards();
+
+        $this->withToken($firstToken)->getJson('/api/v1/user')->assertStatus(401);
+    }
+
+    private function createUser(): User
+    {
+        return User::factory()->create([
+            'email' => 'user@example.com',
+            'password' => 'secret123',
+        ]);
+    }
+
+    private function login(User $user): string
+    {
+        return $this->postJson('/api/v1/login', [
+            'email' => $user->email,
+            'password' => 'secret123',
+        ])->json('token');
+    }
+}

--- a/tests/Unit/Services/TokenBlacklistTest.php
+++ b/tests/Unit/Services/TokenBlacklistTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services;
+
+use App\Services\TokenBlacklist;
+use Tests\TestCase;
+
+class TokenBlacklistTest extends TestCase
+{
+    public function test_expired_tokens_write_no_blacklist_entry(): void
+    {
+        $blacklist = app(TokenBlacklist::class);
+
+        $blacklist->add('live-token-jti', now()->addDay());
+        $blacklist->add('expired-token-jti', now()->subSecond());
+
+        $this->assertTrue($blacklist->has('live-token-jti'));
+        $this->assertFalse($blacklist->has('expired-token-jti'));
+    }
+}


### PR DESCRIPTION
## Problem

The auth ADR calls for logout to invalidate tokens through a Redis-backed JTI blacklist, with each entry expiring when the token itself would. None of that was implemented. Logout was also a silent no-op: the controller checked for Passport's Token model, but the guard hands back an AccessToken wrapper, so the revoke call never ran. Tokens live 30 days, so a logged-out or leaked token stayed usable until it expired on its own.

## Solution

Logout now records the token's JTI in a blacklist and revokes the database row as a second layer, still returning 204. A new TokenBlacklist service (app/Services/TokenBlacklist.php) writes auth:revoked-jti entries through the default cache store, which is Redis in the deployed stack and the array store in tests. The entry expiry is the token's expires_at, so entries die with the token and already-expired tokens write nothing. A new RejectBlacklistedTokens middleware runs after auth:api on the protected route group and rejects blacklisted JTIs with 401. Passport's per-request database lookup stays in place as a fallback until the blacklist can be rebuilt after a Redis flush; ADR-001 is amended to record the implemented mechanics and what remains deferred.
