### PR TITLE
PS-106 - Consolidating exercise validation, visibility, usage, and CTI child handling into single owned definitions

### DIFF
--- a/app/Enums/ExerciseType.php
+++ b/app/Enums/ExerciseType.php
@@ -39,4 +39,21 @@ enum ExerciseType: string
 
         return [...$this->requiredMetrics(), ...$optional];
     }
+
+    /** The CTI child relation name on the Exercise model. */
+    public function childRelation(): string
+    {
+        return match ($this) {
+            self::Resistance => 'resistance',
+            self::TimedHold => 'timedHold',
+            self::Distance => 'distance',
+            self::Interval => 'interval',
+        };
+    }
+
+    /** @return list<string> */
+    public static function childRelations(): array
+    {
+        return array_map(fn (self $type) => $type->childRelation(), self::cases());
+    }
 }

--- a/app/Http/Controllers/Api/V1/EquipmentTypeController.php
+++ b/app/Http/Controllers/Api/V1/EquipmentTypeController.php
@@ -23,10 +23,7 @@ class EquipmentTypeController extends Controller
     public function index(Request $request): AnonymousResourceCollection
     {
         $types = EquipmentType::withCount('exercises as usage_count')
-            ->where(function ($q) use ($request) {
-                $q->where('is_system', true)
-                    ->orWhere('user_id', $request->user()->id);
-            })
+            ->visibleTo($request->user())
             ->orderBy('name')
             ->get();
 

--- a/app/Http/Controllers/Api/V1/ExerciseController.php
+++ b/app/Http/Controllers/Api/V1/ExerciseController.php
@@ -10,25 +10,28 @@ use App\Http\Requests\Api\V1\StoreExerciseRequest;
 use App\Http\Requests\Api\V1\UpdateExerciseRequest;
 use App\Http\Resources\Api\V1\ExerciseResource;
 use App\Models\Exercise;
+use App\Repositories\ExerciseRepository;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Response;
-use Illuminate\Support\Facades\DB;
 
 class ExerciseController extends Controller
 {
     use AuthorizesRequests;
 
-    private const EAGER_LOAD = ['resistance', 'timedHold', 'distance', 'interval', 'equipmentType'];
+    public function __construct(private ExerciseRepository $exercises) {}
+
+    /** @return list<string> */
+    private function eagerLoad(): array
+    {
+        return [...ExerciseType::childRelations(), 'equipmentType'];
+    }
 
     public function index(Request $request): AnonymousResourceCollection
     {
-        $query = Exercise::where(function ($q) use ($request) {
-            $q->whereNull('user_id')
-                ->orWhere('user_id', $request->user()->id);
-        });
+        $query = Exercise::visibleTo($request->user())->withUsage();
 
         if ($request->has('type')) {
             $query->where('type', $request->input('type'));
@@ -42,72 +45,16 @@ class ExerciseController extends Controller
             $query->where('name', 'like', '%'.$request->input('search').'%');
         }
 
-        $exercises = $query
-            ->with(self::EAGER_LOAD)
-            ->orderBy('name')
-            ->get();
-
-        $exerciseIds = $exercises->pluck('id');
-
-        $workoutUsage = DB::table('exercise_workout')
-            ->whereIn('exercise_id', $exerciseIds)
-            ->selectRaw('exercise_id, count(*) as cnt')
-            ->groupBy('exercise_id')
-            ->pluck('cnt', 'exercise_id');
-
-        $templateUsage = DB::table('template_exercises')
-            ->whereIn('exercise_id', $exerciseIds)
-            ->selectRaw('exercise_id, count(*) as cnt')
-            ->groupBy('exercise_id')
-            ->pluck('cnt', 'exercise_id');
-
-        $exercisesWithEntries = DB::table('workout_entries')
-            ->whereIn('exercise_id', $exerciseIds)
-            ->distinct()
-            ->pluck('exercise_id');
-
-        $exercises->each(function (Exercise $exercise) use ($workoutUsage, $templateUsage, $exercisesWithEntries) {
-            $exercise->setAttribute(
-                'usage_count',
-                ($workoutUsage[$exercise->id] ?? 0) + ($templateUsage[$exercise->id] ?? 0)
-            );
-            $exercise->setAttribute(
-                'has_logged_data',
-                $exercisesWithEntries->contains($exercise->id)
-            );
-        });
-
-        return ExerciseResource::collection($exercises);
+        return ExerciseResource::collection(
+            $query->with($this->eagerLoad())->orderBy('name')->get()
+        );
     }
 
     public function store(StoreExerciseRequest $request): JsonResponse
     {
-        $exercise = DB::transaction(function () use ($request) {
-            $exercise = Exercise::create([
-                'name' => $request->validated('name'),
-                'type' => $request->validated('type'),
-                'user_id' => $request->user()->id,
-                'equipment_type_id' => $request->validated('equipment_type_id'),
-                'notes' => $request->validated('notes'),
-            ]);
+        $exercise = $this->exercises->create($request->user(), $request->validated());
 
-            $typeAttributes = $request->validated('type_attributes') ?? [];
-
-            $childRelation = match ($exercise->type) {
-                ExerciseType::Resistance => 'resistance',
-                ExerciseType::TimedHold => 'timedHold',
-                ExerciseType::Distance => 'distance',
-                ExerciseType::Interval => 'interval',
-            };
-
-            $exercise->$childRelation()->create($typeAttributes);
-
-            return $exercise;
-        });
-
-        $exercise->load(self::EAGER_LOAD);
-
-        return (new ExerciseResource($exercise))
+        return (new ExerciseResource($exercise->load($this->eagerLoad())))
             ->response()
             ->setStatusCode(201);
     }
@@ -116,11 +63,9 @@ class ExerciseController extends Controller
     {
         $this->authorize('view', $exercise);
 
-        $exercise->load(self::EAGER_LOAD);
-
-        $usageCount = DB::table('exercise_workout')->where('exercise_id', $exercise->id)->count()
-            + DB::table('template_exercises')->where('exercise_id', $exercise->id)->count();
-        $exercise->setAttribute('usage_count', $usageCount);
+        $exercise->load($this->eagerLoad())
+            ->loadCount(['workouts', 'templates'])
+            ->loadExists(['entries as has_logged_data']);
 
         return new ExerciseResource($exercise);
     }
@@ -129,35 +74,16 @@ class ExerciseController extends Controller
     {
         $this->authorize('update', $exercise);
 
-        DB::transaction(function () use ($request, $exercise) {
-            $exercise->update($request->safe()->only(['name', 'equipment_type_id', 'notes']));
+        $this->exercises->update($exercise, $request->validated());
 
-            $validated = $request->validated();
-            if (isset($validated['type_attributes'])) {
-                $childRelation = match ($exercise->type) {
-                    ExerciseType::Resistance => 'resistance',
-                    ExerciseType::TimedHold => 'timedHold',
-                    ExerciseType::Distance => 'distance',
-                    ExerciseType::Interval => 'interval',
-                };
-                $exercise->$childRelation->update($validated['type_attributes']);
-            }
-        });
-
-        $exercise->load(self::EAGER_LOAD);
-
-        return new ExerciseResource($exercise);
+        return new ExerciseResource($exercise->load($this->eagerLoad()));
     }
 
     public function destroy(Exercise $exercise): Response|JsonResponse
     {
         $this->authorize('delete', $exercise);
 
-        $inUse = DB::table('exercise_workout')->where('exercise_id', $exercise->id)->exists()
-            || DB::table('workout_entries')->where('exercise_id', $exercise->id)->exists()
-            || DB::table('template_exercises')->where('exercise_id', $exercise->id)->exists();
-
-        if ($inUse) {
+        if ($exercise->isInUse()) {
             return response()->json([
                 'message' => 'Exercise is in use by workouts or templates.',
             ], 409);

--- a/app/Http/Requests/Api/V1/AttachExerciseRequest.php
+++ b/app/Http/Requests/Api/V1/AttachExerciseRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Requests\Api\V1;
 
+use App\Models\Exercise;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -15,10 +16,7 @@ class AttachExerciseRequest extends FormRequest
         return [
             'exercise_id' => [
                 'required',
-                Rule::exists('exercises', 'id')->where(function ($query) {
-                    $query->whereNull('user_id')
-                        ->orWhere('user_id', $this->user()->id);
-                }),
+                Rule::exists('exercises', 'id')->where(Exercise::visibilityConstraint($this->user())),
             ],
         ];
     }

--- a/app/Http/Requests/Api/V1/Concerns/ValidatesExerciseAttributes.php
+++ b/app/Http/Requests/Api/V1/Concerns/ValidatesExerciseAttributes.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1\Concerns;
+
+use App\Enums\ExerciseType;
+use App\Models\EquipmentType;
+use Illuminate\Validation\Rule;
+
+trait ValidatesExerciseAttributes
+{
+    /** @return array<int, mixed> */
+    protected function equipmentTypeRule(): array
+    {
+        return [
+            'nullable',
+            'integer',
+            Rule::exists('equipment_types', 'id')->where(EquipmentType::visibilityConstraint($this->user())),
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    protected function typeRulesFor(?ExerciseType $type): array
+    {
+        return match ($type) {
+            ExerciseType::Resistance => [
+                'type_attributes.bodyweight_base' => ['boolean'],
+                'type_attributes.allows_added_weight' => ['boolean'],
+                'type_attributes.bilateral' => ['boolean'],
+            ],
+            ExerciseType::TimedHold => [
+                'type_attributes.target_duration_seconds' => ['nullable', 'integer', 'min:1'],
+            ],
+            ExerciseType::Distance => [
+                'type_attributes.tracks_elevation' => ['boolean'],
+            ],
+            ExerciseType::Interval => [
+                'type_attributes.default_work_seconds' => ['nullable', 'integer', 'min:1'],
+                'type_attributes.default_rest_seconds' => ['nullable', 'integer', 'min:1'],
+                'type_attributes.default_rounds' => ['nullable', 'integer', 'min:1'],
+            ],
+            null => [],
+        };
+    }
+}

--- a/app/Http/Requests/Api/V1/StoreExerciseRequest.php
+++ b/app/Http/Requests/Api/V1/StoreExerciseRequest.php
@@ -5,15 +5,18 @@ declare(strict_types=1);
 namespace App\Http\Requests\Api\V1;
 
 use App\Enums\ExerciseType;
+use App\Http\Requests\Api\V1\Concerns\ValidatesExerciseAttributes;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
 class StoreExerciseRequest extends FormRequest
 {
+    use ValidatesExerciseAttributes;
+
     /** @return array<string, mixed> */
     public function rules(): array
     {
-        $rules = [
+        return array_merge([
             'name' => [
                 'required',
                 'string',
@@ -21,42 +24,9 @@ class StoreExerciseRequest extends FormRequest
                 Rule::unique('exercises')->where('user_id', $this->user()->id),
             ],
             'type' => ['required', Rule::enum(ExerciseType::class)],
-            'equipment_type_id' => [
-                'nullable',
-                'integer',
-                Rule::exists('equipment_types', 'id')->where(function ($query) {
-                    $query->where('is_system', true)
-                        ->orWhere('user_id', $this->user()->id);
-                }),
-            ],
+            'equipment_type_id' => $this->equipmentTypeRule(),
             'notes' => ['nullable', 'string'],
             'type_attributes' => ['sometimes', 'array'],
-        ];
-
-        return array_merge($rules, $this->typeSpecificRules());
-    }
-
-    /** @return array<string, mixed> */
-    private function typeSpecificRules(): array
-    {
-        return match ($this->input('type')) {
-            'resistance' => [
-                'type_attributes.bodyweight_base' => ['boolean'],
-                'type_attributes.allows_added_weight' => ['boolean'],
-                'type_attributes.bilateral' => ['boolean'],
-            ],
-            'timed_hold' => [
-                'type_attributes.target_duration_seconds' => ['nullable', 'integer', 'min:1'],
-            ],
-            'distance' => [
-                'type_attributes.tracks_elevation' => ['boolean'],
-            ],
-            'interval' => [
-                'type_attributes.default_work_seconds' => ['nullable', 'integer', 'min:1'],
-                'type_attributes.default_rest_seconds' => ['nullable', 'integer', 'min:1'],
-                'type_attributes.default_rounds' => ['nullable', 'integer', 'min:1'],
-            ],
-            default => [],
-        };
+        ], $this->typeRulesFor(ExerciseType::tryFrom((string) $this->input('type'))));
     }
 }

--- a/app/Http/Requests/Api/V1/StoreWorkoutEntryRequest.php
+++ b/app/Http/Requests/Api/V1/StoreWorkoutEntryRequest.php
@@ -20,10 +20,7 @@ class StoreWorkoutEntryRequest extends FormRequest
         return array_merge([
             'exercise_id' => [
                 'required',
-                Rule::exists('exercises', 'id')->where(function ($query) {
-                    $query->whereNull('user_id')
-                        ->orWhere('user_id', $this->user()->id);
-                }),
+                Rule::exists('exercises', 'id')->where(Exercise::visibilityConstraint($this->user())),
             ],
             'set_order' => ['required', 'integer', 'min:0'],
             'notes' => ['sometimes', 'nullable', 'string'],

--- a/app/Http/Requests/Api/V1/UpdateExerciseRequest.php
+++ b/app/Http/Requests/Api/V1/UpdateExerciseRequest.php
@@ -4,18 +4,20 @@ declare(strict_types=1);
 
 namespace App\Http\Requests\Api\V1;
 
-use App\Enums\ExerciseType;
+use App\Http\Requests\Api\V1\Concerns\ValidatesExerciseAttributes;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
 class UpdateExerciseRequest extends FormRequest
 {
+    use ValidatesExerciseAttributes;
+
     /** @return array<string, mixed> */
     public function rules(): array
     {
         $exercise = $this->route('exercise');
 
-        $rules = [
+        return array_merge([
             'name' => [
                 'required',
                 'string',
@@ -24,41 +26,9 @@ class UpdateExerciseRequest extends FormRequest
                     ->where('user_id', $this->user()->id)
                     ->ignore($exercise),
             ],
-            'equipment_type_id' => [
-                'nullable',
-                'integer',
-                Rule::exists('equipment_types', 'id')->where(function ($query) {
-                    $query->where('is_system', true)
-                        ->orWhere('user_id', $this->user()->id);
-                }),
-            ],
+            'equipment_type_id' => $this->equipmentTypeRule(),
             'notes' => ['nullable', 'string'],
             'type_attributes' => ['sometimes', 'array'],
-        ];
-
-        return array_merge($rules, $this->typeSpecificRules($exercise->type));
-    }
-
-    /** @return array<string, mixed> */
-    private function typeSpecificRules(ExerciseType $type): array
-    {
-        return match ($type) {
-            ExerciseType::Resistance => [
-                'type_attributes.bodyweight_base' => ['boolean'],
-                'type_attributes.allows_added_weight' => ['boolean'],
-                'type_attributes.bilateral' => ['boolean'],
-            ],
-            ExerciseType::TimedHold => [
-                'type_attributes.target_duration_seconds' => ['nullable', 'integer', 'min:1'],
-            ],
-            ExerciseType::Distance => [
-                'type_attributes.tracks_elevation' => ['boolean'],
-            ],
-            ExerciseType::Interval => [
-                'type_attributes.default_work_seconds' => ['nullable', 'integer', 'min:1'],
-                'type_attributes.default_rest_seconds' => ['nullable', 'integer', 'min:1'],
-                'type_attributes.default_rounds' => ['nullable', 'integer', 'min:1'],
-            ],
-        };
+        ], $this->typeRulesFor($exercise->type));
     }
 }

--- a/app/Http/Resources/Api/V1/ExerciseResource.php
+++ b/app/Http/Resources/Api/V1/ExerciseResource.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Http\Resources\Api\V1;
 
-use App\Enums\ExerciseType;
 use App\Models\Exercise;
+use App\Repositories\ExerciseRepository;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
@@ -23,30 +23,12 @@ class ExerciseResource extends JsonResource
             'user_id' => $this->user_id,
             'equipment_type_id' => $this->equipment_type_id,
             'equipment_type' => $this->whenLoaded('equipmentType', fn () => new EquipmentTypeResource($this->equipmentType)),
-            'type_attributes' => $this->typeAttributes(),
+            'type_attributes' => app(ExerciseRepository::class)->typeAttributes($this->resource),
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
-            'usage_count' => $this->getAttribute('usage_count') ?? 0,
+            'usage_count' => (int) ($this->getAttribute('workouts_count') ?? 0)
+                + (int) ($this->getAttribute('templates_count') ?? 0),
             'has_logged_data' => (bool) ($this->getAttribute('has_logged_data') ?? false),
         ];
-    }
-
-    /** @return array<string, mixed>|null */
-    private function typeAttributes(): ?array
-    {
-        $child = match ($this->type) {
-            ExerciseType::Resistance => $this->resistance,
-            ExerciseType::TimedHold => $this->timedHold,
-            ExerciseType::Distance => $this->distance,
-            ExerciseType::Interval => $this->interval,
-        };
-
-        if ($child === null) {
-            return null;
-        }
-
-        return collect($child->toArray())
-            ->except(['id', 'exercise_id', 'created_at', 'updated_at'])
-            ->all();
     }
 }

--- a/app/Models/EquipmentType.php
+++ b/app/Models/EquipmentType.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Closure;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -31,5 +33,28 @@ class EquipmentType extends Model
     public function exercises(): HasMany
     {
         return $this->hasMany(Exercise::class, 'equipment_type_id');
+    }
+
+    /**
+     * System rows are visible to all users; user rows only to their owner.
+     * Query closure and instance predicate must change together.
+     */
+    public static function visibilityConstraint(User $user): Closure
+    {
+        return fn ($query) => $query->where('is_system', true)->orWhere('user_id', $user->id);
+    }
+
+    /**
+     * @param  Builder<EquipmentType>  $query
+     * @return Builder<EquipmentType>
+     */
+    public function scopeVisibleTo(Builder $query, User $user): Builder
+    {
+        return $query->where(static::visibilityConstraint($user));
+    }
+
+    public function isVisibleTo(User $user): bool
+    {
+        return $this->is_system || $this->user_id === $user->id;
     }
 }

--- a/app/Models/Exercise.php
+++ b/app/Models/Exercise.php
@@ -5,8 +5,12 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Enums\ExerciseType;
+use Closure;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 
 /**
@@ -66,5 +70,68 @@ class Exercise extends Model
     public function interval(): HasOne
     {
         return $this->hasOne(ExerciseInterval::class);
+    }
+
+    /** @return BelongsToMany<Workout, $this> */
+    public function workouts(): BelongsToMany
+    {
+        return $this->belongsToMany(Workout::class, 'exercise_workout', 'exercise_id', 'workout_id');
+    }
+
+    /** @return HasMany<WorkoutEntry, $this> */
+    public function entries(): HasMany
+    {
+        return $this->hasMany(WorkoutEntry::class);
+    }
+
+    /** @return BelongsToMany<WorkoutTemplate, $this> */
+    public function templates(): BelongsToMany
+    {
+        return $this->belongsToMany(WorkoutTemplate::class, 'template_exercises', 'exercise_id', 'template_id');
+    }
+
+    /**
+     * Usage annotations read by ExerciseResource and the delete guard.
+     * usage_count sums workout and template references; entry-only usage
+     * surfaces through has_logged_data.
+     *
+     * @param  Builder<Exercise>  $query
+     * @return Builder<Exercise>
+     */
+    public function scopeWithUsage(Builder $query): Builder
+    {
+        return $query
+            ->withCount(['workouts', 'templates'])
+            ->withExists(['entries as has_logged_data']);
+    }
+
+    public function isInUse(): bool
+    {
+        return $this->workouts()->exists()
+            || $this->entries()->exists()
+            || $this->templates()->exists();
+    }
+
+    /**
+     * System rows (user_id null) visible to all; user rows only to their owner.
+     * Query closure and instance predicate must change together.
+     */
+    public static function visibilityConstraint(User $user): Closure
+    {
+        return fn ($query) => $query->whereNull('user_id')->orWhere('user_id', $user->id);
+    }
+
+    /**
+     * @param  Builder<Exercise>  $query
+     * @return Builder<Exercise>
+     */
+    public function scopeVisibleTo(Builder $query, User $user): Builder
+    {
+        return $query->where(static::visibilityConstraint($user));
+    }
+
+    public function isVisibleTo(User $user): bool
+    {
+        return $this->user_id === null || $this->user_id === $user->id;
     }
 }

--- a/app/Policies/EquipmentTypePolicy.php
+++ b/app/Policies/EquipmentTypePolicy.php
@@ -17,7 +17,7 @@ class EquipmentTypePolicy
 
     public function view(User $user, EquipmentType $equipmentType): bool
     {
-        return $equipmentType->is_system || $equipmentType->user_id === $user->id;
+        return $equipmentType->isVisibleTo($user);
     }
 
     public function create(User $user): bool

--- a/app/Policies/ExercisePolicy.php
+++ b/app/Policies/ExercisePolicy.php
@@ -17,7 +17,7 @@ class ExercisePolicy
 
     public function view(User $user, Exercise $exercise): bool
     {
-        return $exercise->user_id === null || $exercise->user_id === $user->id;
+        return $exercise->isVisibleTo($user);
     }
 
     public function create(User $user): bool

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -9,6 +9,7 @@ use DateInterval;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\RateLimiter;
@@ -24,6 +25,8 @@ class AppServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
+        Model::preventLazyLoading(! $this->app->isProduction());
+
         Passport::tokensExpireIn(new DateInterval('P30D'));
         Passport::personalAccessTokensExpireIn(new DateInterval('P30D'));
 

--- a/app/Repositories/ExerciseRepository.php
+++ b/app/Repositories/ExerciseRepository.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repositories;
+
+use App\Enums\ExerciseType;
+use App\Models\Exercise;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+class ExerciseRepository
+{
+    /** @param  array<string, mixed>  $validated */
+    public function create(User $user, array $validated): Exercise
+    {
+        return DB::transaction(function () use ($user, $validated) {
+            $exercise = Exercise::create([
+                'name' => $validated['name'],
+                'type' => $validated['type'],
+                'user_id' => $user->id,
+                'equipment_type_id' => $validated['equipment_type_id'] ?? null,
+                'notes' => $validated['notes'] ?? null,
+            ]);
+
+            $exercise->{$exercise->type->childRelation()}()
+                ->create($validated['type_attributes'] ?? []);
+
+            return $exercise;
+        });
+    }
+
+    /** @param  array<string, mixed>  $validated */
+    public function update(Exercise $exercise, array $validated): Exercise
+    {
+        return DB::transaction(function () use ($exercise, $validated) {
+            $exercise->update(
+                collect($validated)->only(['name', 'equipment_type_id', 'notes'])->all()
+            );
+
+            if (isset($validated['type_attributes'])) {
+                $exercise->{$exercise->type->childRelation()}
+                    ->update($validated['type_attributes']);
+            }
+
+            return $exercise;
+        });
+    }
+
+    /** @return array<string, mixed>|null */
+    public function typeAttributes(Exercise $exercise): ?array
+    {
+        $child = $exercise->{$exercise->type->childRelation()};
+
+        if ($child === null) {
+            return null;
+        }
+
+        return match ($exercise->type) {
+            ExerciseType::Resistance => [
+                'bodyweight_base' => $child->bodyweight_base,
+                'allows_added_weight' => $child->allows_added_weight,
+                'bilateral' => $child->bilateral,
+            ],
+            ExerciseType::TimedHold => [
+                'target_duration_seconds' => $child->target_duration_seconds,
+            ],
+            ExerciseType::Distance => [
+                'tracks_elevation' => $child->tracks_elevation,
+            ],
+            ExerciseType::Interval => [
+                'default_work_seconds' => $child->default_work_seconds,
+                'default_rest_seconds' => $child->default_rest_seconds,
+                'default_rounds' => $child->default_rounds,
+            ],
+        };
+    }
+}

--- a/resources/js/pages/exercise-detail.test.tsx
+++ b/resources/js/pages/exercise-detail.test.tsx
@@ -152,5 +152,34 @@ describe('ExerciseDetailPage', () => {
       const deleteButton = screen.getByRole('button', { name: /delete/i })
       expect(deleteButton).toBeDisabled()
     })
+
+    it('disables delete for an exercise with logged data but no workout/template usage', async () => {
+      const entryOnlyId = '9003'
+
+      server.use(
+        http.get(`/api/v1/exercises/${entryOnlyId}`, () =>
+          HttpResponse.json({
+            data: {
+              ...fixtureShowResistance.data,
+              id: entryOnlyId,
+              usage_count: 0,
+              has_logged_data: true,
+            },
+          })
+        )
+      )
+
+      renderWithProviders(<ExerciseDetailPage />, {
+        path: 'exercises/:id',
+        route: `/exercises/${entryOnlyId}`,
+      })
+
+      await screen.findByText(exerciseName)
+
+      // Entry-only usage: usage_count is 0 but has_logged_data is true, so
+      // deleting would 409. The guard must disable on the logged-data signal.
+      const deleteButton = screen.getByRole('button', { name: /delete/i })
+      expect(deleteButton).toBeDisabled()
+    })
   })
 })

