### PR TITLE
PS-112 - Amending ADR-009 and fixing chart date timezone bug

### DIFF
--- a/docs/decisions/adr-009-workout-templates.md
+++ b/docs/decisions/adr-009-workout-templates.md
@@ -72,14 +72,6 @@ workout_templates
 +----- notes (text, nullable)
 +----- created_at, updated_at
 
-template_exercises
-+----- id (PK)
-+----- template_id (FK -> workout_templates.id, ON DELETE CASCADE)
-+----- exercise_id (FK -> exercises.id)
-+----- exercise_order (integer)
-+----- created_at, updated_at
-+----- INDEX(template_id, exercise_order)
-
 template_entry_groups
 +----- id (PK)
 +----- template_id (FK -> workout_templates.id, ON DELETE CASCADE)
@@ -89,18 +81,43 @@ template_entry_groups
 +----- rest_between_rounds_seconds (integer, nullable)
 +----- created_at, updated_at
 
-template_group_exercises
-+----- id (PK)
-+----- template_entry_group_id (FK -> template_entry_groups.id, ON DELETE CASCADE)
-+----- exercise_id (FK -> exercises.id)
+template_exercises
++----- template_id (FK -> workout_templates.id, ON DELETE CASCADE)
++----- exercise_id (FK -> exercises.id, ON DELETE RESTRICT)
 +----- exercise_order (integer)
