### PR TITLE
PS-114 - Throttling the register and password-reset endpoints with a named rate limiter

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -8,7 +8,10 @@ use App\Notifications\WelcomeNotification;
 use DateInterval;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Passport\Passport;
 
@@ -31,5 +34,7 @@ class AppServiceProvider extends ServiceProvider
         ResetPassword::createUrlUsing(function (mixed $notifiable, string $token): string {
             return config('app.url').'/password/reset/'.$token.'?email='.urlencode($notifiable->getEmailForPasswordReset());
         });
+
+        RateLimiter::for('auth', fn (Request $request) => Limit::perMinute(5)->by($request->ip()));
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -23,10 +23,11 @@ use Illuminate\Support\Facades\Route;
 
 Route::get('/health', fn () => response()->json(['status' => 'ok']));
 
-Route::post('/register', RegisterController::class);
+// Login and forgot-password rate-limit in the controller (incremented on failure, reset on success) to allow legitimate retries; register and password reset use global middleware limits.
+Route::post('/register', RegisterController::class)->middleware('throttle:auth');
 Route::post('/login', LoginController::class);
 Route::post('/password/forgot', ForgotPasswordController::class);
-Route::post('/password/reset', ResetPasswordController::class);
+Route::post('/password/reset', ResetPasswordController::class)->middleware('throttle:auth');
 
 Route::middleware(['auth:api', RejectBlacklistedTokens::class])->group(function () {
     Route::post('/logout', LogoutController::class);

--- a/tests/Feature/Api/V1/Auth/PasswordResetTest.php
+++ b/tests/Feature/Api/V1/Auth/PasswordResetTest.php
@@ -105,4 +105,13 @@ class PasswordResetTest extends TestCase
                 && str_contains($url, 'email=user%40example.com');
         });
     }
+
+    public function test_reset_is_rate_limited(): void
+    {
+        for ($i = 0; $i < 5; $i++) {
+            $this->postJson('/api/v1/password/reset', []);
+        }
+
+        $this->postJson('/api/v1/password/reset', [])->assertStatus(429);
+    }
 }

--- a/tests/Feature/Api/V1/Auth/RegisterTest.php
+++ b/tests/Feature/Api/V1/Auth/RegisterTest.php
@@ -134,4 +134,13 @@ class RegisterTest extends TestCase
         $user = User::where('email', 'new@example.com')->first();
         Notification::assertSentTo($user, WelcomeNotification::class);
     }
+
+    public function test_register_is_rate_limited(): void
+    {
+        for ($i = 0; $i < 5; $i++) {
+            $this->postJson('/api/v1/register', []);
+        }
+
+        $this->postJson('/api/v1/register', [])->assertStatus(429);
+    }
 }


### PR DESCRIPTION
## Problem

Two of the four unauthenticated auth endpoints had no rate limiting. Login and forgot-password throttle themselves in their controllers, but register and password reset accepted unlimited requests: nothing slowed reset-token guessing, and open registration invited junk accounts and mail-queue abuse since every registration queues a welcome notification.

## Solution

- Registered a named `auth` rate limiter in `AppServiceProvider::boot()`: 5 requests per minute per IP, matching the existing login limit.
- Applied `throttle:auth` middleware to `POST /register` and `POST /password/reset` in `routes/api.php`. Requests past the limit get Laravel's standard 429 response.
- Login and forgot-password keep their in-controller guards, which count failures and reset on success to allow legitimate retries; a comment in the routes file explains why the two styles coexist.
- Added throttle coverage for both endpoints in `RegisterTest` and `PasswordResetTest`.
