### PR TITLE
PS-129 - Mounting the Toaster and differentiating success and error toast variants

### DIFF
--- a/resources/js/components/ui/toaster.tsx
+++ b/resources/js/components/ui/toaster.tsx
@@ -1,17 +1,14 @@
 import { useApp } from '@/lib/use-app'
-import { Check } from 'lucide-react'
-
-export interface Toast {
-  id: string
-  message: string
-}
+import { AlertCircle, Check } from 'lucide-react'
 
 export function Toaster() {
   const { toasts } = useApp()
 
   return (
     <div
-      className="fixed left-1/2 -translate-x-1/2 z-[60] flex flex-col items-center gap-2"
+      role="status"
+      aria-live="polite"
+      className="pointer-events-none fixed left-1/2 -translate-x-1/2 z-[60] flex flex-col items-center gap-2"
       style={{ bottom: 'calc(env(safe-area-inset-bottom, 0px) + 84px)' }}
     >
       {toasts.map(t => (
@@ -20,7 +17,11 @@ export function Toaster() {
           className="ps-page ps-card px-4 py-2.5 text-sm font-medium flex items-center gap-2"
           style={{ boxShadow: '0 6px 20px rgba(0,0,0,.16)' }}
         >
-          <Check size={16} className="text-success" />
+          {t.variant === 'error' ? (
+            <AlertCircle size={16} className="text-destructive" />
+          ) : (
+            <Check size={16} className="text-success" />
+          )}
           {t.message}
         </div>
       ))}

--- a/resources/js/lib/app-context.ts
+++ b/resources/js/lib/app-context.ts
@@ -1,13 +1,16 @@
 import { createContext } from 'react'
 
-interface Toast {
+export type ToastVariant = 'success' | 'error'
+
+export interface Toast {
   id: string
   message: string
+  variant: ToastVariant
 }
 
 export interface AppContextValue {
   toasts: Toast[]
-  toast: (message: string) => void
+  toast: (message: string, variant?: ToastVariant) => void
 }
 
 export const AppContext = createContext<AppContextValue | null>(null)

--- a/resources/js/lib/store.tsx
+++ b/resources/js/lib/store.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState, type ReactNode } from 'react'
-import { AppContext, type AppContextValue } from './app-context'
+import { AppContext, type AppContextValue, type ToastVariant } from './app-context'
+import { Toaster } from '@/components/ui/toaster'
 
 let _id = 1000
 function uid(p: string): string {
@@ -9,18 +10,27 @@ function uid(p: string): string {
 interface Toast {
   id: string
   message: string
+  variant: ToastVariant
 }
+
+// Errors linger longer than confirmations so the failure is readable.
+const TOAST_MS: Record<ToastVariant, number> = { success: 2400, error: 4000 }
 
 export function AppProvider({ children }: { children: ReactNode }) {
   const [toasts, setToasts] = useState<Toast[]>([])
 
-  const toast = useCallback((message: string) => {
+  const toast = useCallback((message: string, variant: ToastVariant = 'success') => {
     const id = uid('toast')
-    setToasts(t => [...t, { id, message }])
-    setTimeout(() => setToasts(t => t.filter(x => x.id !== id)), 2400)
+    setToasts(t => [...t, { id, message, variant }])
+    setTimeout(() => setToasts(t => t.filter(x => x.id !== id)), TOAST_MS[variant])
   }, [])
 
   const value: AppContextValue = { toasts, toast }
 
-  return <AppContext.Provider value={value}>{children}</AppContext.Provider>
+  return (
+    <AppContext.Provider value={value}>
+      {children}
+      <Toaster />
+    </AppContext.Provider>
+  )
 }

--- a/resources/js/pages/equipment.tsx
+++ b/resources/js/pages/equipment.tsx
@@ -37,9 +37,9 @@ export function EquipmentPage() {
     },
     onError: error => {
       if (isAxiosError(error) && error.response?.status === 409) {
-        toast(error.response.data?.message ?? 'Equipment is in use.')
+        toast(error.response.data?.message ?? 'Equipment is in use.', 'error')
       } else {
-        toast('Could not delete. Try again.')
+        toast('Could not delete. Try again.', 'error')
       }
     },
   })

--- a/resources/js/pages/exercise-detail.tsx
+++ b/resources/js/pages/exercise-detail.tsx
@@ -60,7 +60,7 @@ export function ExerciseDetailPage() {
       toast('Exercise updated.')
     },
     onError: () => {
-      toast('Could not update. Try again.')
+      toast('Could not update. Try again.', 'error')
     },
   })
 
@@ -76,9 +76,9 @@ export function ExerciseDetailPage() {
     },
     onError: error => {
       if (isAxiosError(error) && error.response?.status === 409) {
-        toast(error.response.data?.message ?? 'Exercise is in use.')
+        toast(error.response.data?.message ?? 'Exercise is in use.', 'error')
       } else {
-        toast('Could not delete. Try again.')
+        toast('Could not delete. Try again.', 'error')
       }
     },
   })

--- a/resources/js/pages/exercises.test.tsx
+++ b/resources/js/pages/exercises.test.tsx
@@ -11,10 +11,8 @@ describe('ExercisesPage', () => {
     it('displays exercises from the fixture with correct count in subtitle', async () => {
       renderWithProviders(<ExercisesPage />)
 
-      // Wait for an exercise from the fixture to appear
       await screen.findByText('3/4 Sit-Up')
 
-      // Assert subtitle shows the count
       const exerciseCount = fixtureList.data.length
       expect(screen.getByText(`${exerciseCount} in your catalog`)).toBeInTheDocument()
     })
@@ -56,27 +54,21 @@ describe('ExercisesPage', () => {
 
       renderWithProviders(<ExercisesPage />)
 
-      // Wait for exercises to load
       await screen.findByText('3/4 Sit-Up')
 
-      // Click the Create button (in PageHeader)
       const createButton = screen.getByRole('button', { name: 'Create' })
       await user.click(createButton)
 
-      // Type in the name input
       const nameInput = screen.getByLabelText('Name')
       await user.type(nameInput, 'Incline Press')
 
-      // Click Create Exercise button (in Sheet footer)
       const createExerciseButton = screen.getByRole('button', { name: 'Create Exercise' })
       await user.click(createExerciseButton)
 
-      // Wait for the payload to be captured
       await waitFor(() => {
         expect(capturedPayload).toBeTruthy()
       })
 
-      // Verify the payload
       expect(capturedPayload).toEqual({
         name: 'Incline Press',
         type: 'resistance',
@@ -88,6 +80,8 @@ describe('ExercisesPage', () => {
           bilateral: true,
         },
       })
+
+      expect(await screen.findByText('Exercise created.')).toBeInTheDocument()
     }, 15000)
   })
 
@@ -131,17 +125,13 @@ describe('ExercisesPage', () => {
 
       renderWithProviders(<ExercisesPage />)
 
-      // Wait for exercises to load
       await screen.findByText('3/4 Sit-Up')
-
-      // Wait for the user exercise to appear
       await screen.findByText('Test User Exercise')
 
-      // Click the delete button for the user exercise
       const deleteButton = screen.getByLabelText('Delete Test User Exercise')
       await user.click(deleteButton)
 
-      // Confirm the deletion in the dialog - wait for the dialog to appear first
+      // The confirm dialog reuses the "Delete" label, so target the last one.
       const confirmButtons = screen.getAllByRole('button', { name: 'Delete' })
       const dialogConfirmButton = confirmButtons[confirmButtons.length - 1]
       expect(dialogConfirmButton).toBeDefined()
@@ -149,14 +139,11 @@ describe('ExercisesPage', () => {
         await user.click(dialogConfirmButton)
       }
 
-      // Wait for the delete mutation to be called with 409 response
       await waitFor(() => {
         expect(deleteCalled).toBe(true)
       })
 
-      // The error handler in ExercisesPage shows the error message from the 409 response in a toast
-      // The toast appears briefly and disappears after 2400ms, so we verify the mutation was called
-      // which confirms the error flow works correctly
+      expect(await screen.findByText('Exercise is in use by 2 workout(s).')).toBeInTheDocument()
     }, 15000)
   })
 })