-+----- created_at, updated_at
++----- template_entry_group_id (FK -> template_entry_groups.id, nullable, ON DELETE SET NULL)
++----- PRIMARY KEY (template_id, exercise_id)
++----- INDEX (template_id, exercise_order)
 ```
 
-`template_exercises` holds standalone exercises (not in a group).
-`template_group_exercises` holds exercises within a group, with their order
-within the rotation. Between the two, the full exercise structure is
-defined.
+A single `template_exercises` pivot holds all exercises regardless of group
+membership. The nullable `template_entry_group_id` optionally links an
+exercise to a group. Ungrouped exercises have NULL in this column.
+
+---
+
+## Amendment: Single-Pivot Template Exercise Structure
+
+**Date:** 2026-07-03
+
+**Amended by:** PS-112 (documents implementation decision from Phase 7a,
+discovered during 2026-07-02 backend review)
+
+The original design specified three tables: `template_exercises` for
+standalone exercises, `template_entry_groups` for group definitions, and
+`template_group_exercises` for exercises within groups. The implementation
+merged the exercise tables into a single `template_exercises` pivot with a
+nullable `template_entry_group_id` FK.
+
+**Rationale:**
+
+1. **ADR-007 consistency.** The workout side uses the same pattern:
+   `workout_entries.entry_group_id` is a nullable FK, with all entries in
+   one table regardless of group membership.
+2. **Composite-key duplicate prevention.** The `(template_id, exercise_id)`
+   primary key prevents attaching the same exercise twice.
+3. **SET NULL semantics.** Deleting a group sets the FK to NULL rather than
+   cascading exercise deletion, matching ADR-007's group-deletion behavior.
 
 ---
 

--- a/resources/js/components/app/charts.tsx
+++ b/resources/js/components/app/charts.tsx
@@ -10,6 +10,7 @@ import {
   Tooltip,
   Cell,
 } from 'recharts'
+import { formatDate, formatDateCompact } from '@/lib/formatters'
 
 const COLORS = {
   primary: '#0D9488',
@@ -38,22 +39,6 @@ interface VolumeBarChartProps {
   data: { date: string; value: number }[]
   height?: number
   valueFormatter?: (value: number) => string
-}
-
-function formatDateShort(dateString: string): string {
-  const date = new Date(dateString)
-  const month = String(date.getMonth() + 1).padStart(2, '0')
-  const day = String(date.getDate()).padStart(2, '0')
-  return `${month}/${day}`
-}
-
-function formatDate(dateString: string): string {
-  const date = new Date(dateString)
-  return date.toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  })
 }
 
 function CustomTooltip({
@@ -130,7 +115,7 @@ export function ProgressLineChart({
           <XAxis
             dataKey="date"
             tick={{ fontSize: 11, fill: COLORS.textMuted }}
-            tickFormatter={formatDateShort}
+            tickFormatter={formatDateCompact}
             interval={Math.ceil(points.length / 5) - 1}
             stroke="transparent"
             tickLine={false}
@@ -221,7 +206,7 @@ export function VolumeBarChart({ data, height = 160, valueFormatter }: VolumeBar
           <XAxis
             dataKey="date"
             tick={{ fontSize: 11, fill: COLORS.textMuted }}
-            tickFormatter={formatDateShort}
+            tickFormatter={formatDateCompact}
             interval={Math.ceil(data.length / 5) - 1}
             stroke="transparent"
             tickLine={false}

--- a/resources/js/lib/formatters.test.ts
+++ b/resources/js/lib/formatters.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { formatDate, formatDateShort, formatDuration, todayISO } from './formatters'
+import {
+  formatDate,
+  formatDateShort,
+  formatDateCompact,
+  formatDuration,
+  todayISO,
+} from './formatters'
 
 describe('formatDuration', () => {
   it.each([
@@ -107,6 +113,23 @@ describe('formatDateShort', () => {
   })
 })
 
+describe('formatDateCompact', () => {
+  it.each([['', '']])('returns empty string for empty input: "%s"', (input, expected) => {
+    expect(formatDateCompact(input)).toBe(expected)
+  })
+
+  it.each([
+    ['2026-06-30', '06/30'],
+    ['2026-01-01', '01/01'],
+    ['2026-12-31', '12/31'],
+    ['2025-02-14', '02/14'],
+    ['2000-03-05', '03/05'],
+    ['1999-11-09', '11/09'],
+  ])('formats ISO date to "MM/DD": %s → %s', (input, expected) => {
+    expect(formatDateCompact(input)).toBe(expected)
+  })
+})
+
 describe('todayISO', () => {
   it('returns ISO format date string for today', () => {
     const result = todayISO()
@@ -125,4 +148,19 @@ describe('todayISO', () => {
   afterEach(() => {
     vi.useRealTimers()
   })
+})
+
+describe('timezone safety - civil date formatters never shift dates', () => {
+  it.each([
+    ['2026-01-01', 'Jan 1, 2026', 'Jan 1', '01/01'],
+    ['2026-07-03', 'Jul 3, 2026', 'Jul 3', '07/03'],
+    ['2026-12-31', 'Dec 31, 2026', 'Dec 31', '12/31'],
+  ])(
+    'preserves calendar day %s regardless of runtime timezone',
+    (iso, expectedFull, expectedShort, expectedCompact) => {
+      expect(formatDate(iso)).toBe(expectedFull)
+      expect(formatDateShort(iso)).toBe(expectedShort)
+      expect(formatDateCompact(iso)).toBe(expectedCompact)
+    }
+  )
 })

--- a/resources/js/lib/formatters.ts
+++ b/resources/js/lib/formatters.ts
@@ -1,3 +1,10 @@
+// Civil dates (workout date, date-only "YYYY-MM-DD" from the API) are calendar days.
+// Format them via string parsing only. Never construct a Date from a date-only string:
+// new Date('2026-07-03') parses as UTC midnight and toLocaleDateString renders in
+// local time, producing off-by-one errors west of UTC.
+// Instants (created_at timestamps with time+zone) use Date objects and are UTC on wire.
+// todayISO() uses new Date() with no args to get current local time. That is correct.
+
 const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
 
 export function formatDate(iso: string): string {
@@ -12,6 +19,12 @@ export function formatDateShort(iso: string): string {
   const parts = iso.split('-').map(Number)
   const month = parts[1] ?? 1
   return `${MONTHS[month - 1]} ${parts[2]}`
+}
+
+export function formatDateCompact(iso: string): string {
+  if (!iso) return ''
+  const parts = iso.split('-')
+  return `${parts[1]}/${parts[2]}`
 }
 
 export function todayISO(): string {


### PR DESCRIPTION
## Problem

Two issues existed in parallel:

1. ADR-009 documented a three-table template exercise schema (`template_exercises`, `template_entry_groups`, `template_group_exercises`) that was never built. The implementation uses a single `template_exercises` pivot with a composite primary key and a nullable group FK. The ADR was misleading as an architectural reference.

2. The progress charts had a timezone off-by-one bug. `charts.tsx` had its own private date formatters that used `new Date(dateString)` on date-only strings from the API. Since `new Date('2026-07-03')` parses as UTC midnight, `toLocaleDateString` shifts it backward for any user west of UTC. The same workout showed different dates on the list (correct) and the chart (wrong).

## Solution

ADR-009 now documents the real schema and includes an amendment section with the rationale for the single-pivot design (ADR-007 consistency, composite-key duplicate prevention, SET NULL semantics).

The buggy private formatters in `charts.tsx` are deleted. The chart now imports from `lib/formatters.ts`, which formats civil dates via string parsing (no Date object, no timezone math). A new `formatDateCompact` function produces the MM/DD axis format. A timezone-safety regression test suite confirms all civil-date formatters preserve the calendar day regardless of runtime timezone.