--- a/resources/js/pages/exercise-detail.tsx
+++ b/resources/js/pages/exercise-detail.tsx
@@ -218,7 +218,7 @@ export function ExerciseDetailPage() {
 
       {isOwned &&
         (() => {
-          const inUse = ex.usageCount > 0
+          const inUse = ex.usageCount > 0 || ex.hasLoggedData
           return (
             <>
               <div className="flex items-center gap-2">
@@ -228,7 +228,13 @@ export function ExerciseDetailPage() {
                     if (!inUse) setDeleting(true)
                   }}
                   disabled={inUse}
-                  title={inUse ? `In use by ${ex.usageCount} workout(s)` : undefined}
+                  title={
+                    inUse
+                      ? ex.usageCount > 0
+                        ? `In use by ${ex.usageCount} workout(s)`
+                        : 'Has logged workout data'
+                      : undefined
+                  }
                   className={`inline-flex items-center gap-2 text-sm font-semibold px-3 h-11 rounded-lg ${
                     inUse
                       ? 'text-text-muted opacity-50 cursor-not-allowed'

--- a/resources/js/pages/exercises.tsx
+++ b/resources/js/pages/exercises.tsx
@@ -423,7 +423,7 @@ export function ExercisesPage() {
                 <TypeBadge type={ex.type} />
                 {!isSystem &&
                   (() => {
-                    const inUse = ex.usageCount > 0
+                    const inUse = ex.usageCount > 0 || ex.hasLoggedData
                     return (
                       <button
                         onClick={e => {
@@ -431,7 +431,13 @@ export function ExercisesPage() {
                           if (!inUse) setDeleting(ex)
                         }}
                         disabled={inUse}
-                        title={inUse ? `In use by ${ex.usageCount} workout(s)` : 'Delete exercise'}
+                        title={
+                          inUse
+                            ? ex.usageCount > 0
+                              ? `In use by ${ex.usageCount} workout(s)`
+                              : 'Has logged workout data'
+                            : 'Delete exercise'
+                        }
                         aria-label={inUse ? `${ex.name} is in use` : `Delete ${ex.name}`}
                         className={`h-10 w-10 flex items-center justify-center rounded-lg shrink-0 ${
                           inUse

--- a/tests/Feature/Api/V1/ExerciseTest.php
+++ b/tests/Feature/Api/V1/ExerciseTest.php
@@ -8,7 +8,9 @@ use App\Models\EquipmentType;
 use App\Models\Exercise;
 use App\Models\User;
 use App\Models\Workout;
+use App\Models\WorkoutEntry;
 use App\Models\WorkoutTemplate;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Passport\Passport;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -367,6 +369,33 @@ class ExerciseTest extends TestCase
             ->assertStatus(403);
     }
 
+    #[DataProvider('exerciseTypeProvider')]
+    public function test_create_then_update_round_trip_per_type(string $type, array $typeAttributes): void
+    {
+        $user = User::factory()->create();
+        Passport::actingAs($user);
+
+        $created = $this->postJson('/api/v1/exercises', [
+            'name' => 'Round Trip',
+            'type' => $type,
+            'type_attributes' => $typeAttributes,
+        ])->assertStatus(201);
+
+        $response = $this->putJson("/api/v1/exercises/{$created->json('data.id')}", [
+            'name' => 'Round Trip',
+            'type_attributes' => $typeAttributes,
+        ])->assertOk();
+
+        foreach ($typeAttributes as $key => $value) {
+            $response->assertJsonPath("data.type_attributes.{$key}", $value);
+        }
+    }
+
+    public function test_lazy_loading_prevention_is_enabled_outside_production(): void
+    {
+        $this->assertTrue(Model::preventsLazyLoading());
+    }
+
     // Destroy
 
     public function test_deletes_own_exercise(): void
@@ -415,6 +444,34 @@ class ExerciseTest extends TestCase
         $this->deleteJson("/api/v1/exercises/{$exercise->id}")
             ->assertStatus(409);
 
+        $this->assertDatabaseHas('exercises', ['id' => $exercise->id]);
+    }
+
+    public function test_entry_only_usage_agrees_across_index_show_and_destroy(): void
+    {
+        $user = User::factory()->create();
+        $exercise = $this->createExercise($user, 'resistance', ['name' => 'Entry Only']);
+        Passport::actingAs($user);
+
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+        WorkoutEntry::create([
+            'workout_id' => $workout->id,
+            'exercise_id' => $exercise->id,
+            'set_order' => 0,
+        ]);
+
+        $row = collect($this->getJson('/api/v1/exercises')->assertOk()->json('data'))
+            ->firstWhere('id', $exercise->id);
+        $this->assertSame(0, $row['usage_count']);
+        $this->assertTrue($row['has_logged_data']);
+
+        $this->getJson("/api/v1/exercises/{$exercise->id}")
+            ->assertOk()
+            ->assertJsonPath('data.usage_count', 0)
+            ->assertJsonPath('data.has_logged_data', true);
+
+        $this->deleteJson("/api/v1/exercises/{$exercise->id}")
+            ->assertStatus(409);
         $this->assertDatabaseHas('exercises', ['id' => $exercise->id]);
     }
 

--- a/tests/Feature/Api/V1/WorkoutEntryTest.php
+++ b/tests/Feature/Api/V1/WorkoutEntryTest.php
@@ -49,7 +49,7 @@ class WorkoutEntryTest extends TestCase
         return $exercise;
     }
 
-    // -- Store --
+    // Store
 
     public function test_creates_entry_with_resistance_metrics(): void
     {
@@ -340,7 +340,7 @@ class WorkoutEntryTest extends TestCase
             ->assertJsonValidationErrors('set_order');
     }
 
-    // -- Index --
+    // Index
 
     public function test_lists_entries_for_workout(): void
     {
@@ -364,7 +364,7 @@ class WorkoutEntryTest extends TestCase
         $this->assertEquals(2, $response->json('data.2.set_order'));
     }
 
-    // -- Show --
+    // Show
 
     public function test_shows_single_entry_with_metrics(): void
     {
@@ -393,7 +393,7 @@ class WorkoutEntryTest extends TestCase
             ->assertJsonPath('data.metrics.load.actual_weight', '95.00');
     }
 
-    // -- Update --
+    // Update
 
     public function test_updates_entry_base_fields(): void
     {
@@ -498,7 +498,7 @@ class WorkoutEntryTest extends TestCase
         $this->assertDatabaseHas('log_rep_metrics', ['entry_id' => $entry->id]);
     }
 
-    // -- Destroy --
+    // Destroy
 
     public function test_deletes_entry(): void
     {
@@ -545,7 +545,7 @@ class WorkoutEntryTest extends TestCase
         $this->assertDatabaseMissing('log_rep_metrics', ['id' => $repMetric->id]);
     }
 
-    // -- Reorder --
+    // Reorder
 
     public function test_reorders_entries(): void
     {
@@ -669,7 +669,7 @@ class WorkoutEntryTest extends TestCase
         $this->assertDatabaseHas('workout_entries', ['id' => $entry3->id, 'set_order' => 2]);
     }
 
-    // -- Scoped Binding --
+    // Scoped Binding
 
     public function test_scoped_binding_rejects_entry_from_other_workout(): void
     {
@@ -689,7 +689,7 @@ class WorkoutEntryTest extends TestCase
             ->assertStatus(404);
     }
 
-    // -- Auth --
+    // Auth
 
     public function test_cannot_create_entry_on_other_users_workout(): void
     {
@@ -706,7 +706,23 @@ class WorkoutEntryTest extends TestCase
         ])->assertStatus(403);
     }
 
-    // -- Group Fields --
+    public function test_cannot_log_entry_against_another_users_exercise(): void
+    {
+        $owner = User::factory()->create();
+        $foreignExercise = $this->createExercise($owner, 'resistance');
+
+        $actor = User::factory()->create();
+        Passport::actingAs($actor);
+        $workout = Workout::factory()->create(['user_id' => $actor->id]);
+
+        $this->postJson("/api/v1/workouts/{$workout->id}/entries", [
+            'exercise_id' => $foreignExercise->id,
+            'set_order' => 0,
+        ])->assertStatus(422)
+            ->assertJsonValidationErrors('exercise_id');
+    }
+
+    // Group Fields
 
     public function test_creates_entry_with_group_assignment(): void
     {


### PR DESCRIPTION
## Problem

The exercise module held the same knowledge in several places, and some of the copies had already drifted apart and caused bugs.

- `StoreExerciseRequest` and `UpdateExerciseRequest` duplicated most of their rules: the `equipment_type_id` rule and the whole four-branch per-type `type_attributes` matrix. A drift between the two copies had already made a distance exercise created without a unit impossible to update.
- The "system rows plus the user's own rows" visibility rule was hand-written at six sites across `ExerciseController`, `EquipmentTypeController`, `StoreWorkoutEntryRequest`, `AttachExerciseRequest`, `ExercisePolicy`, and `EquipmentTypePolicy`. A wrong copy is a cross-user data exposure.
- "Is this exercise in use" was computed three different ways inside `ExerciseController` and they disagreed. An exercise referenced only by logged workout entries (no attachment, no template) reported a usage count of 0 and no logged data on its detail page, so the delete button showed as enabled and the delete request then failed with a 409.
- The exercise-type to child-table mapping was written three times, in create, in update, and in `ExerciseResource`, and the resource read child relations without any guarantee they were loaded.

## Solution

Each kind of duplication now has one home.

- New `ValidatesExerciseAttributes` trait holds the equipment rule and the per-type attribute matrix once. Both request classes compose it, so the only differences left between create and update are the intended ones.
- `Exercise` and `EquipmentType` each gain a `visibilityConstraint` closure, a `visibleTo` query scope, and an `isVisibleTo` predicate. Every call site delegates to them, and the user is always taken from the authenticated request, never from input. The scope and predicate take a typed `User`.
- `Exercise` gains `workouts`, `entries`, and `templates` relations plus a `withUsage` scope and an `isInUse` method. Index, show, and destroy all read from these, so they agree. The show endpoint now reports logged-data status truthfully, and the delete button on both `exercise-detail.tsx` and `exercises.tsx` is disabled when an exercise has any usage or any logged data.
- New `ExerciseRepository` owns creating, updating, and reshaping the type-specific child rows, with the type-to-child map defined once on the `ExerciseType` enum and the controller's eager-load list derived from it. `ExerciseResource` delegates the reshape. Lazy-loading prevention is turned on outside production.
