### PR TITLE
PS-91 - Delivering the JWT via HTTP-only cookie and removing localStorage token handling

### DIFF
--- a/app/Http/Controllers/Api/V1/Auth/LoginController.php
+++ b/app/Http/Controllers/Api/V1/Auth/LoginController.php
@@ -6,7 +6,7 @@ namespace App\Http\Controllers\Api\V1\Auth;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\V1\LoginRequest;
-use App\Http\Resources\Api\V1\UserResource;
+use App\Http\Responses\AuthTokenResponse;
 use App\Models\User;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Hash;
@@ -34,11 +34,6 @@ class LoginController extends Controller
 
         RateLimiter::clear($key);
 
-        $token = $user->createToken('auth');
-
-        return response()->json([
-            'user' => new UserResource($user),
-            'token' => $token->accessToken,
-        ]);
+        return AuthTokenResponse::make($user);
     }
 }

--- a/app/Http/Controllers/Api/V1/Auth/LogoutController.php
+++ b/app/Http/Controllers/Api/V1/Auth/LogoutController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Api\V1\Auth;
 
 use App\Http\Controllers\Controller;
+use App\Services\AuthTokenCookie;
 use App\Services\TokenBlacklist;
 use DateTimeInterface;
 use Illuminate\Http\Request;
@@ -29,6 +30,6 @@ class LogoutController extends Controller
             $token->revoke();
         }
 
-        return response()->noContent();
+        return response()->noContent()->withCookie(AuthTokenCookie::expire());
     }
 }

--- a/app/Http/Controllers/Api/V1/Auth/RegisterController.php
+++ b/app/Http/Controllers/Api/V1/Auth/RegisterController.php
@@ -6,7 +6,7 @@ namespace App\Http\Controllers\Api\V1\Auth;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\V1\RegisterRequest;
-use App\Http\Resources\Api\V1\UserResource;
+use App\Http\Responses\AuthTokenResponse;
 use App\Models\User;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Http\JsonResponse;
@@ -19,11 +19,6 @@ class RegisterController extends Controller
 
         event(new Registered($user));
 
-        $token = $user->createToken('auth');
-
-        return response()->json([
-            'user' => new UserResource($user),
-            'token' => $token->accessToken,
-        ], 201);
+        return AuthTokenResponse::make($user, 201);
     }
 }