--- a/resources/js/pages/exercises.tsx
+++ b/resources/js/pages/exercises.tsx
@@ -70,7 +70,7 @@ function CreateExerciseSheet({ onClose }: { onClose: () => void }) {
           return
         }
       }
-      toast('Could not create exercise. Try again.')
+      toast('Could not create exercise. Try again.', 'error')
     },
   })
 
@@ -313,9 +313,9 @@ export function ExercisesPage() {
     },
     onError: error => {
       if (isAxiosError(error) && error.response?.status === 409) {
-        toast(error.response.data?.message ?? 'Exercise is in use.')
+        toast(error.response.data?.message ?? 'Exercise is in use.', 'error')
       } else {
-        toast('Could not delete. Try again.')
+        toast('Could not delete. Try again.', 'error')
       }
     },
   })

--- a/resources/js/pages/profile.test.tsx
+++ b/resources/js/pages/profile.test.tsx
@@ -71,10 +71,8 @@ describe('ProfilePage', () => {
 
       await user.click(saveButton)
 
-      // Wait for the request to be captured
       await new Promise(resolve => setTimeout(resolve, 100))
 
-      // Verify the update payload was sent correctly
       expect(updatePayload).toEqual({
         first_name: 'Claude',
         last_name: 'Ai',
@@ -96,10 +94,10 @@ describe('ProfilePage', () => {
       const saveButton = screen.getByRole('button', { name: /save changes/i })
       await user.click(saveButton)
 
-      // The page doesn't display the error message inline; instead it shows a toast
-      // Since we can't verify the toast in unit tests without rendering the Toaster component,
-      // we verify that the error response was handled by checking that the UI didn't change
-      // and the save was attempted
+      // The 422 field error surfaces through the toast, not inline.
+      expect(
+        await screen.findByText('The email field must be a valid email address.')
+      ).toBeInTheDocument()
       expect(emailInput.value).toBe('invalid@sentinel.test')
     })
   })

--- a/resources/js/pages/profile.tsx
+++ b/resources/js/pages/profile.tsx
@@ -56,9 +56,9 @@ export function ProfilePage() {
       if (isAxiosError(err) && err.response?.status === 422) {
         const fieldErrors = err.response.data?.errors as Record<string, string[]> | undefined
         const msg = fieldErrors ? Object.values(fieldErrors).flat()[0] : 'Could not save.'
-        toast(msg ?? 'Could not save.')
+        toast(msg ?? 'Could not save.', 'error')
       } else {
-        toast('Could not save. Try again.')
+        toast('Could not save. Try again.', 'error')
       }
     } finally {
       setSaving(false)
@@ -100,7 +100,7 @@ export function ProfilePage() {
       setUser(updated)
       toast(field === 'theme' ? 'Theme updated.' : 'Measurement system updated.')
     } catch {
-      toast('Could not save preference. Try again.')
+      toast('Could not save preference. Try again.', 'error')
     }
   }
 

--- a/resources/js/pages/template-editor.tsx
+++ b/resources/js/pages/template-editor.tsx
@@ -147,7 +147,7 @@ export function TemplateEditorPage() {
       setSelected([])
       toast('Group created.')
     },
-    onError: () => toast('Could not create group. Try again.'),
+    onError: () => toast('Could not create group. Try again.', 'error'),
   })
 
   const ungroupMutation = useMutation({
@@ -156,7 +156,7 @@ export function TemplateEditorPage() {
       queryClient.invalidateQueries({ queryKey: ['templates', templateId] })
       toast('Group removed.')
     },
-    onError: () => toast('Could not ungroup. Try again.'),
+    onError: () => toast('Could not ungroup. Try again.', 'error'),
   })
 
   if (!templateId) {

--- a/resources/js/pages/templates.tsx
+++ b/resources/js/pages/templates.tsx
@@ -30,7 +30,7 @@ export function TemplatesPage() {
       toast('Template created.')
       navigate(`/templates/${tpl.id}`)
     },
-    onError: () => toast('Could not create template. Try again.'),
+    onError: () => toast('Could not create template. Try again.', 'error'),
   })
 
   const deleteMutation = useMutation({
@@ -39,7 +39,7 @@ export function TemplatesPage() {
       queryClient.invalidateQueries({ queryKey: ['templates'] })
       toast('Template deleted.')
     },
-    onError: () => toast('Could not delete template. Try again.'),
+    onError: () => toast('Could not delete template. Try again.', 'error'),
   })
 
   if (isLoading) {

--- a/resources/js/pages/workout-detail.tsx
+++ b/resources/js/pages/workout-detail.tsx
@@ -300,7 +300,7 @@ export function WorkoutDetailPage() {
     onSuccess: data => {
       queryClient.setQueryData(['workouts', workoutId], data)
     },
-    onError: () => toast('Could not save. Try again.'),
+    onError: () => toast('Could not save. Try again.', 'error'),
   })
 
   const deleteWorkoutMutation = useMutation({
@@ -310,7 +310,7 @@ export function WorkoutDetailPage() {
       toast('Workout deleted.')
       navigate('/workouts')
     },
-    onError: () => toast('Could not delete. Try again.'),
+    onError: () => toast('Could not delete. Try again.', 'error'),
   })
 
   const attachExerciseMutation = useMutation({
@@ -323,7 +323,7 @@ export function WorkoutDetailPage() {
       invalidateWorkout()
       toast('Exercise added.')
     },
-    onError: () => toast('Could not add exercise. Try again.'),
+    onError: () => toast('Could not add exercise. Try again.', 'error'),
   })
 
   const reorderExercisesMutation = useMutation({
@@ -336,7 +336,7 @@ export function WorkoutDetailPage() {
   const addSetMutation = useMutation({
     mutationFn: (payload: CreateEntryPayload) => createEntry(workoutId, payload),
     onSuccess: invalidateWorkout,
-    onError: () => toast('Could not add set. Try again.'),
+    onError: () => toast('Could not add set. Try again.', 'error'),
   })
 
   const deleteEntryMutation = useMutation({
@@ -347,7 +347,7 @@ export function WorkoutDetailPage() {
         return { ...old, entries: old.entries.filter(e => e.id !== entryId) }
       })
     },
-    onError: () => toast('Could not remove set. Try again.'),
+    onError: () => toast('Could not remove set. Try again.', 'error'),
   })
 
   const updateEntryMutation = useMutation({
@@ -408,7 +408,7 @@ export function WorkoutDetailPage() {
       setSelected([])
       toast('Group created.')
     },
-    onError: () => toast('Could not create group. Try again.'),
+    onError: () => toast('Could not create group. Try again.', 'error'),
   })
 
   const ungroupMutation = useMutation({
@@ -417,7 +417,7 @@ export function WorkoutDetailPage() {
       invalidateWorkout()
       toast('Group removed.')
     },
-    onError: () => toast('Could not ungroup. Try again.'),
+    onError: () => toast('Could not ungroup. Try again.', 'error'),
   })
 
   const debouncedEntryUpdate = useCallback(

--- a/resources/js/pages/workouts.tsx
+++ b/resources/js/pages/workouts.tsx
@@ -81,7 +81,7 @@ export function WorkoutsPage() {
       toast('Workout started.')
       navigate(`/workouts/${workout.id}`)
     },
-    onError: () => toast('Could not create workout. Try again.'),
+    onError: () => toast('Could not create workout. Try again.', 'error'),
   })
 
   const startEmpty = ({ name, date }: { name: string; date: string }) => {


### PR DESCRIPTION
## Problem

The `Toaster` component was exported from the ui barrel but never mounted anywhere. `AppProvider` managed the toast queue and every page called `toast()` on success and error, but nothing rendered the toasts, so they expired after their timeout without ever appearing. Every toast in the app was a silent no-op: no "Exercise added" confirmation, no "Could not..." error feedback, across all 8 pages that use it.

This surfaced while testing a duplicate exercise attach. The API correctly returned 409, the error handler ran, but no message reached the screen because there was no Toaster to render it.

## Solution

Mount `<Toaster />` once inside `AppProvider`, so it covers the app and the test harness in one place and cannot be dropped again.

Add a `variant` of `success` or `error` to the toast payload. Success renders a green check and lasts 2.4s; error renders a red alert icon and lasts 4s so the failure is readable. The error variant was threaded through the error call sites across the pages. The toast container is now `pointer-events-none` with `role="status"` and `aria-live="polite"`, so it does not intercept taps and screen readers announce it.

The exercise create, exercise delete, and profile validation tests now assert the toast text, which they previously could not because nothing rendered it.
