### PR TITLE
PS-92 - Introducing a typed exercise-type registry and API-driven chart metrics

### DIFF
--- a/resources/js/api/progress.test.ts
+++ b/resources/js/api/progress.test.ts
@@ -252,6 +252,26 @@ describe('transformProgressData', () => {
     expect(result.type).toBe('interval')
   })
 
+  it('passes the API primary_metric through to primaryMetric', () => {
+    const progress: RawProgressResponse = {
+      exercise_id: 1,
+      exercise_type: 'resistance',
+      range: '6m',
+      primary_metric: 'reps',
+      data_points: [],
+    }
+
+    const records: RawRecordsResponse = {
+      exercise_id: 1,
+      exercise_type: 'resistance',
+      records: {},
+    }
+
+    const result = transformProgressData(progress, records, 'imperial')
+
+    expect(result.primaryMetric).toBe('reps')
+  })
+
   it('handles unknown record keys with fallback label', () => {
     const progress: RawProgressResponse = {
       exercise_id: 1,

--- a/resources/js/api/progress.ts
+++ b/resources/js/api/progress.ts
@@ -1,5 +1,12 @@
 import { api } from './client'
-import type { ExerciseProgressData, ExerciseType, ProgressPoint, ProgressRecord } from './types'
+import type {
+  ExerciseProgressData,
+  ExerciseType,
+  ProgressPoint,
+  ProgressRecord,
+  PrimaryMetric,
+} from './types'
+import { EXERCISE_TYPES } from '@/lib/exercise-types'
 import { formatDuration } from '@/lib/formatters'
 import { unitLabel } from '@/lib/units'
 import type { MeasurementSystem } from '@/lib/units'
@@ -109,6 +116,7 @@ export function transformProgressData(
     volume,
     records: recordsList,
     type: progress.exercise_type,
+    primaryMetric: progress.primary_metric as PrimaryMetric,
   }
 }
 
@@ -116,14 +124,7 @@ export function extractAllTimeBest(
   records: RawRecordsResponse,
   exerciseType: ExerciseType
 ): number | null {
-  const recordKeyMap: Record<ExerciseType, string> = {
-    resistance: 'reps',
-    timed_hold: 'duration',
-    distance: 'distance',
-    interval: 'completed_rounds',
-  }
-
-  const key = recordKeyMap[exerciseType]
+  const key = EXERCISE_TYPES[exerciseType].recordKey
   const record = records.records[key]
   return record?.value ?? null
 }

--- a/resources/js/api/transformers.ts
+++ b/resources/js/api/transformers.ts
@@ -11,6 +11,7 @@ import type {
   TemplateExercise,
 } from '@/api/types'
 import type { MeasurementSystem } from '@/lib/units'
+import { assertNever } from '@/lib/utils'
 
 export interface RawUser {
   id: number
@@ -77,7 +78,7 @@ export function toExercise(raw: RawExercise): Exercise {
   const attrs = raw.type_attributes
   if (!attrs) return exercise
 
-  switch (raw.type) {
+  switch (exercise.type) {
     case 'resistance':
       exercise.bodyweightBase = attrs.bodyweight_base as boolean
       exercise.allowsAddedWeight = attrs.allows_added_weight as boolean
@@ -94,6 +95,8 @@ export function toExercise(raw: RawExercise): Exercise {
       exercise.defaultRestSeconds = (attrs.default_rest_seconds as number) ?? null
       exercise.defaultRounds = (attrs.default_rounds as number) ?? null
       break
+    default:
+      return assertNever(exercise.type)
   }
 
   return exercise

--- a/resources/js/api/type-attributes-drift.test.ts
+++ b/resources/js/api/type-attributes-drift.test.ts
@@ -1,0 +1,48 @@
+/// <reference types="vite/client" />
+import { describe, it, expect } from 'vitest'
+import { toExercise } from './transformers'
+import type { RawExercise } from './transformers'
+import { EXERCISE_TYPES } from '@/lib/exercise-types'
+import type { ExerciseType } from './types'
+
+const modules = import.meta.glob('../test/mocks/fixtures/exercises/*.json', {
+  eager: true,
+}) as Record<string, unknown>
+
+function collectRawExercises(): RawExercise[] {
+  const out: RawExercise[] = []
+  for (const mod of Object.values(modules)) {
+    const data = (mod as { default: { data?: unknown } }).default?.data
+    const rows = Array.isArray(data) ? data : data ? [data] : []
+    for (const row of rows) {
+      if (row && typeof row === 'object' && 'type' in row && 'type_attributes' in row) {
+        out.push(row as RawExercise)
+      }
+    }
+  }
+  return out
+}
+
+describe('type_attributes consumer manifest drift', () => {
+  const raws = collectRawExercises()
+
+  it('captures at least one exercise fixture to check', () => {
+    expect(raws.length).toBeGreaterThan(0)
+  })
+
+  it('maps every captured type_attributes key and transforms without throwing', () => {
+    for (const raw of raws) {
+      expect(() => toExercise(raw)).not.toThrow()
+      const type = raw.type as ExerciseType
+      const manifest = EXERCISE_TYPES[type]?.attributeKeys ?? []
+      for (const key of Object.keys(raw.type_attributes ?? {})) {
+        expect(
+          manifest.includes(key),
+          `Unmapped type_attributes key "${key}" on ${type} exercise "${raw.name}". ` +
+            `Map it in toExercise() and add it to EXERCISE_TYPES.${type}.attributeKeys, ` +
+            `or add a documented exclusion.`
+        ).toBe(true)
+      }
+    }
+  })
+})

--- a/resources/js/api/types.ts
+++ b/resources/js/api/types.ts
@@ -18,6 +18,8 @@ export interface EquipmentType {
 
 export type ExerciseType = 'resistance' | 'timed_hold' | 'distance' | 'interval'
 
+export type PrimaryMetric = 'weight' | 'reps' | 'duration' | 'distance' | 'completed_rounds'
+
 export interface Exercise {
   id: string
   userId: string | null
@@ -195,6 +197,7 @@ export interface ExerciseProgressData {
   volume: { date: string; value: number }[]
   records: ProgressRecord[]
   type: ExerciseType
+  primaryMetric: PrimaryMetric
 }
 
 export type TimeRange = '1M' | '3M' | '6M' | '1Y' | 'All'

--- a/resources/js/components/app/metric-inputs.tsx
+++ b/resources/js/components/app/metric-inputs.tsx
@@ -1,7 +1,7 @@
 import { Trophy, Plus, ChevronDown } from 'lucide-react'
 import type { WorkoutEntry, Exercise } from '@/api/types'
 import { useAuth } from '@/hooks/use-auth'
-import { cn } from '@/lib/utils'
+import { cn, assertNever } from '@/lib/utils'
 import { unitLabel } from '@/lib/units'
 import { Badge } from '@/components/ui/badge'
 import { formatDuration } from '@/lib/formatters'
@@ -81,196 +81,205 @@ export function EntryMetrics({ entry, exercise, allTimeBest, onChange }: EntryMe
   if (!user) return null
   const unit = unitLabel(user.measurementSystem, 'weight')
 
-  if (exercise.type === 'resistance') {
-    const lm = entry.loadMetric || { targetWeight: null, actualWeight: null, bodyweightOnly: false }
-    const rm = entry.repMetric || {
-      targetReps: null,
-      actualReps: null,
-      toFailure: false,
-      failureRep: null,
-    }
-    const bodyOnly = lm.bodyweightOnly || (exercise.bodyweightBase && !exercise.allowsAddedWeight)
-    const showWeight = !bodyOnly
-    const isPR =
-      allTimeBest != null &&
-      rm.actualReps != null &&
-      (allTimeBest === 0 || rm.actualReps > allTimeBest)
+  switch (exercise.type) {
+    case 'resistance': {
+      const lm = entry.loadMetric || {
+        targetWeight: null,
+        actualWeight: null,
+        bodyweightOnly: false,
+      }
+      const rm = entry.repMetric || {
+        targetReps: null,
+        actualReps: null,
+        toFailure: false,
+        failureRep: null,
+      }
+      const bodyOnly = lm.bodyweightOnly || (exercise.bodyweightBase && !exercise.allowsAddedWeight)
+      const showWeight = !bodyOnly
+      const isPR =
+        allTimeBest != null &&
+        rm.actualReps != null &&
+        (allTimeBest === 0 || rm.actualReps > allTimeBest)
 
-    return (
-      <div className="flex flex-col gap-2">
-        <div className="flex items-stretch gap-2">
-          {showWeight ? (
+      return (
+        <div className="flex flex-col gap-2">
+          <div className="flex items-stretch gap-2">
+            {showWeight ? (
+              <MetricField
+                label={exercise.bodyweightBase ? '+ Weight' : 'Weight'}
+                unit={unit}
+                value={lm.actualWeight}
+                target={lm.targetWeight}
+                onChange={v => onChange({ loadMetric: { ...lm, actualWeight: v } })}
+              />
+            ) : (
+              <div className="ps-metric flex flex-col items-center justify-center px-3 py-2 min-h-[64px] flex-1">
+                <span className="label-caps text-text-muted mb-0.5">Load</span>
+                <span className="text-sm font-semibold text-text-secondary">Bodyweight</span>
+              </div>
+            )}
             <MetricField
-              label={exercise.bodyweightBase ? '+ Weight' : 'Weight'}
-              unit={unit}
-              value={lm.actualWeight}
-              target={lm.targetWeight}
-              onChange={v => onChange({ loadMetric: { ...lm, actualWeight: v } })}
+              label="Reps"
+              value={rm.actualReps}
+              target={rm.targetReps}
+              onChange={v => onChange({ repMetric: { ...rm, actualReps: v } })}
             />
-          ) : (
-            <div className="ps-metric flex flex-col items-center justify-center px-3 py-2 min-h-[64px] flex-1">
-              <span className="label-caps text-text-muted mb-0.5">Load</span>
-              <span className="text-sm font-semibold text-text-secondary">Bodyweight</span>
+          </div>
+          <div className="flex items-center justify-between flex-wrap gap-2">
+            <label className="inline-flex items-center gap-2 text-[13px] text-text-secondary cursor-pointer select-none">
+              <input
+                type="checkbox"
+                checked={!!rm.toFailure}
+                onChange={e =>
+                  onChange({
+                    repMetric: {
+                      ...rm,
+                      toFailure: e.target.checked,
+                      failureRep: e.target.checked ? rm.actualReps : null,
+                    },
+                  })
+                }
+                className="h-4 w-4 rounded accent-primary"
+                style={{ accentColor: 'var(--color-primary)' }}
+              />
+              To failure
+            </label>
+            {isPR && <PRBadge />}
+          </div>
+        </div>
+      )
+    }
+    case 'timed_hold': {
+      const dm = entry.durationMetric || {
+        targetDurationSeconds: null,
+        actualDurationSeconds: null,
+      }
+      const isPR =
+        allTimeBest != null &&
+        dm.actualDurationSeconds != null &&
+        (allTimeBest === 0 || dm.actualDurationSeconds > allTimeBest)
+
+      return (
+        <div className="flex flex-col gap-2">
+          <div className="flex items-stretch gap-2">
+            <MetricField
+              label="Target"
+              unit="sec"
+              value={dm.targetDurationSeconds}
+              onChange={v => onChange({ durationMetric: { ...dm, targetDurationSeconds: v } })}
+            />
+            <MetricField
+              label="Hold"
+              unit="sec"
+              value={dm.actualDurationSeconds}
+              onChange={v => onChange({ durationMetric: { ...dm, actualDurationSeconds: v } })}
+            />
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-[12px] text-text-secondary">
+              {dm.actualDurationSeconds != null
+                ? `Logged ${formatDuration(dm.actualDurationSeconds)}`
+                : 'Not logged'}
+              {dm.targetDurationSeconds != null
+                ? ` · target ${formatDuration(dm.targetDurationSeconds)}`
+                : ''}
+            </span>
+            {isPR && <PRBadge />}
+          </div>
+        </div>
+      )
+    }
+    case 'distance': {
+      const dist = entry.distanceMetric || {
+        targetDistance: null,
+        actualDistance: null,
+        lapCount: null,
+        strokeCount: null,
+      }
+      const dur = entry.durationMetric || {
+        targetDurationSeconds: null,
+        actualDurationSeconds: null,
+      }
+      const du = unitLabel(user.measurementSystem, 'distance')
+      const isPR =
+        allTimeBest != null &&
+        dist.actualDistance != null &&
+        (allTimeBest === 0 || dist.actualDistance > allTimeBest)
+
+      return (
+        <div className="flex flex-col gap-2">
+          <div className="flex items-stretch gap-2">
+            <MetricField
+              label="Distance"
+              unit={du}
+              value={dist.actualDistance}
+              target={dist.targetDistance}
+              onChange={v => onChange({ distanceMetric: { ...dist, actualDistance: v } })}
+            />
+            <MetricField
+              label="Time"
+              unit="sec"
+              value={dur.actualDurationSeconds}
+              onChange={v => onChange({ durationMetric: { ...dur, actualDurationSeconds: v } })}
+            />
+          </div>
+          {isPR && (
+            <div className="self-end">
+              <PRBadge />
             </div>
           )}
-          <MetricField
-            label="Reps"
-            value={rm.actualReps}
-            target={rm.targetReps}
-            onChange={v => onChange({ repMetric: { ...rm, actualReps: v } })}
-          />
         </div>
-        <div className="flex items-center justify-between flex-wrap gap-2">
-          <label className="inline-flex items-center gap-2 text-[13px] text-text-secondary cursor-pointer select-none">
-            <input
-              type="checkbox"
-              checked={!!rm.toFailure}
-              onChange={e =>
-                onChange({
-                  repMetric: {
-                    ...rm,
-                    toFailure: e.target.checked,
-                    failureRep: e.target.checked ? rm.actualReps : null,
-                  },
-                })
-              }
-              className="h-4 w-4 rounded accent-primary"
-              style={{ accentColor: 'var(--color-primary)' }}
-            />
-            To failure
-          </label>
-          {isPR && <PRBadge />}
-        </div>
-      </div>
-    )
-  }
-
-  if (exercise.type === 'timed_hold') {
-    const dm = entry.durationMetric || { targetDurationSeconds: null, actualDurationSeconds: null }
-    const isPR =
-      allTimeBest != null &&
-      dm.actualDurationSeconds != null &&
-      (allTimeBest === 0 || dm.actualDurationSeconds > allTimeBest)
-
-    return (
-      <div className="flex flex-col gap-2">
-        <div className="flex items-stretch gap-2">
-          <MetricField
-            label="Target"
-            unit="sec"
-            value={dm.targetDurationSeconds}
-            onChange={v => onChange({ durationMetric: { ...dm, targetDurationSeconds: v } })}
-          />
-          <MetricField
-            label="Hold"
-            unit="sec"
-            value={dm.actualDurationSeconds}
-            onChange={v => onChange({ durationMetric: { ...dm, actualDurationSeconds: v } })}
-          />
-        </div>
-        <div className="flex items-center justify-between">
-          <span className="text-[12px] text-text-secondary">
-            {dm.actualDurationSeconds != null
-              ? `Logged ${formatDuration(dm.actualDurationSeconds)}`
-              : 'Not logged'}
-            {dm.targetDurationSeconds != null
-              ? ` · target ${formatDuration(dm.targetDurationSeconds)}`
-              : ''}
-          </span>
-          {isPR && <PRBadge />}
-        </div>
-      </div>
-    )
-  }
-
-  if (exercise.type === 'distance') {
-    const dist = entry.distanceMetric || {
-      targetDistance: null,
-      actualDistance: null,
-      lapCount: null,
-      strokeCount: null,
+      )
     }
-    const dur = entry.durationMetric || { targetDurationSeconds: null, actualDurationSeconds: null }
-    const du = unitLabel(user.measurementSystem, 'distance')
-    const isPR =
-      allTimeBest != null &&
-      dist.actualDistance != null &&
-      (allTimeBest === 0 || dist.actualDistance > allTimeBest)
+    case 'interval': {
+      const ih = entry.intervalHeader || {
+        programmedRounds: 1,
+        completedRounds: 0,
+        targetWorkSeconds: 30,
+        targetRestSeconds: 15,
+        rounds: [],
+      }
+      const done = ih.completedRounds || 0
+      const total = ih.programmedRounds || 1
+      const setRounds = (n: number) =>
+        onChange({ intervalHeader: { ...ih, completedRounds: Math.max(0, Math.min(total, n)) } })
 
-    return (
-      <div className="flex flex-col gap-2">
-        <div className="flex items-stretch gap-2">
-          <MetricField
-            label="Distance"
-            unit={du}
-            value={dist.actualDistance}
-            target={dist.targetDistance}
-            onChange={v => onChange({ distanceMetric: { ...dist, actualDistance: v } })}
-          />
-          <MetricField
-            label="Time"
-            unit="sec"
-            value={dur.actualDurationSeconds}
-            onChange={v => onChange({ durationMetric: { ...dur, actualDurationSeconds: v } })}
-          />
-        </div>
-        {isPR && (
-          <div className="self-end">
-            <PRBadge />
+      return (
+        <div className="ps-metric px-4 py-3 flex items-center justify-between gap-3">
+          <div>
+            <div className="label-caps text-text-muted mb-0.5">Rounds</div>
+            <div
+              className="tabular-nums"
+              style={{ fontSize: 20, fontWeight: 700, letterSpacing: '-0.5px' }}
+            >
+              {done} <span className="text-text-secondary text-sm font-medium">of {total}</span>
+            </div>
+            <div className="text-[12px] text-text-secondary mt-0.5">
+              {formatDuration(ih.targetWorkSeconds)} work · {formatDuration(ih.targetRestSeconds)}{' '}
+              rest
+            </div>
           </div>
-        )}
-      </div>
-    )
-  }
-
-  if (exercise.type === 'interval') {
-    const ih = entry.intervalHeader || {
-      programmedRounds: 1,
-      completedRounds: 0,
-      targetWorkSeconds: 30,
-      targetRestSeconds: 15,
-      rounds: [],
+          <div className="flex items-center gap-2">
+            <button
+              aria-label="One fewer round"
+              onClick={() => setRounds(done - 1)}
+              className="h-11 w-11 rounded-lg border border-border-strong flex items-center justify-center text-text-secondary hover:bg-surface-card"
+            >
+              <ChevronDown size={20} />
+            </button>
+            <button
+              aria-label="One more round"
+              onClick={() => setRounds(done + 1)}
+              className="h-11 w-11 rounded-lg flex items-center justify-center text-white"
+              style={{ backgroundImage: 'var(--gradient-primary)' }}
+            >
+              <Plus size={20} />
+            </button>
+          </div>
+        </div>
+      )
     }
-    const done = ih.completedRounds || 0
-    const total = ih.programmedRounds || 1
-    const setRounds = (n: number) =>
-      onChange({ intervalHeader: { ...ih, completedRounds: Math.max(0, Math.min(total, n)) } })
-
-    return (
-      <div className="ps-metric px-4 py-3 flex items-center justify-between gap-3">
-        <div>
-          <div className="label-caps text-text-muted mb-0.5">Rounds</div>
-          <div
-            className="tabular-nums"
-            style={{ fontSize: 20, fontWeight: 700, letterSpacing: '-0.5px' }}
-          >
-            {done} <span className="text-text-secondary text-sm font-medium">of {total}</span>
-          </div>
-          <div className="text-[12px] text-text-secondary mt-0.5">
-            {formatDuration(ih.targetWorkSeconds)} work · {formatDuration(ih.targetRestSeconds)}{' '}
-            rest
-          </div>
-        </div>
-        <div className="flex items-center gap-2">
-          <button
-            aria-label="One fewer round"
-            onClick={() => setRounds(done - 1)}
-            className="h-11 w-11 rounded-lg border border-border-strong flex items-center justify-center text-text-secondary hover:bg-surface-card"
-          >
-            <ChevronDown size={20} />
-          </button>
-          <button
-            aria-label="One more round"
-            onClick={() => setRounds(done + 1)}
-            className="h-11 w-11 rounded-lg flex items-center justify-center text-white"
-            style={{ backgroundImage: 'var(--gradient-primary)' }}
-          >
-            <Plus size={20} />
-          </button>
-        </div>
-      </div>
-    )
+    default:
+      return assertNever(exercise.type)
   }
-
-  return null
 }

--- a/resources/js/components/app/pickers.tsx
+++ b/resources/js/components/app/pickers.tsx
@@ -12,6 +12,7 @@ import { TypeBadge } from '@/components/ui/type-badge'
 import { SegmentedControl } from '@/components/ui/segmented-control'
 import { cn } from '@/lib/utils'
 import { todayISO, formatDate } from '@/lib/formatters'
+import { TYPE_OPTIONS } from '@/lib/exercise-types'
 
 function equipmentLabel(equipment: EquipmentType[], equipmentTypeId: string | null): string {
   if (!equipmentTypeId) return 'No equipment'
@@ -58,13 +59,7 @@ export function ExercisePicker({ open, onClose, onSelect }: ExercisePickerProps)
           size="sm"
           value={type}
           onChange={setType}
-          options={[
-            { value: 'all', label: 'All' },
-            { value: 'resistance', label: 'Lift' },
-            { value: 'timed_hold', label: 'Hold' },
-            { value: 'distance', label: 'Cardio' },
-            { value: 'interval', label: 'Interval' },
-          ]}
+          options={[{ value: 'all', label: 'All' }, ...TYPE_OPTIONS]}
         />
       </div>
       <div className="flex flex-col gap-1.5">

--- a/resources/js/components/ui/type-badge.tsx
+++ b/resources/js/components/ui/type-badge.tsx
@@ -1,12 +1,6 @@
 import { Badge } from './badge'
 import type { ExerciseType } from '@/api/types'
-
-const TYPE_LABELS: Record<ExerciseType, string> = {
-  resistance: 'Resistance',
-  timed_hold: 'Timed Hold',
-  distance: 'Distance',
-  interval: 'Interval',
-}
+import { EXERCISE_TYPES } from '@/lib/exercise-types'
 
 const TYPE_TONE: Record<ExerciseType, 'primary' | 'secondary' | 'accent' | 'neutral'> = {
   resistance: 'primary',
@@ -20,5 +14,5 @@ export interface TypeBadgeProps {
 }
 
 export function TypeBadge({ type }: TypeBadgeProps) {
-  return <Badge tone={TYPE_TONE[type] || 'neutral'}>{TYPE_LABELS[type]}</Badge>
+  return <Badge tone={TYPE_TONE[type] || 'neutral'}>{EXERCISE_TYPES[type].label}</Badge>
 }

--- a/resources/js/hooks/use-exercise-progress.ts
+++ b/resources/js/hooks/use-exercise-progress.ts
@@ -9,6 +9,7 @@ const EMPTY: ExerciseProgressData = {
   volume: [],
   records: [],
   type: 'resistance',
+  primaryMetric: 'weight',
 }
 
 export function useExerciseProgress(exerciseId: string, range: TimeRange) {

--- a/resources/js/lib/domain.ts
+++ b/resources/js/lib/domain.ts
@@ -1,11 +1,4 @@
-import type { Exercise, EquipmentType, Workout, WorkoutEntry, ExerciseType } from '@/api/types'
-
-export const TYPE_LABELS: Record<ExerciseType, string> = {
-  resistance: 'Resistance',
-  timed_hold: 'Timed Hold',
-  distance: 'Distance / Time',
-  interval: 'Interval',
-}
+import type { Exercise, EquipmentType, Workout, WorkoutEntry } from '@/api/types'
 
 export function entryHasActual(e: WorkoutEntry): boolean {
   if (e.loadMetric || e.repMetric) {

--- a/resources/js/lib/exercise-types.test.ts
+++ b/resources/js/lib/exercise-types.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { EXERCISE_TYPES, METRIC_DISPLAY } from './exercise-types'
+import type { Exercise, ExerciseType } from '@/api/types'
+
+const sample = (type: ExerciseType): Exercise => ({
+  id: '1',
+  userId: null,
+  name: 'sample',
+  type,
+  equipmentTypeId: null,
+  notes: null,
+  usageCount: 0,
+  hasLoggedData: false,
+})
+
+describe('EXERCISE_TYPES defaultEntryMetrics stays within allowedMetrics', () => {
+  it.each(Object.keys(EXERCISE_TYPES) as ExerciseType[])(
+    'default payload keys for %s stay within the allowed metrics the backend accepts',
+    type => {
+      const cfg = EXERCISE_TYPES[type]
+      const allowed = new Set<string>([...cfg.metrics.required, ...cfg.metrics.optional])
+      const metrics = cfg.defaultEntryMetrics(sample(type)) as Record<string, unknown>
+      for (const key of Object.keys(metrics)) {
+        expect(allowed.has(key), `${type} default emits disallowed metric "${key}"`).toBe(true)
+      }
+    }
+  )
+})
+
+describe('METRIC_DISPLAY', () => {
+  it('labels reps (not weight) when the API resolves primary_metric to reps', () => {
+    expect(METRIC_DISPLAY.reps.unit('imperial')).toBe('reps')
+    expect(METRIC_DISPLAY.reps.yLabel('imperial')).toContain('reps')
+    expect(METRIC_DISPLAY.reps.yLabel('imperial')).not.toMatch(/lb|kg/)
+  })
+
+  it('labels weight for weighted resistance', () => {
+    expect(METRIC_DISPLAY.weight.unit('imperial')).toBe('lb')
+    expect(METRIC_DISPLAY.weight.unit('metric')).toBe('kg')
+  })
+})

--- a/resources/js/lib/exercise-types.ts
+++ b/resources/js/lib/exercise-types.ts
@@ -1,0 +1,129 @@
+import type { Exercise, ExerciseType, PrimaryMetric } from '@/api/types'
+import type { CreateEntryPayload } from '@/api/workouts'
+import type { MeasurementSystem } from '@/lib/units'
+import { unitLabel } from '@/lib/units'
+import { formatDuration } from '@/lib/formatters'
+
+// Metric identifiers as named in the backend metric enum.
+export type MetricDimension =
+  'load' | 'reps' | 'duration' | 'distance' | 'cardio_settings' | 'intensity' | 'interval_header'
+
+type EntryMetrics = CreateEntryPayload['metrics']
+
+export interface ExerciseTypeConfig {
+  label: string
+  metrics: { required: MetricDimension[]; optional: MetricDimension[] }
+  defaultEntryMetrics: (ex: Exercise) => EntryMetrics
+  recordKey: string
+  attributeKeys: readonly string[]
+  attributeRows: (ex: Exercise) => Array<[string, string]>
+}
+
+export const EXERCISE_TYPES: Record<ExerciseType, ExerciseTypeConfig> = {
+  resistance: {
+    label: 'Resistance',
+    metrics: { required: ['load', 'reps'], optional: ['intensity'] },
+    defaultEntryMetrics: ex => ({
+      load: { target_weight: null, actual_weight: null, bodyweight_only: !!ex.bodyweightBase },
+      reps: { target_reps: null, actual_reps: null, to_failure: false, failure_rep: null },
+    }),
+    recordKey: 'reps',
+    attributeKeys: ['bodyweight_base', 'allows_added_weight', 'bilateral'],
+    attributeRows: ex => [
+      ['Bodyweight base', ex.bodyweightBase ? 'Yes' : 'No'],
+      ['Allows added weight', ex.allowsAddedWeight ? 'Yes' : 'No'],
+      ['Bilateral', ex.bilateral ? 'Yes' : 'No (single-arm/leg)'],
+    ],
+  },
+  timed_hold: {
+    label: 'Timed Hold',
+    metrics: { required: ['duration'], optional: ['load', 'intensity'] },
+    defaultEntryMetrics: () => ({
+      duration: { target_duration_seconds: null, actual_duration_seconds: null },
+    }),
+    recordKey: 'duration',
+    attributeKeys: ['target_duration_seconds'],
+    attributeRows: ex =>
+      ex.targetDurationSeconds != null
+        ? [['Target duration', formatDuration(ex.targetDurationSeconds)]]
+        : [],
+  },
+  distance: {
+    label: 'Distance / Time',
+    metrics: { required: ['distance'], optional: ['duration', 'cardio_settings', 'intensity'] },
+    defaultEntryMetrics: () => ({
+      distance: {
+        target_distance: null,
+        actual_distance: null,
+        lap_count: null,
+        stroke_count: null,
+      },
+      duration: { target_duration_seconds: null, actual_duration_seconds: null },
+    }),
+    recordKey: 'distance',
+    attributeKeys: ['tracks_elevation'],
+    attributeRows: ex => [['Tracks elevation', ex.tracksElevation ? 'Yes' : 'No']],
+  },
+  interval: {
+    label: 'Interval',
+    metrics: {
+      required: ['interval_header'],
+      optional: ['cardio_settings', 'distance', 'intensity'],
+    },
+    defaultEntryMetrics: ex => {
+      const n = ex.defaultRounds || 8
+      return {
+        interval_header: {
+          programmed_rounds: n,
+          completed_rounds: 0,
+          target_work_seconds: ex.defaultWorkSeconds || 60,
+          target_rest_seconds: ex.defaultRestSeconds || 60,
+          rounds: Array.from({ length: n }, (_, k) => ({
+            round_number: k + 1,
+            actual_work_seconds: null,
+            actual_rest_seconds: null,
+            heart_rate_avg: null,
+            heart_rate_peak: null,
+          })),
+        },
+      }
+    },
+    recordKey: 'completed_rounds',
+    attributeKeys: ['default_work_seconds', 'default_rest_seconds', 'default_rounds'],
+    attributeRows: ex => [
+      ['Default work', formatDuration(ex.defaultWorkSeconds)],
+      ['Default rest', formatDuration(ex.defaultRestSeconds)],
+      ['Default rounds', String(ex.defaultRounds || '—')],
+    ],
+  },
+}
+
+// Filter/picker options in canonical order. Consumers needing an "all"
+// pseudo-option prepend it themselves.
+export const TYPE_OPTIONS: Array<{ value: ExerciseType; label: string }> = (
+  ['resistance', 'timed_hold', 'distance', 'interval'] as const
+).map(t => ({ value: t, label: EXERCISE_TYPES[t].label }))
+
+// Keyed by the API's per-exercise primary_metric rather than by exercise type,
+// so bodyweight-only lifts plot reps while weighted lifts plot weight.
+export const METRIC_DISPLAY: Record<
+  PrimaryMetric,
+  {
+    yLabel: (system: MeasurementSystem) => string
+    unit: (system: MeasurementSystem) => string
+    valueFormatter?: (v: number) => string
+  }
+> = {
+  weight: { yLabel: s => `Top set (${unitLabel(s, 'weight')})`, unit: s => unitLabel(s, 'weight') },
+  reps: { yLabel: () => 'Top set (reps)', unit: () => 'reps' },
+  duration: {
+    yLabel: () => 'Duration',
+    unit: () => '',
+    valueFormatter: v => formatDuration(Math.round(v)),
+  },
+  distance: {
+    yLabel: s => `Distance (${unitLabel(s, 'distance')})`,
+    unit: s => unitLabel(s, 'distance'),
+  },
+  completed_rounds: { yLabel: () => 'Rounds', unit: () => 'rounds' },
+}

--- a/resources/js/lib/utils.ts
+++ b/resources/js/lib/utils.ts
@@ -4,3 +4,7 @@ import { twMerge } from 'tailwind-merge'
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function assertNever(value: never): never {
+  throw new Error(`Unhandled case: ${String(value)}`)
+}

--- a/resources/js/pages/exercise-detail.tsx
+++ b/resources/js/pages/exercise-detail.tsx
@@ -9,9 +9,9 @@ import { TypeBadge } from '@/components/ui/type-badge'
 import { Badge } from '@/components/ui/badge'
 import { InlineEdit } from '@/components/ui/inline-edit'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+import { EXERCISE_TYPES } from '@/lib/exercise-types'
 import { useApp } from '@/lib/use-app'
 import { equipmentName } from '@/lib/domain'
-import { formatDuration } from '@/lib/formatters'
 import {
   getExercise,
   updateExercise as updateExerciseApi,
@@ -108,21 +108,7 @@ export function ExerciseDetailPage() {
   }
 
   const isOwned = ex.userId !== null
-  const attrs: Array<[string, string]> = []
-
-  if (ex.type === 'resistance') {
-    attrs.push(['Bodyweight base', ex.bodyweightBase ? 'Yes' : 'No'])
-    attrs.push(['Allows added weight', ex.allowsAddedWeight ? 'Yes' : 'No'])
-    attrs.push(['Bilateral', ex.bilateral ? 'Yes' : 'No (single-arm/leg)'])
-  } else if (ex.type === 'timed_hold') {
-    if (ex.targetDurationSeconds) {
-      attrs.push(['Target duration', formatDuration(ex.targetDurationSeconds)])
-    }
-  } else if (ex.type === 'interval') {
-    attrs.push(['Default work', formatDuration(ex.defaultWorkSeconds)])
-    attrs.push(['Default rest', formatDuration(ex.defaultRestSeconds)])
-    attrs.push(['Default rounds', String(ex.defaultRounds || '—')])
-  }
+  const attrs = EXERCISE_TYPES[ex.type].attributeRows(ex)
 
   return (
     <div dusk="exercise-detail-page">

--- a/resources/js/pages/exercise-progress.tsx
+++ b/resources/js/pages/exercise-progress.tsx
@@ -7,9 +7,8 @@ import { SegmentedControl } from '@/components/ui/segmented-control'
 import { ProgressLineChart, VolumeBarChart } from '@/components/app/charts'
 import { useExerciseProgress } from '@/hooks/use-exercise-progress'
 import { useAuth } from '@/hooks/use-auth'
-import { unitLabel } from '@/lib/units'
+import { METRIC_DISPLAY } from '@/lib/exercise-types'
 import { getExercise } from '@/api/exercises'
-import { formatDuration } from '@/lib/formatters'
 import type { TimeRange } from '@/api/types'
 
 const RANGES: Array<{ value: TimeRange; label: string }> = [
@@ -32,24 +31,10 @@ export function ProgressPanel({ exerciseId, range }: { exerciseId: string; range
   if (!ex || !user || isLoading) return null
 
   const isResistance = ex.type === 'resistance'
-  const isHold = ex.type === 'timed_hold'
-  const weightUnit = unitLabel(user.measurementSystem, 'weight')
-  const distUnit = unitLabel(user.measurementSystem, 'distance')
-  const yLabel = isResistance
-    ? `Top set (${weightUnit})`
-    : isHold
-      ? 'Duration'
-      : ex.type === 'distance'
-        ? `Distance (${distUnit})`
-        : 'Rounds'
-  const valueFormatter = isHold ? (v: number) => formatDuration(Math.round(v)) : undefined
-  const unit = isResistance
-    ? weightUnit
-    : ex.type === 'distance'
-      ? distUnit
-      : ex.type === 'interval'
-        ? 'rounds'
-        : ''
+  const display = METRIC_DISPLAY[data.primaryMetric]
+  const yLabel = display.yLabel(user.measurementSystem)
+  const unit = display.unit(user.measurementSystem)
+  const valueFormatter = display.valueFormatter
 
   return (
     <>

--- a/resources/js/pages/exercises.tsx
+++ b/resources/js/pages/exercises.tsx
@@ -13,19 +13,15 @@ import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { Sheet } from '@/components/ui/sheet'
 import { Toggle } from '@/components/ui/toggle'
 import { useApp } from '@/lib/use-app'
-import { equipmentName, TYPE_LABELS } from '@/lib/domain'
+import { equipmentName } from '@/lib/domain'
+import { assertNever } from '@/lib/utils'
+import { EXERCISE_TYPES, TYPE_OPTIONS } from '@/lib/exercise-types'
 import { listExercises, createExercise, deleteExercise as deleteExerciseApi } from '@/api/exercises'
 import { listEquipment } from '@/api/equipment'
 import type { Exercise, ExerciseType, EquipmentType } from '@/api/types'
 import type { CreateExercisePayload } from '@/api/exercises'
 
-const TYPES: Array<{ value: string; label: string }> = [
-  { value: 'all', label: 'All' },
-  { value: 'resistance', label: 'Resistance' },
-  { value: 'timed_hold', label: 'Hold' },
-  { value: 'distance', label: 'Distance' },
-  { value: 'interval', label: 'Interval' },
-]
+const TYPES = [{ value: 'all', label: 'All' }, ...TYPE_OPTIONS]
 
 function CreateExerciseSheet({ onClose }: { onClose: () => void }) {
   const navigate = useNavigate()
@@ -82,24 +78,32 @@ function CreateExerciseSheet({ onClose }: { onClose: () => void }) {
 
     const typeAttributes: Record<string, unknown> = {}
 
-    if (type === 'resistance') {
-      typeAttributes.bodyweight_base = bodyweight
-      typeAttributes.allows_added_weight = addedWeight
-      typeAttributes.bilateral = bilateral
-    } else if (type === 'timed_hold') {
-      if (targetDurationSeconds) {
-        typeAttributes.target_duration_seconds = parseInt(targetDurationSeconds)
-      }
-    } else if (type === 'interval') {
-      if (defaultWorkSeconds) {
-        typeAttributes.default_work_seconds = parseInt(defaultWorkSeconds)
-      }
-      if (defaultRestSeconds) {
-        typeAttributes.default_rest_seconds = parseInt(defaultRestSeconds)
-      }
-      if (defaultRounds) {
-        typeAttributes.default_rounds = parseInt(defaultRounds)
-      }
+    switch (type) {
+      case 'resistance':
+        typeAttributes.bodyweight_base = bodyweight
+        typeAttributes.allows_added_weight = addedWeight
+        typeAttributes.bilateral = bilateral
+        break
+      case 'timed_hold':
+        if (targetDurationSeconds) {
+          typeAttributes.target_duration_seconds = parseInt(targetDurationSeconds)
+        }
+        break
+      case 'distance':
+        break
+      case 'interval':
+        if (defaultWorkSeconds) {
+          typeAttributes.default_work_seconds = parseInt(defaultWorkSeconds)
+        }
+        if (defaultRestSeconds) {
+          typeAttributes.default_rest_seconds = parseInt(defaultRestSeconds)
+        }
+        if (defaultRounds) {
+          typeAttributes.default_rounds = parseInt(defaultRounds)
+        }
+        break
+      default:
+        assertNever(type)
     }
 
     const payload: CreateExercisePayload = {
@@ -111,6 +115,94 @@ function CreateExerciseSheet({ onClose }: { onClose: () => void }) {
     }
 
     createMutation.mutate(payload)
+  }
+
+  function typeFields() {
+    switch (type) {
+      case 'resistance':
+        return (
+          <div className="ps-metric p-3 flex flex-col gap-3">
+            <div className="flex items-center justify-between" aria-label="Bodyweight base">
+              <span className="text-sm">Bodyweight base</span>
+              <Toggle checked={bodyweight} onChange={setBodyweight} label="Bodyweight base" />
+            </div>
+            <div className="flex items-center justify-between" aria-label="Allows added weight">
+              <span className="text-sm">Allows added weight</span>
+              <Toggle checked={addedWeight} onChange={setAddedWeight} label="Allows added weight" />
+            </div>
+            <div className="flex items-center justify-between" aria-label="Bilateral">
+              <span className="text-sm">Bilateral</span>
+              <Toggle checked={bilateral} onChange={setBilateral} label="Bilateral" />
+            </div>
+          </div>
+        )
+      case 'timed_hold':
+        return (
+          <div className="ps-metric p-3 flex flex-col gap-3">
+            <div className="flex items-center justify-between">
+              <label htmlFor="target-duration" className="text-sm">
+                Target duration (seconds, optional)
+              </label>
+              <input
+                id="target-duration"
+                type="number"
+                value={targetDurationSeconds}
+                onChange={e => setTargetDurationSeconds(e.target.value)}
+                className="ps-input w-20 px-2 py-1.5 text-sm"
+                min="1"
+              />
+            </div>
+          </div>
+        )
+      case 'distance':
+        return null
+      case 'interval':
+        return (
+          <div className="ps-metric p-3 flex flex-col gap-3">
+            <div className="flex items-center justify-between">
+              <label htmlFor="default-work" className="text-sm">
+                Work seconds (optional)
+              </label>
+              <input
+                id="default-work"
+                type="number"
+                value={defaultWorkSeconds}
+                onChange={e => setDefaultWorkSeconds(e.target.value)}
+                className="ps-input w-20 px-2 py-1.5 text-sm"
+                min="1"
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <label htmlFor="default-rest" className="text-sm">
+                Rest seconds (optional)
+              </label>
+              <input
+                id="default-rest"
+                type="number"
+                value={defaultRestSeconds}
+                onChange={e => setDefaultRestSeconds(e.target.value)}
+                className="ps-input w-20 px-2 py-1.5 text-sm"
+                min="1"
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <label htmlFor="default-rounds" className="text-sm">
+                Rounds (optional)
+              </label>
+              <input
+                id="default-rounds"
+                type="number"
+                value={defaultRounds}
+                onChange={e => setDefaultRounds(e.target.value)}
+                className="ps-input w-20 px-2 py-1.5 text-sm"
+                min="1"
+              />
+            </div>
+          </div>
+        )
+      default:
+        return assertNever(type)
+    }
   }
 
   return (
@@ -179,7 +271,7 @@ function CreateExerciseSheet({ onClose }: { onClose: () => void }) {
                     : undefined
                 }
               >
-                {TYPE_LABELS[t]}
+                {EXERCISE_TYPES[t].label}
               </button>
             ))}
           </div>
@@ -207,84 +299,7 @@ function CreateExerciseSheet({ onClose }: { onClose: () => void }) {
           </select>
         </div>
 
-        {type === 'resistance' && (
-          <div className="ps-metric p-3 flex flex-col gap-3">
-            <div className="flex items-center justify-between" aria-label="Bodyweight base">
-              <span className="text-sm">Bodyweight base</span>
-              <Toggle checked={bodyweight} onChange={setBodyweight} label="Bodyweight base" />
-            </div>
-            <div className="flex items-center justify-between" aria-label="Allows added weight">
-              <span className="text-sm">Allows added weight</span>
-              <Toggle checked={addedWeight} onChange={setAddedWeight} label="Allows added weight" />
-            </div>
-            <div className="flex items-center justify-between" aria-label="Bilateral">
-              <span className="text-sm">Bilateral</span>
-              <Toggle checked={bilateral} onChange={setBilateral} label="Bilateral" />
-            </div>
-          </div>
-        )}
-
-        {type === 'timed_hold' && (
-          <div className="ps-metric p-3 flex flex-col gap-3">
-            <div className="flex items-center justify-between">
-              <label htmlFor="target-duration" className="text-sm">
-                Target duration (seconds, optional)
-              </label>
-              <input
-                id="target-duration"
-                type="number"
-                value={targetDurationSeconds}
-                onChange={e => setTargetDurationSeconds(e.target.value)}
-                className="ps-input w-20 px-2 py-1.5 text-sm"
-                min="1"
-              />
-            </div>
-          </div>
-        )}
-
-        {type === 'interval' && (
-          <div className="ps-metric p-3 flex flex-col gap-3">
-            <div className="flex items-center justify-between">
-              <label htmlFor="default-work" className="text-sm">
-                Work seconds (optional)
-              </label>
-              <input
-                id="default-work"
-                type="number"
-                value={defaultWorkSeconds}
-                onChange={e => setDefaultWorkSeconds(e.target.value)}
-                className="ps-input w-20 px-2 py-1.5 text-sm"
-                min="1"
-              />
-            </div>
-            <div className="flex items-center justify-between">
-              <label htmlFor="default-rest" className="text-sm">
-                Rest seconds (optional)
-              </label>
-              <input
-                id="default-rest"
-                type="number"
-                value={defaultRestSeconds}
-                onChange={e => setDefaultRestSeconds(e.target.value)}
-                className="ps-input w-20 px-2 py-1.5 text-sm"
-                min="1"
-              />
-            </div>
-            <div className="flex items-center justify-between">
-              <label htmlFor="default-rounds" className="text-sm">
-                Rounds (optional)
-              </label>
-              <input
-                id="default-rounds"
-                type="number"
-                value={defaultRounds}
-                onChange={e => setDefaultRounds(e.target.value)}
-                className="ps-input w-20 px-2 py-1.5 text-sm"
-                min="1"
-              />
-            </div>
-          </div>
-        )}
+        {typeFields()}
       </div>
     </Sheet>
   )

--- a/resources/js/pages/progress.tsx
+++ b/resources/js/pages/progress.tsx
@@ -5,15 +5,10 @@ import { SegmentedControl } from '@/components/ui/segmented-control'
 import { SearchableSelect } from '@/components/ui/searchable-select'
 import { ProgressPanel } from './exercise-progress'
 import { listExercises } from '@/api/exercises'
+import { TYPE_OPTIONS } from '@/lib/exercise-types'
 import type { TimeRange } from '@/api/types'
 
-const TYPES: Array<{ value: string; label: string }> = [
-  { value: 'all', label: 'All' },
-  { value: 'resistance', label: 'Resistance' },
-  { value: 'timed_hold', label: 'Hold' },
-  { value: 'distance', label: 'Distance' },
-  { value: 'interval', label: 'Interval' },
-]
+const TYPES = [{ value: 'all', label: 'All' }, ...TYPE_OPTIONS]
 
 const RANGES: Array<{ value: TimeRange; label: string }> = [
   { value: '1M', label: '1M' },

--- a/resources/js/pages/workout-detail.tsx
+++ b/resources/js/pages/workout-detail.tsx
@@ -22,6 +22,7 @@ import {
 import { toMetricsPayload } from '@/api/transformers'
 import type { CreateEntryPayload, AssignEntryPayload } from '@/api/workouts'
 import { fetchRecords, extractAllTimeBest } from '@/api/progress'
+import { EXERCISE_TYPES } from '@/lib/exercise-types'
 import { useApp } from '@/lib/use-app'
 import { useAuth } from '@/hooks/use-auth'
 import { formatDuration } from '@/lib/formatters'
@@ -91,67 +92,11 @@ function buildBlocks(entries: WorkoutEntry[], groups: EntryGroup[]): Block[] {
 }
 
 function defaultEntryPayload(ex: Exercise, setOrder: number): CreateEntryPayload {
-  const base: CreateEntryPayload = {
+  return {
     exercise_id: Number(ex.id),
     set_order: setOrder,
-    metrics: {},
+    metrics: EXERCISE_TYPES[ex.type].defaultEntryMetrics(ex),
   }
-
-  if (ex.type === 'resistance') {
-    base.metrics = {
-      load: {
-        target_weight: null,
-        actual_weight: null,
-        bodyweight_only: !!ex.bodyweightBase,
-      },
-      reps: {
-        target_reps: null,
-        actual_reps: null,
-        to_failure: false,
-        failure_rep: null,
-      },
-    }
-  } else if (ex.type === 'timed_hold') {
-    base.metrics = {
-      duration: {
-        target_duration_seconds: null,
-        actual_duration_seconds: null,
-      },
-    }
-  } else if (ex.type === 'distance') {
-    base.metrics = {
-      distance: {
-        target_distance: null,
-        actual_distance: null,
-        lap_count: null,
-        stroke_count: null,
-      },
-      duration: {
-        target_duration_seconds: null,
-        actual_duration_seconds: null,
-      },
-    }
-  } else if (ex.type === 'interval') {
-    const n = ex.defaultRounds || 8
-    const rounds = Array.from({ length: n }, (_, k) => ({
-      round_number: k + 1,
-      actual_work_seconds: null,
-      actual_rest_seconds: null,
-      heart_rate_avg: null,
-      heart_rate_peak: null,
-    }))
-    base.metrics = {
-      interval_header: {
-        programmed_rounds: n,
-        completed_rounds: 0,
-        target_work_seconds: ex.defaultWorkSeconds || 60,
-        target_rest_seconds: ex.defaultRestSeconds || 60,
-        rounds,
-      },
-    }
-  }
-
-  return base
 }
 
 function ExerciseHeader({


### PR DESCRIPTION
## Problem

The frontend restated "what a resistance exercise looks like" in seven separate places: the metric inputs, the default entry payload, the exercise detail rows, the progress chart config, the create form, the API transformer, and the record-key lookup. Each had its own per-type conditional, and every type-specific field on the exercise is optional, so adding a new exercise type would silently miss sites with no compile error. The user-facing type labels were also defined five times and had drifted: the picker said "Lift" and "Cardio", the badges said "Resistance" and "Distance", the filters said "Hold", and two maps disagreed on distance ("Distance" versus "Distance / Time").

Separately, the progress chart derived its axis label and tooltip unit from the exercise type alone and ignored the per-exercise primary metric the API already resolves. For bodyweight-only resistance exercises the backend plots rep counts, but the chart labeled the axis in pounds and showed tooltips like "12 lb" for what were actually reps.

The API also serializes exercise type_attributes generically, so a new attribute added on the backend reaches the client and gets silently dropped by the transformer, with nothing to catch it.

## Solution

Added `resources/js/lib/exercise-types.ts`, one typed registry keyed by exercise type. Each type declares its label, allowed and required metrics, default entry payload, record key, consumed type_attributes keys, and detail attribute rows. The seven scattered sites now read this registry, and the remaining per-type JSX became exhaustive switches with an `assertNever` default, so a new exercise type fails to compile until every site is handled.

Collapsed the five label definitions into one canonical set used everywhere (badges, filters, quick-add picker, and detail): Resistance, Timed Hold, Distance / Time, Interval. The invented picker labels and the divergent filter labels are gone. Distance exercises now also show a "Tracks elevation" row on the detail page, which they previously did not.

The progress chart now reads the API's `primary_metric` through a metric-keyed display map in the registry instead of deriving display from the type. Bodyweight-only resistance exercises label reps; weighted exercises are unchanged. `transformProgressData` passes the field through and `ExerciseProgressData` carries it.

Added a drift test that runs every captured exercise fixture through `toExercise()` and fails, naming the key, when a fixture carries a type_attributes key not declared on the registry. When the backend adds an attribute and the fixtures are regenerated, the test flags it instead of dropping it silently.