--- a/app/Http/Middleware/AuthenticateViaTokenCookie.php
+++ b/app/Http/Middleware/AuthenticateViaTokenCookie.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Services\AuthTokenCookie;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class AuthenticateViaTokenCookie
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $token = $request->cookie(AuthTokenCookie::NAME);
+
+        // The header always wins so bearer clients (curl, the future mobile
+        // app) behave exactly as before the cookie existed.
+        if (! $request->headers->has('Authorization') && is_string($token) && $token !== '') {
+            $request->headers->set('Authorization', 'Bearer '.$token);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Responses/AuthTokenResponse.php
+++ b/app/Http/Responses/AuthTokenResponse.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Responses;
+
+use App\Http\Resources\Api\V1\UserResource;
+use App\Models\User;
+use App\Services\AuthTokenCookie;
+use Illuminate\Http\JsonResponse;
+
+class AuthTokenResponse
+{
+    public static function make(User $user, int $status = 200): JsonResponse
+    {
+        $token = $user->createToken('auth');
+
+        return response()->json([
+            'user' => new UserResource($user),
+        ], $status)->withCookie(AuthTokenCookie::issue($token->accessToken, now()->addSeconds($token->expiresIn)));
+    }
+}

--- a/app/Services/AuthTokenCookie.php
+++ b/app/Services/AuthTokenCookie.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use DateTimeInterface;
+use Symfony\Component\HttpFoundation\Cookie;
+
+class AuthTokenCookie
+{
+    public const NAME = 'ps_token';
+
+    // Path scoping keeps the cookie off web routes entirely, so only API
+    // requests ever carry the token.
+    private const PATH = '/api/v1';
+
+    public static function issue(string $token, DateTimeInterface $expiresAt): Cookie
+    {
+        return self::make($token, $expiresAt);
+    }
+
+    public static function expire(): Cookie
+    {
+        return self::make('', 1);
+    }
+
+    private static function make(string $value, DateTimeInterface|int $expire): Cookie
+    {
+        return new Cookie(
+            name: self::NAME,
+            value: $value,
+            expire: $expire,
+            path: self::PATH,
+            secure: true,
+            httpOnly: true,
+            sameSite: Cookie::SAMESITE_LAX,
+        );
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\AuthenticateViaTokenCookie;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -14,7 +15,7 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->api(prepend: [AuthenticateViaTokenCookie::class]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         $exceptions->shouldRenderJsonWhen(

--- a/docs/decisions/adr-001-auth-passport-jwt.md
+++ b/docs/decisions/adr-001-auth-passport-jwt.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted (amended 2026-07-02 with PS-90 implementation notes)
+Accepted (amended 2026-07-02 with PS-90 implementation notes, 2026-07-03 with PS-91 cookie delivery)
 
 ## Date
 
@@ -63,7 +63,39 @@ than raw Redis commands:
 - A Redis flush does not resurrect logged-out tokens today because
   the database `revoked` flag still rejects them.
 
-Cookie-based delivery for web clients remains open under PS-91.
+## Implementation Notes (2026-07-03, PS-91)
+
+Web delivery is cookie-only as of PS-91:
+
+- Login and register attach the Passport JWT to the response as a
+  `ps_token` cookie flagged `HttpOnly`, `Secure`, and `SameSite=Lax`,
+  path-scoped to `/api/v1`, with the cookie lifetime matching the token
+  lifetime. The token no longer appears in any response body.
+  `App\Services\AuthTokenCookie` is the single source for the name,
+  path, and flags; `App\Http\Responses\AuthTokenResponse` builds the
+  login and register responses.
+- `App\Http\Middleware\AuthenticateViaTokenCookie` (prepended to the
+  `api` middleware group) copies the cookie into the `Authorization`
+  header when no such header is present. A caller-supplied
+  `Authorization` header always wins, which keeps bearer clients
+  (curl, Postman, the future mobile app) working unchanged.
+- Logout attaches an expired `ps_token` cookie so the browser drops
+  it; revocation itself remains the PS-90 JTI blacklist plus the
+  database `revoked` flag.
+- **SameSite/Secure decision** (resolves the open item under New
+  Decisions Required): `SameSite=Lax` plus the CORS origin allowlist
+  covers CSRF on the cookie path, since cross-site state-changing
+  requests never carry a Lax cookie and Lax top-level navigations are
+  GET-only reads. `Secure` is always set: the deployed instance and
+  Dusk run HTTPS, and browsers treat `http://localhost` as a
+  trustworthy origin, so local development keeps working. The
+  `/api/v1` path scope keeps the cookie away from web-group routes and
+  their cookie middleware entirely.
+- **Deferred mobile branch**: when a mobile client ships, an explicit
+  client signal (for example an `X-Client: mobile` header) at login
+  and register will return the token in the response body instead of
+  setting the cookie. The authenticated request path needs no change
+  because the header already wins over the cookie.
 
 ---
 
@@ -128,7 +160,7 @@ A lightweight JWT library without additional OAuth2 infrastructure.
 ### New Decisions Required
 
 - Implement secure Redis connection pooling and failover strategy to keep the blacklist available
-- Decide on HTTP-only cookie SameSite and Secure flags for web clients to prevent CSRF and XSS attacks
+- ~~Decide on HTTP-only cookie SameSite and Secure flags for web clients to prevent CSRF and XSS attacks~~ (resolved by PS-91; see Implementation Notes, 2026-07-03)
 - Define JWT expiration times (access token TTL and refresh token rotation policy)
 - Determine scope definitions and their mapping to application permissions
 

--- a/resources/js/api/auth.ts
+++ b/resources/js/api/auth.ts
@@ -1,10 +1,9 @@
-import { api, setToken, clearToken } from './client'
+import { api, markAuthenticated, markUnauthenticated } from './client'
 import { toUser } from './transformers'
 import type { User } from './types'
 
 interface AuthResponse {
   user: User
-  token: string
 }
 
 interface LoginPayload {
@@ -23,24 +22,19 @@ interface RegisterPayload {
 
 export async function login(payload: LoginPayload): Promise<AuthResponse> {
   const { data } = await api.post('/login', payload)
-  const user = toUser(data.user)
-  setToken(data.token)
-  return { user, token: data.token }
+  markAuthenticated()
+  return { user: toUser(data.user) }
 }
 
 export async function register(payload: RegisterPayload): Promise<AuthResponse> {
   const { data } = await api.post('/register', payload)
-  const user = toUser(data.user)
-  setToken(data.token)
-  return { user, token: data.token }
+  markAuthenticated()
+  return { user: toUser(data.user) }
 }
 
 export async function logout(): Promise<void> {
-  try {
-    await api.post('/logout')
-  } finally {
-    clearToken()
-  }
+  await api.post('/logout')
+  markUnauthenticated()
 }
 
 export async function forgotPassword(email: string): Promise<void> {

--- a/resources/js/api/client.ts
+++ b/resources/js/api/client.ts
@@ -1,39 +1,30 @@
 import axios from 'axios'
 
-const TOKEN_KEY = 'ps_token'
-
 export const api = axios.create({
   baseURL: '/api/v1',
   headers: { Accept: 'application/json' },
 })
 
-api.interceptors.request.use(config => {
-  const token = localStorage.getItem(TOKEN_KEY)
-  if (token) {
-    config.headers.Authorization = `Bearer ${token}`
-  }
-  return config
-})
+// The token lives in an HttpOnly cookie the browser attaches on its own, so
+// this flag is the only client-side auth signal. It distinguishes an expired
+// session (redirect to login) from a plain guest 401 (no redirect).
+let authenticated = false
+
+export function markAuthenticated(): void {
+  authenticated = true
+}
+
+export function markUnauthenticated(): void {
+  authenticated = false
+}
 
 api.interceptors.response.use(
   response => response,
   error => {
-    if (error.response?.status === 401 && localStorage.getItem(TOKEN_KEY)) {
-      localStorage.removeItem(TOKEN_KEY)
+    if (error.response?.status === 401 && authenticated) {
+      authenticated = false
       window.location.href = '/login'
     }
     return Promise.reject(error)
   }
 )
-
-export function setToken(token: string): void {
-  localStorage.setItem(TOKEN_KEY, token)
-}
-
-export function clearToken(): void {
-  localStorage.removeItem(TOKEN_KEY)
-}
-
-export function hasToken(): boolean {
-  return !!localStorage.getItem(TOKEN_KEY)
-}

--- a/resources/js/lib/auth-provider.tsx
+++ b/resources/js/lib/auth-provider.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState, useEffect, type ReactNode } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
-import { hasToken, clearToken } from '@/api/client'
+import { markAuthenticated } from '@/api/client'
 import { getProfile } from '@/api/user'
 import { logout as logoutApi } from '@/api/auth'
 import { AuthContext } from './auth-context'
@@ -9,18 +9,19 @@ import type { User } from '@/api/types'
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null)
-  const [isLoading, setIsLoading] = useState(hasToken())
+  // The token is an HttpOnly cookie the client cannot inspect, so the only
+  // way to learn the auth state is to ask the API.
+  const [isLoading, setIsLoading] = useState(true)
   const queryClient = useQueryClient()
   const navigate = useNavigate()
 
   useEffect(() => {
-    if (!hasToken()) return
     getProfile()
-      .then(setUser)
-      .catch(() => {
-        clearToken()
-        setUser(null)
+      .then(profile => {
+        markAuthenticated()
+        setUser(profile)
       })
+      .catch(() => setUser(null))
       .finally(() => setIsLoading(false))
   }, [])
 

--- a/resources/js/pages/auth.test.tsx
+++ b/resources/js/pages/auth.test.tsx
@@ -5,31 +5,28 @@ import { http } from 'msw'
 import { errorEnvelope } from '@/test/mocks/handlers/_helpers'
 import { LoginPage, RegisterPage } from './auth'
 
+const workoutsStub = { path: '/workouts', element: <div>Workouts landing</div> }
+
 describe('LoginPage', () => {
-  it('logs in successfully and sets token in localStorage', async () => {
+  it('logs in successfully and redirects to workouts', async () => {
     const user = userEvent.setup()
-    renderWithProviders(<LoginPage />, { user: null })
+    renderWithProviders(<LoginPage />, {
+      user: null,
+      route: '/login',
+      path: '/login',
+      additionalRoutes: [workoutsStub],
+    })
 
-    const emailInput = screen.getByLabelText('Email')
-    const passwordInput = screen.getByLabelText('Password')
-    const submitButton = screen.getByRole('button', { name: /log in/i })
+    await user.type(screen.getByLabelText('Email'), 'test@example.com')
+    await user.type(screen.getByLabelText('Password'), 'password123')
+    await user.click(screen.getByRole('button', { name: /log in/i }))
 
-    await user.type(emailInput, 'test@example.com')
-    await user.type(passwordInput, 'password123')
-    await user.click(submitButton)
-
-    // Verify token was set in localStorage (setToken is called by login())
-    expect(localStorage.getItem('ps_token')).toBe('test-access-token')
-
-    // Verify no error message is displayed
-    const errorElements = screen.queryAllByText(/something went wrong/i)
-    expect(errorElements).toHaveLength(0)
+    expect(await screen.findByText('Workouts landing')).toBeInTheDocument()
   })
 
   it('displays validation error message when credentials are invalid', async () => {
     const user = userEvent.setup()
 
-    // Override the login handler to return a 422 validation error
     server.use(
       http.post('/api/v1/login', () =>
         errorEnvelope(422, 'The given data was invalid.', {
@@ -38,83 +35,60 @@ describe('LoginPage', () => {
       )
     )
 
-    renderWithProviders(<LoginPage />, { user: null })
+    renderWithProviders(<LoginPage />, {
+      user: null,
+      route: '/login',
+      path: '/login',
+      additionalRoutes: [workoutsStub],
+    })
 
-    const emailInput = screen.getByLabelText('Email')
-    const passwordInput = screen.getByLabelText('Password')
-    const submitButton = screen.getByRole('button', { name: /log in/i })
+    await user.type(screen.getByLabelText('Email'), 'invalid@example.com')
+    await user.type(screen.getByLabelText('Password'), 'wrongpassword')
+    await user.click(screen.getByRole('button', { name: /log in/i }))
 
-    await user.type(emailInput, 'invalid@example.com')
-    await user.type(passwordInput, 'wrongpassword')
-    await user.click(submitButton)
-
-    // Verify error message is displayed
-    const errorMessage = await screen.findByText('These credentials do not match our records.')
-    expect(errorMessage).toBeInTheDocument()
-
-    // Verify token was not set
-    expect(localStorage.getItem('ps_token')).toBeNull()
+    expect(
+      await screen.findByText('These credentials do not match our records.')
+    ).toBeInTheDocument()
+    expect(screen.queryByText('Workouts landing')).not.toBeInTheDocument()
   })
 })
 
 describe('RegisterPage', () => {
-  it('creates account successfully with required fields and sets token in localStorage', async () => {
+  it('creates account successfully with required fields and redirects to workouts', async () => {
     const user = userEvent.setup()
-    renderWithProviders(<RegisterPage />, { user: null })
+    renderWithProviders(<RegisterPage />, {
+      user: null,
+      route: '/register',
+      path: '/register',
+      additionalRoutes: [workoutsStub],
+    })
 
-    const emailInput = screen.getByLabelText('Email')
-    const passwordInput = screen.getByLabelText('Password')
-    const confirmInput = screen.getByLabelText('Confirm')
-    const submitButton = screen.getByRole('button', { name: /create account/i })
+    await user.click(screen.getByRole('tab', { name: /imperial/i }))
+    await user.type(screen.getByLabelText('Email'), 'newuser@example.com')
+    await user.type(screen.getByLabelText('Password'), 'password123')
+    await user.type(screen.getByLabelText('Confirm'), 'password123')
+    await user.click(screen.getByRole('button', { name: /create account/i }))
 
-    // Select measurement system (imperial)
-    const imperialButton = screen.getByRole('tab', { name: /imperial/i })
-    await user.click(imperialButton)
-
-    // Fill in required fields
-    await user.type(emailInput, 'newuser@example.com')
-    await user.type(passwordInput, 'password123')
-    await user.type(confirmInput, 'password123')
-
-    // Submit the form
-    await user.click(submitButton)
-
-    // Verify token was set in localStorage
-    expect(localStorage.getItem('ps_token')).toBe('test-access-token')
-
-    // Verify no error message is displayed
-    const errorElements = screen.queryAllByText(/something went wrong/i)
-    expect(errorElements).toHaveLength(0)
+    expect(await screen.findByText('Workouts landing')).toBeInTheDocument()
   })
 
   it('allows registering with optional first and last name fields', async () => {
     const user = userEvent.setup()
-    renderWithProviders(<RegisterPage />, { user: null })
+    renderWithProviders(<RegisterPage />, {
+      user: null,
+      route: '/register',
+      path: '/register',
+      additionalRoutes: [workoutsStub],
+    })
 
-    const firstNameInput = screen.getByLabelText('First name')
-    const lastNameInput = screen.getByLabelText('Last name')
-    const emailInput = screen.getByLabelText('Email')
-    const passwordInput = screen.getByLabelText('Password')
-    const confirmInput = screen.getByLabelText('Confirm')
-    const metricButton = screen.getByRole('tab', { name: /metric/i })
-    const submitButton = screen.getByRole('button', { name: /create account/i })
+    await user.type(screen.getByLabelText('First name'), 'Justin')
+    await user.type(screen.getByLabelText('Last name'), 'Christenson')
+    await user.type(screen.getByLabelText('Email'), 'justin@example.com')
+    await user.type(screen.getByLabelText('Password'), 'password123')
+    await user.type(screen.getByLabelText('Confirm'), 'password123')
+    await user.click(screen.getByRole('tab', { name: /metric/i }))
+    await user.click(screen.getByRole('button', { name: /create account/i }))
 
-    // Fill in all fields including optional ones
-    await user.type(firstNameInput, 'Justin')
-    await user.type(lastNameInput, 'Christenson')
-    await user.type(emailInput, 'justin@example.com')
-    await user.type(passwordInput, 'password123')
-    await user.type(confirmInput, 'password123')
-    await user.click(metricButton)
-
-    // Submit the form
-    await user.click(submitButton)
-
-    // Verify token was set in localStorage
-    expect(localStorage.getItem('ps_token')).toBe('test-access-token')
-
-    // Verify no error message is displayed
-    const errorElements = screen.queryAllByText(/something went wrong/i)
-    expect(errorElements).toHaveLength(0)
+    expect(await screen.findByText('Workouts landing')).toBeInTheDocument()
   })
 })

--- a/resources/js/test/mocks/fixtures/auth/login.json
+++ b/resources/js/test/mocks/fixtures/auth/login.json
@@ -8,6 +8,5 @@
     "theme": "system",
     "created_at": "2026-01-01T00:00:00.000000Z",
     "updated_at": "2026-01-01T00:00:00.000000Z"
-  },
-  "token": "test-access-token"
+  }
 }

--- a/resources/js/test/mocks/fixtures/auth/register.json
+++ b/resources/js/test/mocks/fixtures/auth/register.json
@@ -1,6 +1,6 @@
 {
   "user": {
-    "id": 14,
+    "id": 18,
     "email": "test-throwaway@example.com",
     "first_name": "Capture",
     "last_name": "Test",
@@ -8,6 +8,5 @@
     "theme": null,
     "created_at": "2026-01-01T00:00:00.000000Z",
     "updated_at": "2026-01-01T00:00:00.000000Z"
-  },
-  "token": "test-access-token"
+  }
 }

--- a/tests/Browser/AuthTest.php
+++ b/tests/Browser/AuthTest.php
@@ -53,8 +53,10 @@ it('logs in with valid credentials and redirects to workouts', function () {
 
 it('redirects unauthenticated user from workouts to login', function () {
     $this->browse(function (Browser $browser) {
+        // The guard redirect now waits on the boot-time auth probe, so give the
+        // first cold page load a bigger budget than Dusk's 5-second default.
         $browser->visit('/workouts')
-            ->waitForLocation('/login')
+            ->waitForLocation('/login', 10)
             ->assertPathIs('/login');
     });
 });
@@ -100,5 +102,25 @@ it('renders the forgot password page', function () {
             ->assertPresent('input[name="email"]')
             ->assertSeeLink('Back to login')
             ->screenshot('auth-forgot-password-desktop');
+    });
+});
+
+it('keeps the auth cookie out of document.cookie and dead after logout', function () {
+    $user = User::factory()->create();
+
+    $this->browse(function (Browser $browser) use ($user) {
+        $this->loginAs($browser, $user);
+
+        // HttpOnly plus the /api/v1 path scope keep the token invisible to scripts.
+        $cookies = (string) $browser->script('return document.cookie')[0];
+        expect($cookies)->not->toContain('ps_token');
+
+        $browser->visit('/profile')
+            ->waitFor('@logout-btn')
+            ->click('@logout-btn')
+            ->waitForLocation('/login')
+            ->visit('/workouts')
+            ->waitForLocation('/login')
+            ->assertPathIs('/login');
     });
 });

--- a/tests/Browser/ExercisesPageTest.php
+++ b/tests/Browser/ExercisesPageTest.php
@@ -75,8 +75,8 @@ it('navigates to exercise detail page', function () {
     $this->browse(function (Browser $browser) use ($user) {
         $this->loginAs($browser, $user);
         $browser->visit('/exercises')
-            ->waitFor('@exercise-list')
-            ->click('@exercise-list')
+            ->waitFor('[dusk="exercise-list"] > *:first-child')
+            ->click('[dusk="exercise-list"] > *:first-child')
             ->waitFor('@exercise-detail-page')
             ->assertVisible('@exercise-name')
             ->assertVisible('@exercise-type')
@@ -91,8 +91,8 @@ it('exercise detail displays at desktop width', function () {
         $this->loginAs($browser, $user);
         $browser->resize(1920, 1080)
             ->visit('/exercises')
-            ->waitFor('@exercise-list')
-            ->click('@exercise-list')
+            ->waitFor('[dusk="exercise-list"] > *:first-child')
+            ->click('[dusk="exercise-list"] > *:first-child')
             ->waitFor('@exercise-detail-page')
             ->assertVisible('@exercise-name')
             ->assertVisible('@exercise-type')
@@ -108,8 +108,8 @@ it('exercise detail displays at tablet width', function () {
         $this->loginAs($browser, $user);
         $browser->resize(768, 1024)
             ->visit('/exercises')
-            ->waitFor('@exercise-list')
-            ->click('@exercise-list')
+            ->waitFor('[dusk="exercise-list"] > *:first-child')
+            ->click('[dusk="exercise-list"] > *:first-child')
             ->waitFor('@exercise-detail-page')
             ->assertVisible('@exercise-name')
             ->assertVisible('@exercise-type')
@@ -124,8 +124,8 @@ it('exercise detail displays at phone width', function () {
         $this->loginAs($browser, $user);
         $browser->resize(375, 812)
             ->visit('/exercises')
-            ->waitFor('@exercise-list')
-            ->click('@exercise-list')
+            ->waitFor('[dusk="exercise-list"] > *:first-child')
+            ->click('[dusk="exercise-list"] > *:first-child')
             ->waitFor('@exercise-detail-page')
             ->assertVisible('@exercise-name')
             ->assertVisible('@exercise-type')
@@ -140,8 +140,8 @@ it('shows progress link on exercise detail', function () {
     $this->browse(function (Browser $browser) use ($user) {
         $this->loginAs($browser, $user);
         $browser->visit('/exercises')
-            ->waitFor('@exercise-list')
-            ->click('@exercise-list')
+            ->waitFor('[dusk="exercise-list"] > *:first-child')
+            ->click('[dusk="exercise-list"] > *:first-child')
             ->waitFor('@exercise-detail-page')
             ->assertVisible('@progress-link')
             ->assertSee('View Progress');
@@ -154,8 +154,8 @@ it('hides delete button on system exercise', function () {
     $this->browse(function (Browser $browser) use ($user) {
         $this->loginAs($browser, $user);
         $browser->visit('/exercises')
-            ->waitFor('@exercise-list')
-            ->click('@exercise-list')
+            ->waitFor('[dusk="exercise-list"] > *:first-child')
+            ->click('[dusk="exercise-list"] > *:first-child')
             ->waitFor('@exercise-detail-page')
             ->assertMissing('@delete-exercise-btn');
     });
@@ -184,8 +184,8 @@ it('shows system badge on system exercise detail', function () {
     $this->browse(function (Browser $browser) use ($user) {
         $this->loginAs($browser, $user);
         $browser->visit('/exercises')
-            ->waitFor('@exercise-list')
-            ->click('@exercise-list')
+            ->waitFor('[dusk="exercise-list"] > *:first-child')
+            ->click('[dusk="exercise-list"] > *:first-child')
             ->waitFor('@exercise-detail-page')
             ->assertVisible('@system-badge')
             ->assertSee('SYSTEM')
@@ -217,7 +217,7 @@ it('disables exercise delete button when exercise is in use', function () {
             ->waitFor('@exercises-page')
             ->type('@exercise-search', 'Test Custom Exercise')
             ->pause(500)
-            ->click('@exercise-list')
+            ->click('[dusk="exercise-list"] > *:first-child')
             ->waitFor('@exercise-detail-page')
             ->assertVisible('@delete-exercise-btn')
             ->assertDisabled('@delete-exercise-btn')
@@ -245,7 +245,7 @@ it('enables exercise delete button when exercise is not in use', function () {
             ->waitFor('@exercises-page')
             ->type('@exercise-search', 'Unused Custom Exercise')
             ->pause(500)
-            ->click('@exercise-list')
+            ->click('[dusk="exercise-list"] > *:first-child')
             ->waitFor('@exercise-detail-page')
             ->assertVisible('@delete-exercise-btn')
             ->assertEnabled('@delete-exercise-btn')

--- a/tests/CreatesPassportToken.php
+++ b/tests/CreatesPassportToken.php
@@ -4,12 +4,41 @@ declare(strict_types=1);
 
 namespace Tests;
 
+use App\Services\AuthTokenCookie;
+use Illuminate\Testing\TestResponse;
 use Laravel\Passport\ClientRepository;
+use Symfony\Component\HttpFoundation\Cookie;
 
 trait CreatesPassportToken
 {
     protected function setUpPassport(): void
     {
         app(ClientRepository::class)->createPersonalAccessGrantClient('Test Personal Access Client');
+    }
+
+    protected function loginAndReadTokenCookie(string $email, string $password): string
+    {
+        $cookie = $this->postJson('/api/v1/login', [
+            'email' => $email,
+            'password' => $password,
+        ])->getCookie(AuthTokenCookie::NAME, decrypt: false);
+
+        $this->assertNotNull($cookie, 'Login response did not set the auth token cookie.');
+
+        return (string) $cookie->getValue();
+    }
+
+    protected function assertIssuesAuthTokenCookie(TestResponse $response): void
+    {
+        $cookie = $response->getCookie(AuthTokenCookie::NAME, decrypt: false);
+
+        $this->assertNotNull($cookie, 'Response did not set the auth token cookie.');
+        $this->assertNotSame('', $cookie->getValue());
+        $this->assertTrue($cookie->isHttpOnly());
+        $this->assertTrue($cookie->isSecure());
+        $this->assertSame(Cookie::SAMESITE_LAX, $cookie->getSameSite());
+        $this->assertSame('/api/v1', $cookie->getPath());
+        // The cookie must live as long as the 30-day token, not default to session scope.
+        $this->assertGreaterThan(now()->addDays(29)->getTimestamp(), $cookie->getExpiresTime());
     }
 }

--- a/tests/Feature/Api/V1/Auth/CookieAuthenticationTest.php
+++ b/tests/Feature/Api/V1/Auth/CookieAuthenticationTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1\Auth;
+
+use App\Models\User;
+use App\Services\AuthTokenCookie;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\CreatesPassportToken;
+use Tests\TestCase;
+
+class CookieAuthenticationTest extends TestCase
+{
+    use CreatesPassportToken;
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpPassport();
+    }
+
+    public function test_authenticates_with_only_the_token_cookie(): void
+    {
+        $user = User::factory()->create();
+        $token = $user->createToken('auth')->accessToken;
+
+        $this->withCredentials()
+            ->withUnencryptedCookie(AuthTokenCookie::NAME, $token)
+            ->getJson('/api/v1/user')
+            ->assertOk()
+            ->assertJsonPath('data.email', $user->email);
+    }
+
+    public function test_authorization_header_wins_over_the_cookie(): void
+    {
+        $headerUser = User::factory()->create(['email' => 'header@example.com']);
+        $cookieUser = User::factory()->create(['email' => 'cookie@example.com']);
+
+        $headerToken = $headerUser->createToken('auth')->accessToken;
+        $cookieToken = $cookieUser->createToken('auth')->accessToken;
+
+        $this->withCredentials()
+            ->withToken($headerToken)
+            ->withUnencryptedCookie(AuthTokenCookie::NAME, $cookieToken)
+            ->getJson('/api/v1/user')
+            ->assertOk()
+            ->assertJsonPath('data.email', 'header@example.com');
+    }
+
+    public function test_rejects_a_garbage_cookie_value(): void
+    {
+        User::factory()->create();
+
+        $this->withCredentials()
+            ->withUnencryptedCookie(AuthTokenCookie::NAME, 'not-a-jwt')
+            ->getJson('/api/v1/user')
+            ->assertStatus(401);
+    }
+
+    public function test_logout_expires_the_cookie_and_rejects_the_replayed_token(): void
+    {
+        User::factory()->create([
+            'email' => 'user@example.com',
+            'password' => 'secret123',
+        ]);
+
+        $token = $this->loginAndReadTokenCookie('user@example.com', 'secret123');
+
+        $this->withCredentials()
+            ->withUnencryptedCookie(AuthTokenCookie::NAME, $token)
+            ->postJson('/api/v1/logout')
+            ->assertNoContent()
+            ->assertCookieExpired(AuthTokenCookie::NAME);
+
+        // In-process test requests share one guard instance; drop it when
+        // re-presenting the same token the way a real per-request process would.
+        $this->app['auth']->forgetGuards();
+
+        $this->withCredentials()
+            ->withUnencryptedCookie(AuthTokenCookie::NAME, $token)
+            ->getJson('/api/v1/user')
+            ->assertStatus(401);
+    }
+}

--- a/tests/Feature/Api/V1/Auth/LoginTest.php
+++ b/tests/Feature/Api/V1/Auth/LoginTest.php
@@ -20,7 +20,7 @@ class LoginTest extends TestCase
         $this->setUpPassport();
     }
 
-    public function test_logs_in_with_valid_credentials(): void
+    public function test_logs_in_with_valid_credentials_and_sets_the_token_cookie(): void
     {
         User::factory()->create([
             'email' => 'user@example.com',
@@ -33,7 +33,10 @@ class LoginTest extends TestCase
         ]);
 
         $response->assertOk()
-            ->assertJsonStructure(['user', 'token']);
+            ->assertJsonStructure(['user'])
+            ->assertJsonMissingPath('token');
+
+        $this->assertIssuesAuthTokenCookie($response);
     }
 
     public function test_rejects_wrong_password(): void

--- a/tests/Feature/Api/V1/Auth/LogoutTest.php
+++ b/tests/Feature/Api/V1/Auth/LogoutTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature\Api\V1\Auth;
 
 use App\Models\User;
+use App\Services\AuthTokenCookie;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Passport\Passport;
 use Tests\TestCase;
@@ -13,12 +14,14 @@ class LogoutTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_revokes_current_token(): void
+    public function test_revokes_current_token_and_expires_the_cookie(): void
     {
         $user = User::factory()->create();
         Passport::actingAs($user);
 
-        $this->postJson('/api/v1/logout')->assertNoContent();
+        $this->postJson('/api/v1/logout')
+            ->assertNoContent()
+            ->assertCookieExpired(AuthTokenCookie::NAME);
     }
 
     public function test_rejects_unauthenticated_request(): void

--- a/tests/Feature/Api/V1/Auth/RegisterTest.php
+++ b/tests/Feature/Api/V1/Auth/RegisterTest.php
@@ -39,15 +39,17 @@ class RegisterTest extends TestCase
         ], $overrides);
     }
 
-    public function test_registers_user_and_returns_token(): void
+    public function test_registers_user_and_sets_the_token_cookie(): void
     {
         $response = $this->postJson('/api/v1/register', $this->validPayload());
 
         $response->assertStatus(201)
             ->assertJsonStructure([
                 'user' => ['id', 'email', 'first_name', 'last_name', 'measurement_system', 'theme'],
-                'token',
-            ]);
+            ])
+            ->assertJsonMissingPath('token');
+
+        $this->assertIssuesAuthTokenCookie($response);
 
         $this->assertDatabaseHas('users', [
             'email' => 'new@example.com',

--- a/tests/Feature/Api/V1/Auth/TokenRevocationTest.php
+++ b/tests/Feature/Api/V1/Auth/TokenRevocationTest.php
@@ -92,9 +92,6 @@ class TokenRevocationTest extends TestCase
 
     private function login(User $user): string
     {
-        return $this->postJson('/api/v1/login', [
-            'email' => $user->email,
-            'password' => 'secret123',
-        ])->json('token');
+        return $this->loginAndReadTokenCookie($user->email, 'secret123');
     }
 }

--- a/tests/Unit/Services/AuthTokenCookieTest.php
+++ b/tests/Unit/Services/AuthTokenCookieTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services;
+
+use App\Services\AuthTokenCookie;
+use Illuminate\Support\Carbon;
+use Symfony\Component\HttpFoundation\Cookie;
+use Tests\TestCase;
+
+class AuthTokenCookieTest extends TestCase
+{
+    public function test_issue_builds_a_hardened_api_scoped_cookie(): void
+    {
+        $expiresAt = Carbon::parse('2026-08-02 12:00:00', 'UTC');
+
+        $cookie = AuthTokenCookie::issue('jwt-value', $expiresAt);
+
+        $this->assertSame('ps_token', $cookie->getName());
+        $this->assertSame('jwt-value', $cookie->getValue());
+        $this->assertSame($expiresAt->getTimestamp(), $cookie->getExpiresTime());
+        $this->assertSame('/api/v1', $cookie->getPath());
+        $this->assertTrue($cookie->isHttpOnly());
+        $this->assertTrue($cookie->isSecure());
+        $this->assertSame(Cookie::SAMESITE_LAX, $cookie->getSameSite());
+    }
+
+    public function test_expire_builds_an_expired_cookie_on_the_same_name_and_path(): void
+    {
+        $cookie = AuthTokenCookie::expire();
+
+        $this->assertSame('ps_token', $cookie->getName());
+        $this->assertSame('/api/v1', $cookie->getPath());
+        $this->assertLessThan(time(), $cookie->getExpiresTime());
+        $this->assertTrue($cookie->isHttpOnly());
+        $this->assertTrue($cookie->isSecure());
+        $this->assertSame(Cookie::SAMESITE_LAX, $cookie->getSameSite());
+    }
+}


### PR DESCRIPTION
## Problem

Login and register returned the API token in the JSON response body, and the React app stored it in localStorage and replayed it as a Bearer header. localStorage is readable by any script on the page, so a single XSS could exfiltrate a token that stays valid for 30 days. The auth ADR had already chosen HTTP-only cookie delivery for web clients; the implementation never caught up.

## Solution

The token now travels only in an HTTP-only cookie.

- `App\Services\AuthTokenCookie` builds the `ps_token` cookie in one place: HttpOnly, Secure, SameSite=Lax, path `/api/v1`, expiring with the token. `App\Http\Responses\AuthTokenResponse` builds the login and register responses, so the JSON body carries only the user.
- `App\Http\Middleware\AuthenticateViaTokenCookie`, prepended to the api middleware group, copies the cookie into the Authorization header when no such header is present. A caller-supplied header always wins, so bearer clients like curl and a future mobile app work unchanged and Passport needed no changes.
- Logout attaches an expired cookie on top of the existing JTI blacklist revocation, and a replayed cookie value is rejected.
- The React app no longer touches localStorage. It learns auth state from a `GET /user` probe at boot, and an in-memory flag tells the 401 interceptor whether to redirect to login (dead session) or stay put (guest). The auth page tests now assert the post-login redirect, and the MSW auth fixtures were recaptured from the running API since the responses lost their token field.
- The auth ADR records the SameSite and Secure decision and defers body delivery for mobile until a mobile client exists.
